### PR TITLE
Rails 8 + Vite + React の Docker 開発環境を構築

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,22 @@
 # Ignore Docker-related files
 /.dockerignore
 /Dockerfile*
+
+# Ignore Vite build outputs
+/public/vite*
+
+# Ignore host-installed gems (Mac binaries, conflict with container)
+/vendor/bundle
+
+# Ignore OS-specific files
+.DS_Store
+Thumbs.db
+
+# Ignore editor configs
+/.vscode
+/.idea
+/.cursor
+*.swp
+
+# Ignore test coverage artifacts
+/coverage

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# PostgreSQL
+  POSTGRES_USER=vow_pact
+  POSTGRES_PASSWORD=
+  POSTGRES_DB=vow_pact_development
+
+  # Rails -> DB 接続URL
+  # 形式: postgresql://USER:PASSWORD@HOST:PORT/DBNAME
+  DATABASE_URL=postgresql://vow_pact:PASSWORD@db:5432/vow_pact_development
+
+  # OpenAI API
+  OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/*.log
 !/log/.keep
 !/tmp/.keep
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,40 @@
+# Ruby 3.4.9 のスリム版（mise.toml と完全一致）
+FROM ruby:3.4.9-slim
+
+# OS パッケージのインストール
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    git \
+    curl \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 20.x の公式リポジトリ追加 + インストール
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -qq \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# 作業ディレクトリ
+WORKDIR /app
+
+# Bundler と Gemfile を先にコピー → bundle install（Docker レイヤーキャッシュ活用）
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# package.json も先にコピー → npm install（同様にキャッシュ活用）
+COPY package.json package-lock.json ./
+RUN npm install
+
+# アプリケーションのソースコード全体をコピー
+COPY . .
+
+# ポート公開（Rails: 3000, Vite: 3036）
+EXPOSE 3000 3036
+
+# デフォルト起動コマンド
+CMD ["bin/dev"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,7 @@ FROM ruby:3.4.9-slim
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
+    libyaml-dev \
     git \
     curl \
     ca-certificates \

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server
+web: bin/rails server -p 3000 -b 0.0.0.0
 css: bin/rails tailwindcss:watch
 vite: bin/vite dev

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,14 +11,14 @@
 #     policy.img_src     :self, :https, :data
 #     policy.object_src  :none
 #     policy.script_src  :self, :https
-    # Allow @vite/client to hot reload javascript changes in development
+# Allow @vite/client to hot reload javascript changes in development
 #    policy.script_src *policy.script_src, :unsafe_eval, "http://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 
-    # You may need to enable this in production as well depending on your setup.
+# You may need to enable this in production as well depending on your setup.
 #    policy.script_src *policy.script_src, :blob if Rails.env.test?
 
 #     policy.style_src   :self, :https
-    # Allow @vite/client to hot reload style changes in development
+# Allow @vite/client to hot reload style changes in development
 #    policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
 
 #     # Specify URI for violation reports

--- a/config/vite.json
+++ b/config/vite.json
@@ -1,7 +1,8 @@
 {
   "all": {
     "sourceCodeDir": "app/frontend",
-    "watchAdditionalPaths": []
+    "watchAdditionalPaths": [],
+    "host": "0.0.0.0"
   },
   "development": {
     "autoBuild": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: postgres:18
+    restart: always
+    environment:
+      TZ: Asia/Tokyo
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    # 起動毎に bundle install と db:prepare を実行（冪等な起動）
+    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && bin/dev"
+    tty: true
+    stdin_open: true
+    volumes:
+      - .:/app:cached
+      - bundle_cache:/usr/local/bundle
+      - node_modules:/app/node_modules
+    environment:
+      TZ: Asia/Tokyo
+      RAILS_ENV: development
+      DATABASE_URL: ${DATABASE_URL}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    ports:
+      - "3000:3000"
+      - "3036:3036"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  bundle_cache:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
## 概要

Rails 8 + Vite + React + TypeScript + PostgreSQL の Docker 開発環境を構築。
ホスト側の設定に依存せず、`docker compose up` 一発で起動できる状態にした。

## 主な変更内容

- `Dockerfile.dev` を新規作成（Ruby 3.4.9-slim + Node.js 20）
- `docker-compose.yml` を新規作成（`db`: postgres:18 / `web`: Rails + bin/dev）
- `.env` ベースの機密情報管理を導入
  - `.env` は Git 除外、`.env.example` をテンプレとしてコミット
- `Procfile.dev` の `web` 行に `-p 3000 -b 0.0.0.0` を追加（コンテナ外接続用）
- `config/vite.json` に `"host": "0.0.0.0"` を追加（Vite dev サーバーをコンテナ外公開）
- `.dockerignore` に Vite 出力・`vendor/bundle`・OS/エディタ固有ファイル等を追加

## 設計判断

- **機密情報の扱い**: `.env` を採用
  - 開発 DB パスワードは形式的な値だが、OpenAI API キー等の本物の機密と扱いを統一するため
  - Twelve-Factor App のモダン慣習に揃える
- **イメージのスリム版採用**: `ruby:3.4.9-slim`
  - イメージサイズ約 250MB（フル版約 1GB の 1/4）
  - 必要な開発ヘッダ（`libyaml-dev` 等)は明示的に追加する方針
- **PostgreSQL バージョン**: 18 を pin（latest 指定なし）

## 解決したトラブル

### 1. psych の native extension ビルド失敗
- **原因**: `ruby:slim` には `libyaml-dev` が含まれていないため、psych の C 拡張ビルド時に `yaml.h not found` エラー
- **対応**: `Dockerfile.dev` の apt-get install に `libyaml-dev` を追加

### 2. postgres:18 のマウントポイント変更
- **原因**: postgres:18 でデータ格納先が `/var/lib/postgresql/data` から `/var/lib/postgresql/<バージョン>/main` に変更され、従来のマウント方式は許容されなくなった
- **対応**: `docker-compose.yml` の volumes を `/var/lib/postgresql/data` から `/var/lib/postgresql` に変更

## 動作確認

- [x] `docker compose build` がエラーなく完了する
- [x] `docker compose up` で db → web の順に起動する
- [x] db の healthcheck が成功してから web が起動する
- [x] `http://localhost:3000` で Rails のデフォルトページが表示される
- [x] バージョン情報が以下の通り表示される
  - Rails version: 8.1.3
  - Ruby version: 3.4.9 [aarch64-linux]（コンテナ内で動作していることを確認）

## 残課題（別 PR で対応予定）

- 本番 DB（Neon）への接続設定
- Solid Queue / Cache / Cable の本番運用設定
- Render などへのデプロイ手順整備

## 補足

- ブランチ運用: 本 PR から `feature/...` ブランチ運用に切り替え
- これまでに main 直コミットしていた `Initial setup` と `Fix path` は土台部分として残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Docker and Docker Compose for local development with PostgreSQL 18 database
  * Added environment configuration template with PostgreSQL and API key placeholders
  * Updated development server settings for containerized environments
  * Expanded build artifact ignores for Docker and Git

<!-- end of auto-generated comment: release notes by coderabbit.ai -->