### PR TITLE
実装フェーズ用に設計書一式とCLAUDE.mdを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+# OS-specific files
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,224 @@
+# CLAUDE.md — Vow Pact 開発ガイド
+
+Claude Code がプロジェクトのコンテキストを理解するためのガイド。
+
+---
+
+## 1. 最重要ルール
+
+### 禁止事項
+- `.permit!`（必ず `.permit(:attr1, ...)` 明示）
+- N+1 クエリ（`includes` / `preload`）
+- 複数 DB 操作のトランザクションなし
+- ハードコードされた機密情報
+- テストなしで機能実装
+- `binding.pry` / `console.log` を本番に残す
+- 機密情報（`password_digest` 等）を API レスポンスに含める
+
+### 必須作業
+- コミット前: `bundle exec rubocop -a` + `bundle exec rspec`
+- PR マージ前: `gh pr checks <PR番号>`（CI 通過必須）
+
+### 言語ルール
+- コード: 英語 / コミット: 日本語
+- PR 本文・コメント: 日本語 / Claude Code の応答: 日本語
+
+### コミット注意
+- `Co-Authored-By: Claude` を含めない
+- PR 本文に `🤖 Generated with Claude Code` を含めない
+
+---
+
+## 2. プロジェクト概要
+
+**Vow Pact**（誓約契約）: 中世ファンタジー × モダン UI の自己鍛錬アプリ。
+
+ユーザーは「目標 + 試練（制約）+ 期日」を契約として誓い、達成すると紋章が付与される。
+
+差別化: 制約の明示 / 紋章・称号付与 / 中世ファンタジー世界観。
+
+---
+
+## 3. 技術スタック
+
+| カテゴリ | 内容 |
+|---|---|
+| Ruby / FW | Ruby 3.4 / Rails 8.1（API mode + Vite）|
+| DB / Job / Cache | PostgreSQL 18（Neon Free）/ Solid Queue / Solid Cache |
+| 認証 / Serializer | Rails 8 標準ジェネレータ（セッション） / alba |
+| Test / Lint（BE） | RSpec + factory_bot + faker / RuboCop（rails-omakase）|
+| Frontend | React 18+ / TypeScript 5+ / Vite / Tailwind CSS |
+| FE 状態 / Routing | TanStack Query / React Router |
+| Test / Lint（FE） | Vitest / ESLint + Prettier |
+| AI | OpenAI `gpt-4o-mini`、Solid Queue 非同期、ログを `ai_generations` に記録 |
+| Infra | Docker Compose（dev）/ Render Free（prod app）/ Neon Free（prod DB）/ GitHub Actions |
+| **使わない** | Devise / Sidekiq / Redis / Webpack / Sprockets / Hotwire |
+
+AI 詳細: 202 Accepted + `job_id` → ポーリング、レート制限 1 ユーザー 1 分 10 回。
+
+---
+
+## 4. ディレクトリ構成
+
+```
+app/
+├── controllers/api/v1/  # auth/, pacts, check_ins, ai/, rankings
+├── models/               # users, pacts, check_ins, crests, ai_generations
+├── services/             # PactCompleter, CrestGenerator, StreakCalculator, ai/*
+├── serializers/          # alba ベース
+├── jobs/                 # Solid Queue
+└── frontend/             # vite_ruby 規約（entrypoints, pages, components, hooks, lib, types）
+
+spec/  # models, requests/api/v1/, services, factories
+docs/  # data_model, api_design, design_guide, design_prompts, VowPact_mock/
+```
+
+詳細: `docs/data_model.md`, `docs/api_design.md`
+
+---
+
+## 5. 世界観・デザイン
+
+**モダン × 中世ファンタジー**。
+
+| 色 | コード | 用途 |
+|---|---|---|
+| Parchment | `#f4e8d0` | 背景 |
+| Ink | `#2c1810` | テキスト |
+| Seal | `#8b1a1a` | アクセント・CTA |
+| Gold | `#c9a961` | 装飾・レアリティ |
+
+フォント: Noto Sans JP（UI）/ Noto Serif JP（契約書本文）。
+
+文言ルール:
+- **世界観風**: AI ボタン「天啓を受ける」、契約締結「ここに誓う」、X シェア「𝕏で天下に宣する」、特定見出し「誓いは刻まれた」「成就せり」「誓約の殿堂」、称号
+- **現代語**: ナビ・ステータス・基本操作・エラー
+- 難読漢字は ruby タグでふりがな
+
+詳細: `docs/design_guide.md`
+
+---
+
+## 6. コーディング規約
+
+- Ruby: クラス UpperCamelCase / メソッド snake_case / 定数 UPPER_SNAKE_CASE
+- TS: コンポーネント PascalCase / Hook `use` + camelCase / 関数 camelCase / 型 PascalCase
+- サービスクラス: `app/services/` に配置、命名は動作を表す名詞、メインメソッド `call`
+- Thin Controller / Fat Model、N+1 回避、Strong Parameters 必須、バリデーションはモデル層
+- コメントは WHY を書く（自明な処理には不要）
+
+---
+
+## 7. 重要な設計判断
+
+### Pact（契約）
+- active 契約はユーザーごと **最大 3 つ**（4 つ目は 422）
+- 1 契約 = 1 制約
+- 編集可: `goal`, `constraint_text` のみ（`deadline` / `difficulty` / `signed_at` 不可）
+- 削除は論理削除（`status: abandoned`）
+
+### CheckIn
+- 1 日 1 契約 1 件（DB UNIQUE 制約）
+- `checked_on` はサーバー側で自動設定（チート防止）
+- 訂正は UPDATE（同日 2 回 POST = 上書き）
+
+### 達成判定 / Crest
+- 寛容モード: `broken` 日があっても記録があれば達成扱い
+- チェックイン作成時に自動判定 / 手動: `POST /pacts/:id/complete`
+- 達成 → status: completed + completed_at + Crest 生成
+- 1 契約 = 1 紋章（DB UNIQUE）、failed には紋章なし
+- レアリティ: `difficulty × compliance_rate × period_score`
+
+### Ranking
+- 公平性: 「今月の達成数」「連続チェックイン日数」のみ
+- `is_public=true` のみ表示、自分の順位は常に見える
+
+### Enum
+- `Pact.status`: active(0) / completed(1) / failed(2) / abandoned(3)
+- `CheckIn.status`: kept(0) / broken(1) / skipped(2)
+- `Crest.rarity`: common(0) / rare(1) / epic(2) / legendary(3)
+- `AiGeneration.generation_type`: goal_suggestion(0) / constraint_suggestion(1) / difficulty_judgment(2) / title_generation(3)
+
+### API
+- URL: `/api/v1/` プレフィックス
+- レスポンス: データ直接返す（`data` キーラップなし）
+- エラー: `{ errors: [{ code, field, message }] }`
+- 認証: セッション Cookie（HttpOnly + Secure + SameSite=Lax）
+
+詳細: `docs/api_design.md`
+
+---
+
+## 8. 実装方針
+
+新概念は短く解説してから実装（全体像 1〜3 行 + 採用理由 1〜2 行 + 実装）。**TDD**（Red → Green → Refactor）。
+
+テストカテゴリ:
+- モデル: バリデーション、アソシエーション、スコープ、メソッド
+- リクエスト: 正常系・異常系・認可
+- サービス: ユニット
+
+実装前: 関連設計書を確認 / 既存コード把握 / 調査に 5 分以上使わない / 同じファイルを 2 回読まない / 不明点は実装しながら確認。
+
+---
+
+## 9. Git ワークフロー
+
+GitHub Flow（main + feature/*）。機能ブランチは必ず main から分岐。
+
+```bash
+git switch main && git pull origin main
+git switch -c feature/xxx
+# 開発、コミット...
+git fetch origin main && git merge origin/main   # 1 日 1 回以上
+gh pr create --title "..."
+gh pr checks <PR番号> && gh pr merge <PR番号>
+git switch main && git pull origin main
+```
+
+---
+
+## 10. 主要コマンド
+
+```bash
+# Docker
+docker compose up -d
+docker compose exec web bash
+docker compose exec web bin/rails console
+
+# Rails
+docker compose exec web bin/rails db:migrate
+docker compose exec web bundle exec rspec
+docker compose exec web bundle exec rubocop -a
+
+# Frontend
+docker compose exec web npm run test
+docker compose exec web npm run lint
+```
+
+`~/.zshrc` で `alias dcw="docker compose exec web"` 推奨。
+
+---
+
+## 11. 参照先
+
+| カテゴリ | 参照先 |
+|---|---|
+| データモデル | `docs/data_model.md` |
+| API 設計 | `docs/api_design.md` |
+| デザイン詳細 | `docs/design_guide.md` |
+| モックアップ | `docs/VowPact_mock/` |
+| 環境変数 | `.env.example` |
+| Rails ガイド | https://railsguides.jp/ |
+
+---
+
+## 12. 迷ったら
+
+1. 設計書を見る（`docs/data_model.md`, `docs/api_design.md`）
+2. Rails ガイド: https://railsguides.jp/
+3. 同じ修正を 2 回したらこのファイルにルール追加
+
+---
+
+**最終更新**: 2026-05-03

--- a/docs/VowPact_mock/.design-canvas.state.json
+++ b/docs/VowPact_mock/.design-canvas.state.json
@@ -1,0 +1,1 @@
+{"sections":{"states":{"labels":{"signup-loading":"F. 新規登録中"}}}}

--- a/docs/VowPact_mock/VowPact - 01 Signed.html
+++ b/docs/VowPact_mock/VowPact - 01 Signed.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約締結後</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&family=Caveat:wght@500;600&display=swap"
+  rel="stylesheet"
+/>
+<style>
+  :root {
+    --parchment: #f4e8d0;
+    --ink: #2c1810;
+    --seal: #8b1a1a;
+    --gold: #c9a961;
+    --gray: #6b6b6b;
+  }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: #ece2cf;
+    font-family: "Noto Sans JP", system-ui, sans-serif;
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+  }
+  ruby rt {
+    font-family: "Noto Serif JP", serif;
+  }
+  button:hover {
+    filter: brightness(1.06);
+  }
+  button:active {
+    transform: translateY(1px);
+  }
+  /* DesignCanvas のフレーム内側に余白を出さず固定サイズで見せる */
+  .frame-shell {
+    background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%);
+    padding: 16px;
+    box-sizing: border-box;
+    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    overflow: auto;
+  }
+  .phone-bezel {
+    width: 412px;
+    border-radius: 36px;
+    overflow: hidden;
+    box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12);
+    background: #fbf6ec;
+  }
+</style>
+</head>
+<body>
+
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/share-card.jsx"></script>
+
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 01. 契約締結後の画面">
+        <DCSection id="screen" title="画面：契約締結後（モバイル）">
+          <DCArtboard id="phone-default" label="iPhone 14 Pro · 412×900" width={444} height={980}>
+            <div className="frame-shell">
+              <div className="phone-bezel">
+                <SignedScreen width={412} />
+              </div>
+            </div>
+          </DCArtboard>
+          <DCArtboard id="phone-narrow" label="iPhone SE · 375×900" width={407} height={980}>
+            <div className="frame-shell">
+              <div className="phone-bezel" style={{ width: 375 }}>
+                <SignedScreen width={375} />
+              </div>
+            </div>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="share" title="X投稿用 シェアカード（1080×1080想定 / 540表示）">
+          <DCArtboard id="share-parchment" label="羊皮紙 + 朱印" width={580} height={580}>
+            <div style={{ padding: 20, background: "#ece2cf", height: "100%", boxSizing: "border-box", display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <div style={{ boxShadow: "0 24px 50px -24px rgba(44,24,16,0.45)" }}>
+                <ShareCard size={540} />
+              </div>
+            </div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 02 Home.html
+++ b/docs/VowPact_mock/VowPact - 02 Home.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — ホーム</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&family=Caveat:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/home.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 02. ホーム画面（複数契約対応）">
+        <DCSection id="home" title="状態バリエーション">
+          <DCArtboard id="default" label="A. 通常（2/3 件）" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><HomeScreen width={412} variant="default" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="full" label="B. 上限（3/3 件）" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><HomeScreen width={412} variant="full" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="empty" label="C. 0件（オンボーディング）" width={444} height={900}>
+            <div className="frame-shell"><div className="phone-bezel"><HomeScreen width={412} variant="empty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="narrow" label="D. iPhone SE 幅（375）" width={407} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel" style={{ width: 375 }}><HomeScreen width={375} variant="default" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 03 Create Step1.html
+++ b/docs/VowPact_mock/VowPact - 03 Create Step1.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約書作成 Step 1</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&family=Caveat:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  textarea:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel">
+  // share rtStyle without depending on signed.jsx
+  window.rtStyle = { fontSize: "0.45em", letterSpacing: "0.05em", color: "#8b6f47", fontWeight: 400 };
+</script>
+<script type="text/babel" src="screens/step1-goal.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 03. 契約書作成 Step 1（目標入力）">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="empty" label="A. 初期（未入力）" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step1Screen width={412} initialMode="empty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="loading" label="B. AI生成中" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step1Screen width={412} initialMode="loading" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="suggestions" label="C. 提案あり（未選択）" width={444} height={1240}>
+            <div className="frame-shell"><div className="phone-bezel"><Step1Screen width={412} initialMode="suggestions" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="selected" label="D. 提案を選択（次へ進める）" width={444} height={1240}>
+            <div className="frame-shell"><div className="phone-bezel"><Step1Screen width={412} initialMode="selected" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="filled" label="E. 自由入力済み" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step1Screen width={412} initialMode="filled" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 04 Create Step2.html
+++ b/docs/VowPact_mock/VowPact - 04 Create Step2.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約書作成 Step 2</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  textarea:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/step2-trial.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 04. 契約書作成 Step 2（試練入力）">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="empty" label="A. 初期" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="empty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="loading" label="B. ガチャ中" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="loading" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="suggestions" label="C. 5案 提示" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="suggestions" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="selected" label="D. 1件選択" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="selected" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="multi" label="E. 複数選択（2件）" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="multi" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="filled" label="F. 自由入力済み" width={444} height={1020}>
+            <div className="frame-shell"><div className="phone-bezel"><Step2Screen width={412} initialMode="filled" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 05 Create Step3.html
+++ b/docs/VowPact_mock/VowPact - 05 Create Step3.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約書作成 Step 3</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/step3-deadline.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 05. 契約書作成 Step 3（期日入力）">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="empty" label="A. 初期（未選択）" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><Step3Screen width={412} initialMode="empty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="preset30" label="B. 30日後を選択" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><Step3Screen width={412} initialMode="preset30" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="custom" label="C. カレンダーで任意日選択" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><Step3Screen width={412} initialMode="custom" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="preset365" label="D. 1年後を選択" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><Step3Screen width={412} initialMode="preset365" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 06 Create Step4.html
+++ b/docs/VowPact_mock/VowPact - 06 Create Step4.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約書作成 Step 4</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600&family=Klee+One:wght@400;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  input:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/step4-sign.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 06. 契約書作成 Step 4（署名・成立）">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="empty" label="A. 署名未入力" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><Step4Screen width={412} initialMode="empty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="prefilled" label="B. 自動入力済み" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><Step4Screen width={412} initialMode="prefilled" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="edited" label="C. ユーザー編集中" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><Step4Screen width={412} initialMode="edited" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="sealing" label="D. 押印中（演出）" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><Step4Screen width={412} initialMode="sealing" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="sealed" label="E. 契約成立" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><Step4Screen width={412} initialMode="sealed" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 07 Fulfilled.html
+++ b/docs/VowPact_mock/VowPact - 07 Fulfilled.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 成就（達成画面）</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&family=Klee+One:wght@400;600&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/fulfilled.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+
+  function ReplayButton({ onClick }) {
+    return (
+      <button
+        onClick={onClick}
+        style={{
+          position: "absolute", top: 12, right: 12, zIndex: 10,
+          background: "rgba(44,24,16,0.85)", color: "#fbf6ec",
+          border: "1px solid #c9a961", borderRadius: 999, padding: "6px 12px",
+          fontSize: 11, letterSpacing: "0.12em", cursor: "pointer",
+          fontFamily: "'Noto Sans JP', sans-serif",
+        }}
+      >
+        ↻ 演出を再生
+      </button>
+    );
+  }
+
+  function ReplayHost({ rarity }) {
+    const [key, setKey] = React.useState(0);
+    return (
+      <div className="frame-shell">
+        <div className="phone-bezel" style={{ position: "relative" }}>
+          <ReplayButton onClick={() => setKey(k => k + 1)} />
+          <FulfilledScreen key={key} width={412} rarity={rarity} animate={true} />
+        </div>
+      </div>
+    );
+  }
+
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 07. 成就（達成画面）">
+        <DCSection id="hero" title="メイン状態（演出付き）">
+          <DCArtboard id="epic-anim" label="A. エピック · 演出再生" width={444} height={1280}>
+            <ReplayHost rarity="epic" />
+          </DCArtboard>
+          <DCArtboard id="epic-static" label="B. エピック · 静止状態" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><FulfilledScreen width={412} rarity="epic" animate={false} /></div></div>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="rarity" title="レアリティ別バリエーション">
+          <DCArtboard id="legendary" label="C. レジェンダリー" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><FulfilledScreen width={412} rarity="legendary" animate={false} totalDays={180} keptDays={178} /></div></div>
+          </DCArtboard>
+          <DCArtboard id="rare" label="D. レア" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><FulfilledScreen width={412} rarity="rare" animate={false} totalDays={30} keptDays={26} /></div></div>
+          </DCArtboard>
+          <DCArtboard id="common" label="E. コモン" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><FulfilledScreen width={412} rarity="common" animate={false} totalDays={7} keptDays={6} /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 08 Hall.html
+++ b/docs/VowPact_mock/VowPact - 08 Hall.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 誓約の殿堂</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/fulfilled.jsx"></script>
+<script type="text/babel" src="screens/hall.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 08. 誓約の殿堂（コレクション画面）">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="default" label="A. 全て表示（新しい順）" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><HallScreen width={412} initialFilter="all" initialSort="recent" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="fulfilled" label="B. 達成のみ" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><HallScreen width={412} initialFilter="fulfilled" initialSort="recent" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="rarity" label="C. レアリティ順" width={444} height={1480}>
+            <div className="frame-shell"><div className="phone-bezel"><HallScreen width={412} initialFilter="all" initialSort="rarity" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="abandoned" label="D. 破棄フィルター" width={444} height={1280}>
+            <div className="frame-shell"><div className="phone-bezel"><HallScreen width={412} initialFilter="abandoned" initialSort="recent" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="empty" label="E. 空状態" width={444} height={1100}>
+            <div className="frame-shell"><div className="phone-bezel"><HallScreen width={412} initialMode="empty" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 09 Rank.html
+++ b/docs/VowPact_mock/VowPact - 09 Rank.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — ランキング</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/fulfilled.jsx"></script>
+<script type="text/babel" src="screens/rank.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 09. ランキング画面">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="default" label="A. 今月 / 達成数（自分 8位）" width={444} height={1620}>
+            <div className="frame-shell"><div className="phone-bezel"><RankScreen width={412} initialPeriod="month" initialType="achievements" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="score-all" label="B. 累計 / レアリティスコア（自分 23位）" width={444} height={1700}>
+            <div className="frame-shell"><div className="phone-bezel"><RankScreen width={412} initialPeriod="all" initialType="score" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="hidden" label="C. 非公開（参加していない）" width={444} height={1100}>
+            <div className="frame-shell"><div className="phone-bezel"><RankScreen width={412} initialMode="hidden" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 10 Auth.html
+++ b/docs/VowPact_mock/VowPact - 10 Auth.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — ログイン / 新規登録</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  input:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/auth.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 10. ログイン・新規登録">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="signin" label="A. ログイン（初期）" width={444} height={1000}>
+            <div className="frame-shell"><div className="phone-bezel"><AuthScreen width={412} initialTab="signin" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="signin-error" label="B. ログインエラー" width={444} height={1000}>
+            <div className="frame-shell"><div className="phone-bezel"><AuthScreen width={412} initialTab="signin" mode="error" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="signin-loading" label="C. ログイン中" width={444} height={1000}>
+            <div className="frame-shell"><div className="phone-bezel"><AuthScreen width={412} initialTab="signin" mode="loading" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="signup" label="D. 新規登録（初期）" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><AuthScreen width={412} initialTab="signup" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="signup-error" label="E. 新規登録 バリデーションエラー" width={444} height={1180}>
+            <div className="frame-shell"><div className="phone-bezel"><AuthScreen width={412} initialTab="signup" mode="error" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 11 Settings.html
+++ b/docs/VowPact_mock/VowPact - 11 Settings.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 設定</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  input:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; position: relative; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/settings.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 11. 設定">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="default" label="A. デフォルト" width={444} height={1500}>
+            <div className="frame-shell"><div className="phone-bezel"><SettingsScreen width={412} /></div></div>
+          </DCArtboard>
+          <DCArtboard id="confirm" label="B. アカウント削除確認モーダル" width={444} height={1500}>
+            <div className="frame-shell"><div className="phone-bezel"><SettingsScreen width={412} mode="confirm-delete" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 12 Detail.html
+++ b/docs/VowPact_mock/VowPact - 12 Detail.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約詳細</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; position: relative; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/signed.jsx"></script>
+<script type="text/babel" src="screens/detail.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 12. 契約詳細">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="default" label="A. デフォルト（未チェックイン）" width={444} height={1840}>
+            <div className="frame-shell"><div className="phone-bezel"><DetailScreen width={412} /></div></div>
+          </DCArtboard>
+          <DCArtboard id="checked" label="B. 今日のチェックイン済み" width={444} height={1840}>
+            <div className="frame-shell"><div className="phone-bezel"><DetailScreen width={412} mode="checked-in" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="abandon" label="C. 破棄確認モーダル" width={444} height={1840}>
+            <div className="frame-shell"><div className="phone-bezel"><DetailScreen width={412} mode="abandon" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/VowPact - 13 Edit.html
+++ b/docs/VowPact_mock/VowPact - 13 Edit.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VowPact — 契約書を編集する</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; background: #ece2cf; font-family: "Noto Sans JP", system-ui, sans-serif; color: #2c1810; -webkit-font-smoothing: antialiased; }
+  ruby rt { font-family: "Noto Serif JP", serif; }
+  button:hover:not(:disabled) { filter: brightness(1.04); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  textarea:focus, input:focus { outline: none; }
+  .frame-shell { background: linear-gradient(180deg, #ece2cf 0%, #d8c9a8 100%); padding: 16px; box-sizing: border-box; height: 100%; display: flex; align-items: flex-start; justify-content: center; overflow: auto; }
+  .phone-bezel { width: 412px; border-radius: 36px; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(44,24,16,0.45), 0 6px 18px rgba(44,24,16,0.12); background: #fbf6ec; position: relative; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="screens/edit.jsx"></script>
+<script type="text/babel">
+  const { DesignCanvas, DCSection, DCArtboard } = window;
+  function App() {
+    return (
+      <DesignCanvas title="VowPact / 13. 契約書を編集する">
+        <DCSection id="states" title="状態バリエーション">
+          <DCArtboard id="default" label="A. 初期（変更なし・保存ボタン非活性）" width={444} height={1500}>
+            <div className="frame-shell"><div className="phone-bezel"><EditScreen width={412} /></div></div>
+          </DCArtboard>
+          <DCArtboard id="dirty" label="B. 編集中（保存ボタン活性）" width={444} height={1500}>
+            <div className="frame-shell"><div className="phone-bezel"><EditScreen width={412} mode="dirty" /></div></div>
+          </DCArtboard>
+          <DCArtboard id="saved" label="C. 保存完了トースト" width={444} height={1500}>
+            <div className="frame-shell"><div className="phone-bezel"><EditScreen width={412} mode="saved" /></div></div>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/VowPact_mock/design-canvas.jsx
+++ b/docs/VowPact_mock/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/VowPact_mock/screens/auth.jsx
+++ b/docs/VowPact_mock/screens/auth.jsx
@@ -1,0 +1,545 @@
+/* global React, RARITY */
+
+const { useState: useAuthState } = React;
+
+// ============================================================
+// background ornament — subtle medieval flourish
+// ============================================================
+function BgOrnament() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="100%"
+      height="100%"
+      viewBox="0 0 412 900"
+      preserveAspectRatio="xMidYMid slice"
+      style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.08 }}
+    >
+      <defs>
+        <pattern id="auth-cross" width="40" height="40" patternUnits="userSpaceOnUse">
+          <path d="M20 8v24M8 20h24" stroke="#8b6f47" strokeWidth="0.4" />
+          <circle cx="20" cy="20" r="0.8" fill="#8b6f47" />
+        </pattern>
+      </defs>
+      <rect width="412" height="900" fill="url(#auth-cross)" />
+      {/* corner flourishes */}
+      <g stroke="#8b6f47" strokeWidth="1" fill="none">
+        <path d="M20 20 q30 0 30 30 M20 20 q0 30 30 30" />
+        <path d="M392 20 q-30 0 -30 30 M392 20 q0 30 -30 30" />
+        <path d="M20 880 q30 0 30 -30 M20 880 q0 -30 30 -30" />
+        <path d="M392 880 q-30 0 -30 -30 M392 880 q0 -30 -30 -30" />
+      </g>
+    </svg>
+  );
+}
+
+// ============================================================
+// big logo — VOW PACT with ornamental seal
+// ============================================================
+function BigLogo() {
+  return (
+    <div style={{ textAlign: "center" }}>
+      {/* seal mark */}
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 14 }}>
+        <svg width="64" height="64" viewBox="0 0 64 64" aria-hidden="true">
+          <defs>
+            <radialGradient id="auth-seal" cx="0.5" cy="0.5">
+              <stop offset="0%" stopColor="#a8252a" />
+              <stop offset="100%" stopColor="#7a1419" />
+            </radialGradient>
+          </defs>
+          <circle cx="32" cy="32" r="28" fill="url(#auth-seal)" stroke="#5a0d12" strokeWidth="1" />
+          <circle cx="32" cy="32" r="22" fill="none" stroke="#fbf6ec" strokeWidth="0.8" opacity="0.7" />
+          {/* shield */}
+          <path d="M32 16 l10 4 v8 c0 6 -4 10 -10 12 c-6 -2 -10 -6 -10 -12 v-8 z" fill="#fbf6ec" opacity="0.95" />
+          {/* cross */}
+          <path d="M32 22 v14 M26 28 h12" stroke="#7a1419" strokeWidth="1.6" strokeLinecap="round" />
+          {/* outer text — V P */}
+          <text x="32" y="13" fontSize="6" fontFamily="'Cormorant Garamond', serif" fill="#fbf6ec" textAnchor="middle" letterSpacing="2" fontWeight="700">VOW</text>
+          <text x="32" y="58" fontSize="6" fontFamily="'Cormorant Garamond', serif" fill="#fbf6ec" textAnchor="middle" letterSpacing="2" fontWeight="700">PACT</text>
+        </svg>
+      </div>
+
+      {/* wordmark */}
+      <div
+        style={{
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: 38,
+          letterSpacing: "0.32em",
+          color: "#2c1810",
+          paddingLeft: "0.32em",
+          lineHeight: 1,
+        }}
+      >
+        VOW PACT
+      </div>
+      {/* divider */}
+      <div style={{ margin: "14px auto 12px", width: 130, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+      {/* tagline */}
+      <p
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 13,
+          fontWeight: 500,
+          color: "#8b6f47",
+          letterSpacing: "0.2em",
+          paddingLeft: "0.2em",
+          lineHeight: 1.7,
+        }}
+      >
+        自分との契約を、紋章に変える
+      </p>
+    </div>
+  );
+}
+
+// ============================================================
+// tabs
+// ============================================================
+function AuthTabs({ tab, onTab }) {
+  return (
+    <div style={{ display: "flex", borderBottom: "1px solid #d4c8b0", margin: "0 4px" }}>
+      {[
+        { id: "signin", label: "ログイン", en: "SIGN IN" },
+        { id: "signup", label: "新規登録", en: "SIGN UP" },
+      ].map((t) => {
+        const active = tab === t.id;
+        return (
+          <button
+            key={t.id}
+            onClick={() => onTab(t.id)}
+            style={{
+              flex: 1,
+              padding: "12px 8px 14px",
+              background: "transparent",
+              border: "none",
+              borderBottom: active ? "2px solid #8b1a1a" : "2px solid transparent",
+              color: active ? "#2c1810" : "#8b6f47",
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 14,
+              fontWeight: active ? 700 : 500,
+              letterSpacing: "0.16em",
+              cursor: "pointer",
+              marginBottom: -1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
+            <span>{t.label}</span>
+            <span
+              style={{
+                fontSize: 8,
+                letterSpacing: "0.4em",
+                color: active ? "#a77b1f" : "#a89c84",
+                fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+                fontWeight: 600,
+                paddingLeft: "0.4em",
+              }}
+            >
+              {t.en}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ============================================================
+// field
+// ============================================================
+function Field({ label, en, type = "text", value, onChange, placeholder, error, help, autoComplete }) {
+  const [focused, setFocused] = useAuthState(false);
+  return (
+    <label style={{ display: "block", fontFamily: "'Noto Sans JP', sans-serif" }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 6 }}>
+        <span
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 12,
+            fontWeight: 600,
+            color: "#2c1810",
+            letterSpacing: "0.1em",
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            fontSize: 8,
+            letterSpacing: "0.4em",
+            color: "#a89c84",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.4em",
+          }}
+        >
+          {en}
+        </span>
+      </div>
+      <input
+        type={type}
+        value={value || ""}
+        onChange={(e) => onChange?.(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        style={{
+          width: "100%",
+          boxSizing: "border-box",
+          padding: "11px 12px",
+          background: "rgba(255,255,255,0.9)",
+          border: error ? "1px solid #8b1a1a" : focused ? "1px solid #8b6f47" : "1px solid #d4c8b0",
+          outline: focused && !error ? "1px solid #c9a96155" : "none",
+          outlineOffset: "-3px",
+          borderRadius: 2,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          fontSize: 14,
+          color: "#2c1810",
+          letterSpacing: "0.02em",
+        }}
+      />
+      {error && (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 11,
+            color: "#8b1a1a",
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.04em",
+            display: "flex",
+            alignItems: "center",
+            gap: 5,
+          }}
+        >
+          <span aria-hidden="true">⚠</span>
+          {error}
+        </div>
+      )}
+      {!error && help && (
+        <div style={{ marginTop: 6, fontSize: 10, color: "#8b6f47", letterSpacing: "0.04em", fontStyle: "italic" }}>{help}</div>
+      )}
+    </label>
+  );
+}
+
+// ============================================================
+// primary button (with loading)
+// ============================================================
+function PrimaryBtn({ children, loading, disabled, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled || loading}
+      style={{
+        width: "100%",
+        padding: "14px 16px",
+        background: disabled || loading ? "#5a4636" : "#2c1810",
+        color: "#fbf6ec",
+        border: "1px solid #2c1810",
+        borderRadius: 2,
+        fontFamily: "'Noto Serif JP', serif",
+        fontSize: 14,
+        fontWeight: 600,
+        letterSpacing: "0.2em",
+        cursor: disabled || loading ? "not-allowed" : "pointer",
+        boxShadow: "0 8px 18px -10px rgba(44,24,16,0.6)",
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        opacity: disabled ? 0.55 : 1,
+      }}
+    >
+      {loading && (
+        <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="12" r="9" stroke="rgba(251,246,236,0.3)" strokeWidth="2.5" fill="none" />
+          <path d="M21 12a9 9 0 00-9-9" stroke="#fbf6ec" strokeWidth="2.5" fill="none" strokeLinecap="round">
+            <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="0.9s" repeatCount="indefinite" />
+          </path>
+        </svg>
+      )}
+      <span>{children}</span>
+    </button>
+  );
+}
+
+// ============================================================
+// checkbox
+// ============================================================
+function Check({ checked, onChange, children }) {
+  return (
+    <label style={{ display: "flex", alignItems: "flex-start", gap: 9, cursor: "pointer" }}>
+      <span
+        role="checkbox"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        style={{
+          flexShrink: 0,
+          marginTop: 1,
+          width: 18,
+          height: 18,
+          background: checked ? "#2c1810" : "#fff",
+          border: `1px solid ${checked ? "#2c1810" : "#a89c84"}`,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#fbf6ec",
+          fontSize: 12,
+        }}
+      >
+        {checked && (
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 6.5L4.8 9 10 3.5" stroke="#fbf6ec" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </span>
+      <span style={{ fontSize: 12, color: "#2c1810", lineHeight: 1.6, fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.04em" }}>{children}</span>
+    </label>
+  );
+}
+
+// ============================================================
+// sign in form
+// ============================================================
+function SignInForm({ mode = "default" }) {
+  const [email, setEmail] = useAuthState(mode === "error" ? "yuto@example.com" : "");
+  const [pw, setPw] = useAuthState(mode === "error" ? "wrongpass" : "");
+  const loading = mode === "loading";
+  const formError = mode === "error" ? "メールアドレスまたはパスワードが違います" : null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      {formError && (
+        <div
+          style={{
+            padding: "10px 12px",
+            background: "rgba(139,26,26,0.08)",
+            border: "1px solid #8b1a1a",
+            borderLeft: "3px solid #8b1a1a",
+            borderRadius: 2,
+            fontSize: 12,
+            color: "#8b1a1a",
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.04em",
+            lineHeight: 1.5,
+          }}
+        >
+          ⚠ {formError}
+        </div>
+      )}
+      <Field
+        label="メールアドレス"
+        en="EMAIL"
+        type="email"
+        value={email}
+        onChange={setEmail}
+        placeholder="you@example.com"
+        autoComplete="email"
+      />
+      <Field
+        label="パスワード"
+        en="PASSWORD"
+        type="password"
+        value={pw}
+        onChange={setPw}
+        placeholder="••••••••"
+        autoComplete="current-password"
+      />
+      <PrimaryBtn loading={loading}>
+        {loading ? "認証しています..." : "ログイン"}
+      </PrimaryBtn>
+      <div style={{ textAlign: "center", marginTop: 4 }}>
+        <a
+          href="#"
+          style={{
+            fontSize: 12,
+            color: "#8b6f47",
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.06em",
+            textDecoration: "underline",
+            textUnderlineOffset: 3,
+            textDecorationColor: "#c9a96188",
+          }}
+        >
+          パスワードを忘れた方
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// sign up form
+// ============================================================
+function SignUpForm({ mode = "default" }) {
+  const [name, setName] = useAuthState(mode !== "default" ? "Yuto" : "");
+  const [email, setEmail] = useAuthState(mode === "error" ? "invalid-email" : mode === "loading" ? "yuto@example.com" : "");
+  const [pw, setPw] = useAuthState(mode !== "default" ? "secret123" : "");
+  const [pw2, setPw2] = useAuthState(mode === "error" ? "secret124" : mode === "loading" ? "secret123" : "");
+  const [agree, setAgree] = useAuthState(mode === "loading");
+  const loading = mode === "loading";
+
+  const errors =
+    mode === "error"
+      ? {
+          email: "正しいメールアドレスを入力してください",
+          pw2: "パスワードが一致しません",
+        }
+      : {};
+
+  const canSubmit = !!name && !!email && pw.length >= 8 && pw === pw2 && agree;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <Field
+        label={
+          <span>
+            <ruby>契約者名<rt style={{ fontSize: "0.5em", color: "#8b6f47", letterSpacing: "0.06em" }}>けいやくしゃめい</rt></ruby>
+          </span>
+        }
+        en="NAME"
+        value={name}
+        onChange={setName}
+        placeholder="あなたの名（ニックネーム可）"
+        help="契約書と紋章に刻まれる名前です"
+        autoComplete="username"
+      />
+      <Field
+        label="メールアドレス"
+        en="EMAIL"
+        type="email"
+        value={email}
+        onChange={setEmail}
+        placeholder="you@example.com"
+        error={errors.email}
+        autoComplete="email"
+      />
+      <Field
+        label="パスワード"
+        en="PASSWORD"
+        type="password"
+        value={pw}
+        onChange={setPw}
+        placeholder="8文字以上"
+        help="8文字以上、英数字を含めてください"
+        autoComplete="new-password"
+      />
+      <Field
+        label="パスワード（確認）"
+        en="CONFIRM"
+        type="password"
+        value={pw2}
+        onChange={setPw2}
+        placeholder="もう一度入力"
+        error={errors.pw2}
+        autoComplete="new-password"
+      />
+
+      <div style={{ marginTop: 4 }}>
+        <Check checked={agree} onChange={setAgree}>
+          <a href="#" style={{ color: "#8b1a1a", textDecoration: "underline", textUnderlineOffset: 2 }}>利用規約</a>
+          {" "}および{" "}
+          <a href="#" style={{ color: "#8b1a1a", textDecoration: "underline", textUnderlineOffset: 2 }}>プライバシーポリシー</a>
+          に同意します
+        </Check>
+      </div>
+
+      <PrimaryBtn loading={loading} disabled={!canSubmit && !loading}>
+        {loading ? "契約を結んでいます..." : "登録する"}
+      </PrimaryBtn>
+    </div>
+  );
+}
+
+// ============================================================
+// screen
+// ============================================================
+function AuthScreen({ width = 412, initialTab = "signin", mode = "default" }) {
+  const [tab, setTab] = useAuthState(initialTab);
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 920,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+        overflow: "hidden",
+      }}
+    >
+      <BgOrnament />
+
+      {/* status bar spacer */}
+      <div style={{ height: 16 }} />
+
+      {/* hero */}
+      <section style={{ padding: "32px 24px 28px", position: "relative" }}>
+        <BigLogo />
+      </section>
+
+      {/* card */}
+      <section
+        style={{
+          margin: "0 20px 22px",
+          padding: "20px 22px 24px",
+          background: "rgba(255,255,255,0.78)",
+          border: "1px solid #d4c8b0",
+          outline: "1px solid #c9a96155",
+          outlineOffset: -5,
+          boxShadow: "0 14px 30px -20px rgba(44,24,16,0.35)",
+          position: "relative",
+        }}
+      >
+        <AuthTabs tab={tab} onTab={setTab} />
+        <div style={{ paddingTop: 22 }}>
+          {tab === "signin" ? <SignInForm mode={mode} /> : <SignUpForm mode={mode} />}
+        </div>
+      </section>
+
+      {/* footer */}
+      <footer
+        style={{
+          padding: "0 24px 24px",
+          textAlign: "center",
+          marginTop: "auto",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.3em",
+            color: "#a77b1f",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.3em",
+            marginBottom: 8,
+          }}
+        >
+          ── ANNO MMXXVI ──
+        </div>
+        <div style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.06em", lineHeight: 1.7 }}>
+          <a href="#" style={{ color: "#8b6f47", textDecoration: "none" }}>利用規約</a>
+          <span aria-hidden="true" style={{ margin: "0 10px", color: "#c9a961" }}>·</span>
+          <a href="#" style={{ color: "#8b6f47", textDecoration: "none" }}>プライバシー</a>
+          <span aria-hidden="true" style={{ margin: "0 10px", color: "#c9a961" }}>·</span>
+          <a href="#" style={{ color: "#8b6f47", textDecoration: "none" }}>お問い合わせ</a>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+Object.assign(window, { AuthScreen });

--- a/docs/VowPact_mock/screens/detail.jsx
+++ b/docs/VowPact_mock/screens/detail.jsx
@@ -1,0 +1,680 @@
+/* global React, ContractCard, Seal, rtStyle */
+
+const { useState: useDetailState } = React;
+
+// ============================================================
+// icons
+// ============================================================
+function ChkOk({ size = 14 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M3 7l3 3 5-6" stroke="#2f7d3a" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ChkBad({ size = 14 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M4 4l6 6M10 4l-6 6" stroke="#8b1a1a" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+function ChkSkip({ size = 14 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M3 7h8" stroke="#8b6f47" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+function BackArrowD({ size = 14, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M9 3L4 7l5 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function PencilD({ size = 14, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 13L4 10l7-7 3 3-7 7-3 1z M10 4l3 3" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ShareD({ size = 13, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M2 2 L14 14 M14 2 L2 14" stroke={color} strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ============================================================
+// status badge with seal stamped on the contract
+// ============================================================
+function DaysLeftBanner({ days }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "stretch",
+        background: "rgba(255,255,255,0.55)",
+        border: "1px solid #c9a961",
+        outline: "1px solid #c9a96155",
+        outlineOffset: "-4px",
+        padding: "12px 16px",
+        margin: "0 0 18px",
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.4em",
+            color: "#a77b1f",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.4em",
+            marginBottom: 4,
+          }}
+        >
+          DAYS REMAINING
+        </div>
+        <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 12, color: "#2c1810", letterSpacing: "0.06em" }}>
+          期日まで
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: 44,
+            fontWeight: 700,
+            color: "#8b1a1a",
+            lineHeight: 1,
+            letterSpacing: "0.02em",
+          }}
+        >
+          {days}
+        </span>
+        <span style={{ fontSize: 14, color: "#8b6f47", fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.1em" }}>日</span>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// stats (sub-header)
+// ============================================================
+function StatsRow({ keptPct, streak, daysLeft }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr",
+        gap: 6,
+        background: "rgba(255,255,255,0.55)",
+        border: "1px solid #d4c8b0",
+        padding: "12px 8px",
+        marginBottom: 18,
+      }}
+    >
+      <StatCell en="KEPT" jp="達成率" value={keptPct} unit="%" emphasize />
+      <Divider />
+      <StatCell en="STREAK" jp="連続" value={streak} unit="日" />
+      <Divider />
+      <StatCell en="LEFT" jp="残り" value={daysLeft} unit="日" />
+    </div>
+  );
+}
+function StatCell({ en, jp, value, unit, emphasize }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div
+        style={{
+          fontSize: 8,
+          letterSpacing: "0.35em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.35em",
+          marginBottom: 3,
+        }}
+      >
+        {en}
+      </div>
+      <div style={{ display: "inline-flex", alignItems: "baseline", gap: 2 }}>
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: emphasize ? 24 : 20,
+            fontWeight: 600,
+            color: emphasize ? "#a77b1f" : "#2c1810",
+            lineHeight: 1,
+          }}
+        >
+          {value}
+        </span>
+        <span style={{ fontSize: 10, color: "#8b6f47" }}>{unit}</span>
+      </div>
+      <div style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.18em", marginTop: 3 }}>{jp}</div>
+    </div>
+  );
+}
+function Divider() {
+  return <span aria-hidden="true" style={{ background: "rgba(201,169,97,0.35)", width: 1, alignSelf: "stretch" }} />;
+}
+
+// ============================================================
+// check-in history (calendar dot grid + list)
+// ============================================================
+
+const HISTORY = [
+  // newest first; 10 days
+  { d: "10/30", status: "ok" },
+  { d: "10/29", status: "ok" },
+  { d: "10/28", status: "ok" },
+  { d: "10/27", status: "ok" },
+  { d: "10/26", status: "ok" },
+  { d: "10/25", status: "skip" },
+  { d: "10/24", status: "bad" },
+  { d: "10/23", status: "ok" },
+  { d: "10/22", status: "ok" },
+  { d: "10/21", status: "bad" },
+];
+
+const STATUS = {
+  ok: { label: "守れた", icon: <ChkOk />, color: "#2f7d3a", bg: "rgba(47,125,58,0.1)", border: "#2f7d3a" },
+  bad: { label: "守れなかった", icon: <ChkBad />, color: "#8b1a1a", bg: "rgba(139,26,26,0.08)", border: "#8b1a1a" },
+  skip: { label: "スキップ", icon: <ChkSkip />, color: "#8b6f47", bg: "rgba(139,111,71,0.08)", border: "#8b6f47" },
+  none: { label: "未記録", icon: null, color: "#a89c84", bg: "transparent", border: "#d4c8b0" },
+};
+
+function HistoryGrid({ history }) {
+  // 30 cells: first 20 unrecorded, last 10 actual data (oldest -> newest)
+  const cells = [];
+  for (let i = 0; i < 20; i++) cells.push({ status: "none", d: null });
+  for (let i = history.length - 1; i >= 0; i--) cells.push(history[i]);
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(15, 1fr)", gap: 4, marginBottom: 14 }}>
+      {cells.map((c, i) => {
+        const s = STATUS[c.status];
+        return (
+          <span
+            key={i}
+            title={c.d ? `${c.d} ${s.label}` : "未記録"}
+            style={{
+              width: "100%",
+              aspectRatio: "1",
+              background: s.bg,
+              border: `1px solid ${s.border}`,
+              borderRadius: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            {c.status === "ok" && <ChkOk size={9} />}
+            {c.status === "bad" && <ChkBad size={9} />}
+            {c.status === "skip" && <ChkSkip size={9} />}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function HistoryLegend() {
+  return (
+    <div style={{ display: "flex", gap: 14, flexWrap: "wrap", padding: "0 2px 6px" }}>
+      {[
+        ["ok", "守れた"],
+        ["bad", "守れなかった"],
+        ["skip", "スキップ"],
+        ["none", "未記録"],
+      ].map(([k, label]) => {
+        const s = STATUS[k];
+        return (
+          <span key={k} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 10, color: "#8b6f47", fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.04em" }}>
+            <span
+              style={{
+                width: 12, height: 12,
+                background: s.bg,
+                border: `1px solid ${s.border}`,
+                display: "inline-flex", alignItems: "center", justifyContent: "center",
+                borderRadius: 1,
+              }}
+            >
+              {k === "ok" && <ChkOk size={8} />}
+              {k === "bad" && <ChkBad size={8} />}
+              {k === "skip" && <ChkSkip size={8} />}
+            </span>
+            {label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function HistoryList({ history }) {
+  return (
+    <div style={{ background: "rgba(255,255,255,0.55)", border: "1px solid #d4c8b0" }}>
+      {history.slice(0, 7).map((h, i) => {
+        const s = STATUS[h.status];
+        return (
+          <div
+            key={i}
+            style={{
+              display: "flex", alignItems: "center", gap: 12,
+              padding: "10px 14px",
+              borderBottom: i < 6 ? "1px solid rgba(212,200,176,0.5)" : "none",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 22, height: 22, borderRadius: "50%",
+                background: s.bg, border: `1px solid ${s.border}`,
+                display: "inline-flex", alignItems: "center", justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              {s.icon}
+            </span>
+            <span style={{ flex: 1, fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontSize: 14, fontWeight: 600, color: "#2c1810", letterSpacing: "0.04em" }}>
+              {h.d}
+            </span>
+            <span style={{ fontSize: 11, color: s.color, fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.06em", fontWeight: 600 }}>
+              {s.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ============================================================
+// abandon confirm modal
+// ============================================================
+function AbandonModal({ onCancel, onConfirm }) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: "absolute", inset: 0,
+        background: "rgba(28,16,10,0.55)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: 20, zIndex: 10,
+        backdropFilter: "blur(2px)",
+      }}
+    >
+      <div
+        style={{
+          background: "#fbf6ec",
+          border: "1px solid #8b1a1a",
+          outline: "1px solid #8b1a1a55",
+          outlineOffset: -5,
+          padding: "22px 22px 18px",
+          width: "100%",
+          maxWidth: 340,
+          boxShadow: "0 24px 48px -16px rgba(44,24,16,0.5)",
+          fontFamily: "'Noto Sans JP', sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 9, letterSpacing: "0.4em",
+            color: "#8b1a1a",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 700,
+            paddingLeft: "0.4em",
+            marginBottom: 10,
+          }}
+        >
+          ── ABANDON PACT ──
+        </div>
+        <h3
+          style={{
+            margin: "0 0 12px",
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 20, fontWeight: 700,
+            color: "#2c1810",
+            letterSpacing: "0.08em",
+            lineHeight: 1.4,
+          }}
+        >
+          契約を破棄しますか？
+        </h3>
+        <p
+          style={{
+            margin: "0 0 12px",
+            fontSize: 12,
+            color: "#2c1810",
+            lineHeight: 1.8,
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.04em",
+          }}
+        >
+          破棄した契約は殿堂に
+          <strong style={{ color: "#8b1a1a" }}>「破棄した契約」</strong>
+          として記録されます。
+        </p>
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "rgba(139,26,26,0.06)",
+            borderLeft: "3px solid #8b1a1a",
+            fontSize: 11,
+            color: "#8b1a1a",
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.04em",
+            lineHeight: 1.7,
+            marginBottom: 18,
+          }}
+        >
+          ⚠ この操作は取り消せません。
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <button
+            onClick={onCancel}
+            style={{
+              flex: 1, padding: "11px 12px",
+              background: "transparent", color: "#2c1810",
+              border: "1px solid #2c1810", borderRadius: 2,
+              fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 600,
+              letterSpacing: "0.14em", cursor: "pointer",
+            }}
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              flex: 1, padding: "11px 12px",
+              background: "#8b1a1a", color: "#fbf6ec",
+              border: "1px solid #8b1a1a", borderRadius: 2,
+              fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 700,
+              letterSpacing: "0.14em", cursor: "pointer",
+            }}
+          >
+            破棄する
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// action buttons
+// ============================================================
+function PrimaryD({ children, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: "100%", padding: "14px 16px",
+        background: "#8b1a1a", color: "#fbf6ec",
+        border: "1px solid #8b1a1a", borderRadius: 2,
+        fontFamily: "'Noto Serif JP', serif", fontSize: 14, fontWeight: 700,
+        letterSpacing: "0.2em", cursor: "pointer",
+        boxShadow: "0 8px 18px -10px rgba(139,26,26,0.6)",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+function SecondaryD({ children, icon, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: "100%", padding: "12px 14px",
+        background: "rgba(255,255,255,0.85)", color: "#2c1810",
+        border: "1px solid #2c1810", borderRadius: 2,
+        fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 600,
+        letterSpacing: "0.14em", cursor: "pointer",
+        display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 8,
+      }}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+// ============================================================
+// section header (compact)
+// ============================================================
+function SecHead({ jp, en }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 10 }}>
+      <span style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 700, color: "#2c1810", letterSpacing: "0.16em" }}>{jp}</span>
+      <span style={{ fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontSize: 9, letterSpacing: "0.4em", color: "#a77b1f", fontWeight: 600, paddingLeft: "0.4em" }}>{en}</span>
+      <span style={{ flex: 1, height: 1, background: "linear-gradient(to right, #c9a96155, transparent)", marginBottom: 2 }} />
+    </div>
+  );
+}
+
+// ============================================================
+// detail screen
+// ============================================================
+function DetailScreen({ width = 412, mode = "default" }) {
+  const [confirm, setConfirm] = useDetailState(mode === "abandon");
+  const checkedInToday = mode === "checked-in";
+
+  const data = {
+    no: "001",
+    goal: (
+      <>
+        TOEIC 800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+      </>
+    ),
+    trial: (
+      <>
+        <ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>まで、SNSを1日30分以内に<ruby>制限<rt style={rtStyle}>せいげん</rt></ruby>する
+      </>
+    ),
+    difficulty: 4,
+    deadline: "2026年 8月 2日 まで",
+    signer: "Yuto",
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1500,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      {/* status spacer */}
+      <div style={{ height: 12 }} />
+
+      {/* top bar */}
+      <header
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto 1fr",
+          alignItems: "center",
+          padding: "10px 16px 12px",
+          borderBottom: "1px solid rgba(212,200,176,0.6)",
+        }}
+      >
+        <button
+          aria-label="ホームに戻る"
+          style={{
+            background: "transparent", border: "none",
+            padding: "6px 4px", cursor: "pointer",
+            display: "inline-flex", alignItems: "center", gap: 4,
+            color: "#8b6f47",
+            fontFamily: "'Noto Serif JP', serif", fontSize: 12, fontWeight: 500,
+            letterSpacing: "0.08em",
+            justifySelf: "start",
+          }}
+        >
+          <BackArrowD />
+          ホームに戻る
+        </button>
+        <div
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: 11,
+            letterSpacing: "0.45em",
+            color: "#8b6f47",
+            fontWeight: 600,
+            paddingLeft: "0.45em",
+            whiteSpace: "nowrap",
+          }}
+        >
+          PACT &nbsp;·&nbsp; No. {data.no}
+        </div>
+        <span />
+      </header>
+
+      <main style={{ padding: "20px 20px 24px" }}>
+        <DaysLeftBanner days={73} />
+
+        <StatsRow keptPct={78} streak={5} daysLeft={73} />
+
+        {/* contract — with seal stamped */}
+        <div style={{ position: "relative", marginBottom: 28 }}>
+          <ContractCard data={data} />
+          <div
+            style={{
+              position: "absolute",
+              top: 36,
+              right: 28,
+              transform: "rotate(-8deg)",
+              filter: "drop-shadow(0 2px 4px rgba(139,26,26,0.25))",
+              pointerEvents: "none",
+            }}
+          >
+            <Seal size={84} rotate={0} />
+          </div>
+        </div>
+
+        {/* check-in history */}
+        <section style={{ marginBottom: 28 }}>
+          <SecHead jp="チェックイン履歴" en="CHECK-IN HISTORY" />
+
+          <div
+            style={{
+              padding: "14px 12px 10px",
+              background: "rgba(255,255,255,0.5)",
+              border: "1px solid #d4c8b0",
+              marginBottom: 14,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginBottom: 10,
+                padding: "0 4px",
+              }}
+            >
+              <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.15em", fontFamily: "'Noto Serif JP', serif" }}>
+                直近 30 日
+              </span>
+              <span style={{ fontSize: 9, color: "#a77b1f", letterSpacing: "0.3em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.3em" }}>
+                LAST 30 DAYS
+              </span>
+            </div>
+            <HistoryGrid history={HISTORY} />
+            <HistoryLegend />
+          </div>
+
+          <div style={{ marginBottom: 6, fontSize: 11, color: "#8b6f47", letterSpacing: "0.06em", paddingLeft: 4, fontFamily: "'Noto Serif JP', serif" }}>
+            最近の記録
+          </div>
+          <HistoryList history={HISTORY} />
+
+          {/* gentle encouragement */}
+          <p
+            style={{
+              margin: "12px 4px 0",
+              fontSize: 11,
+              color: "#8b6f47",
+              fontFamily: "'Noto Serif JP', serif",
+              letterSpacing: "0.04em",
+              lineHeight: 1.7,
+              fontStyle: "italic",
+              textAlign: "center",
+            }}
+          >
+            一日守れぬ日があっても、誓いそのものは折れぬ。
+          </p>
+        </section>
+
+        {/* actions */}
+        <section style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {!checkedInToday && (
+            <PrimaryD>今日のチェックイン</PrimaryD>
+          )}
+          {checkedInToday && (
+            <div
+              style={{
+                padding: "12px 14px",
+                background: "rgba(47,125,58,0.08)",
+                border: "1px solid #2f7d3a",
+                borderLeft: "3px solid #2f7d3a",
+                fontSize: 12,
+                color: "#2f7d3a",
+                fontFamily: "'Noto Serif JP', serif",
+                letterSpacing: "0.06em",
+                textAlign: "center",
+                fontWeight: 600,
+              }}
+            >
+              ✓ 今日のチェックインは完了しています
+            </div>
+          )}
+          <SecondaryD icon={<PencilD />}>契約書を編集する</SecondaryD>
+          <SecondaryD icon={<span style={{ fontFamily: "'Noto Serif JP', serif', sans-serif", fontSize: 13, fontWeight: 700, lineHeight: 1 }}>𝕏</span>}>
+            経過を共有する
+          </SecondaryD>
+
+          <div style={{ marginTop: 10, textAlign: "center" }}>
+            <button
+              onClick={() => setConfirm(true)}
+              style={{
+                background: "transparent", border: "none",
+                padding: "10px 14px",
+                color: "#8b1a1a",
+                fontFamily: "'Noto Serif JP', serif", fontSize: 12,
+                letterSpacing: "0.12em", cursor: "pointer",
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+                textDecorationColor: "#8b1a1a55",
+                textDecorationThickness: 1,
+              }}
+            >
+              契約を破棄する
+            </button>
+          </div>
+        </section>
+      </main>
+
+      {confirm && (
+        <AbandonModal
+          onCancel={() => setConfirm(false)}
+          onConfirm={() => setConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { DetailScreen });

--- a/docs/VowPact_mock/screens/edit.jsx
+++ b/docs/VowPact_mock/screens/edit.jsx
@@ -1,0 +1,507 @@
+/* global React */
+
+const { useState: useEditState } = React;
+
+// ============================================================
+// icons
+// ============================================================
+function BackArrowE({ size = 14, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M9 3L4 7l5 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function LockE({ size = 12, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="5" y="11" width="14" height="9" rx="1.5" stroke={color} strokeWidth="1.6" />
+      <path d="M8 11V8a4 4 0 118 0v3" stroke={color} strokeWidth="1.6" />
+    </svg>
+  );
+}
+function StarE({ filled, size = 14 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path
+        d="M7 1.5l1.7 3.5 3.8.5-2.8 2.7.7 3.8L7 10.2 3.6 12l.7-3.8L1.5 5.5l3.8-.5L7 1.5z"
+        fill={filled ? "#c9a961" : "transparent"}
+        stroke={filled ? "#8b6f1f" : "#a89c84"}
+        strokeWidth="0.9"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+function CheckE({ size = 14, color = "#fbf6ec" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M3 7l3 3 5-6" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ============================================================
+// editable field with counter
+// ============================================================
+function EditField({ label, en, value, onChange, max = 200, placeholder, error, multiline }) {
+  const [focused, setFocused] = useEditState(false);
+  const len = value?.length || 0;
+  const over = len > max;
+  return (
+    <div style={{ display: "block", fontFamily: "'Noto Sans JP', sans-serif" }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 8 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+          <span
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 14, fontWeight: 700,
+              color: "#2c1810",
+              letterSpacing: "0.16em",
+            }}
+          >
+            {label}
+          </span>
+          <span
+            style={{
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontSize: 9, letterSpacing: "0.4em",
+              color: "#a77b1f",
+              fontWeight: 600,
+              paddingLeft: "0.4em",
+            }}
+          >
+            {en}
+          </span>
+        </div>
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: 11,
+            color: over ? "#8b1a1a" : "#8b6f47",
+            letterSpacing: "0.1em",
+            fontWeight: 600,
+          }}
+        >
+          {len} / {max}
+        </span>
+      </div>
+      {multiline ? (
+        <textarea
+          value={value || ""}
+          onChange={(e) => onChange?.(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder={placeholder}
+          rows={4}
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "12px 14px",
+            background: "#f4e8d0",
+            border: error || over
+              ? "1px solid #8b1a1a"
+              : focused ? "1px solid #8b6f47" : "1px solid #d4c8b0",
+            outline: focused && !error && !over ? "1px solid #c9a96155" : "none",
+            outlineOffset: "-4px",
+            borderRadius: 0,
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 15,
+            lineHeight: 1.7,
+            color: "#2c1810",
+            letterSpacing: "0.04em",
+            resize: "vertical",
+            minHeight: 96,
+          }}
+        />
+      ) : (
+        <input
+          value={value || ""}
+          onChange={(e) => onChange?.(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder={placeholder}
+          style={{
+            width: "100%", boxSizing: "border-box",
+            padding: "12px 14px", background: "#f4e8d0",
+            border: error || over ? "1px solid #8b1a1a" : focused ? "1px solid #8b6f47" : "1px solid #d4c8b0",
+            outline: focused && !error && !over ? "1px solid #c9a96155" : "none",
+            outlineOffset: "-4px", borderRadius: 0,
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 15, color: "#2c1810",
+            letterSpacing: "0.04em",
+          }}
+        />
+      )}
+      {error && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "#8b1a1a", fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.04em", display: "flex", alignItems: "center", gap: 5 }}>
+          <span aria-hidden="true">⚠</span>
+          {error}
+        </div>
+      )}
+      {over && !error && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "#8b1a1a", fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.04em" }}>
+          ⚠ 文字数が上限を超えています
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// locked field
+// ============================================================
+function LockedField({ label, en, value, note }) {
+  return (
+    <div style={{ fontFamily: "'Noto Sans JP', sans-serif" }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 8 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+          <span
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 14, fontWeight: 700,
+              color: "#8b6f47",
+              letterSpacing: "0.16em",
+            }}
+          >
+            {label}
+          </span>
+          <span
+            style={{
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontSize: 9, letterSpacing: "0.4em",
+              color: "#a89c84",
+              fontWeight: 600,
+              paddingLeft: "0.4em",
+            }}
+          >
+            {en}
+          </span>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 9, color: "#8b6f47", letterSpacing: "0.2em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.2em" }}>
+          <LockE />
+          LOCKED
+        </span>
+      </div>
+      <div
+        style={{
+          padding: "12px 14px",
+          background: "rgba(212,200,176,0.25)",
+          border: "1px dashed #b3a890",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 15,
+          color: "#6b5d48",
+          letterSpacing: "0.04em",
+          lineHeight: 1.6,
+          minHeight: 24,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {value}
+      </div>
+      {note && (
+        <div style={{ marginTop: 6, fontSize: 10, color: "#8b6f47", fontStyle: "italic", letterSpacing: "0.04em", fontFamily: "'Noto Serif JP', serif" }}>
+          ※ {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// toast
+// ============================================================
+function Toast() {
+  return (
+    <div
+      role="status"
+      style={{
+        position: "absolute",
+        top: 70,
+        left: "50%",
+        transform: "translateX(-50%)",
+        padding: "12px 20px",
+        background: "#2c1810",
+        color: "#fbf6ec",
+        border: "1px solid #2c1810",
+        outline: "1px solid #c9a96177",
+        outlineOffset: "-4px",
+        borderRadius: 2,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 10,
+        fontFamily: "'Noto Serif JP', serif",
+        fontSize: 13,
+        fontWeight: 600,
+        letterSpacing: "0.1em",
+        boxShadow: "0 12px 24px -10px rgba(44,24,16,0.5)",
+        zIndex: 10,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 22, height: 22, borderRadius: "50%",
+          background: "#c9a961",
+          display: "inline-flex", alignItems: "center", justifyContent: "center",
+        }}
+      >
+        <CheckE color="#2c1810" />
+      </span>
+      契約書を更新しました
+    </div>
+  );
+}
+
+// ============================================================
+// section header
+// ============================================================
+function SecHeadE({ jp, en }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 14 }}>
+      <span style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 12, fontWeight: 700, color: "#2c1810", letterSpacing: "0.2em" }}>{jp}</span>
+      <span style={{ fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontSize: 9, letterSpacing: "0.4em", color: "#a77b1f", fontWeight: 600, paddingLeft: "0.4em" }}>{en}</span>
+      <span style={{ flex: 1, height: 1, background: "linear-gradient(to right, #c9a96155, transparent)", marginBottom: 2 }} />
+    </div>
+  );
+}
+
+// ============================================================
+// edit screen
+// ============================================================
+function EditScreen({ width = 412, mode = "default" }) {
+  const initialGoal = "TOEIC 800点を達成する";
+  const initialTrial = "達成までSNSを1日30分以内に制限する";
+
+  const [goal, setGoal] = useEditState(mode === "dirty" || mode === "saved" ? "TOEIC 800点を半年以内に達成する" : initialGoal);
+  const [trial, setTrial] = useEditState(initialTrial);
+
+  const dirty = goal !== initialGoal || trial !== initialTrial;
+  const valid = goal.trim().length > 0 && trial.trim().length > 0 && goal.length <= 200 && trial.length <= 200;
+  const canSave = dirty && valid;
+
+  const showToast = mode === "saved";
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1320,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      <div style={{ height: 12 }} />
+
+      {/* top bar */}
+      <header
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto 1fr",
+          alignItems: "center",
+          padding: "10px 16px 12px",
+          borderBottom: "1px solid rgba(212,200,176,0.6)",
+        }}
+      >
+        <button
+          aria-label="戻る"
+          style={{
+            background: "transparent", border: "none",
+            padding: "6px 4px", cursor: "pointer",
+            display: "inline-flex", alignItems: "center", gap: 4,
+            color: "#8b6f47",
+            fontFamily: "'Noto Serif JP', serif", fontSize: 12, fontWeight: 500,
+            letterSpacing: "0.08em",
+            justifySelf: "start",
+          }}
+        >
+          <BackArrowE />
+          戻る
+        </button>
+        <div
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: 11,
+            letterSpacing: "0.45em",
+            color: "#8b6f47",
+            fontWeight: 600,
+            paddingLeft: "0.45em",
+          }}
+        >
+          PACT &nbsp;·&nbsp; No. 001
+        </div>
+        <span />
+      </header>
+
+      {/* hero */}
+      <section style={{ textAlign: "center", padding: "26px 24px 20px" }}>
+        <div
+          style={{
+            fontSize: 9, letterSpacing: "0.5em",
+            color: "#a77b1f",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.5em",
+            marginBottom: 10,
+          }}
+        >
+          ── EDIT VOW ──
+        </div>
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 700,
+            fontSize: 24,
+            letterSpacing: "0.14em",
+            color: "#2c1810",
+            paddingLeft: "0.14em",
+            lineHeight: 1.4,
+          }}
+        >
+          契約書を編集する
+        </h1>
+        <p
+          style={{
+            margin: "10px 0 0",
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 12,
+            color: "#8b6f47",
+            letterSpacing: "0.06em",
+            fontStyle: "italic",
+            lineHeight: 1.6,
+          }}
+        >
+          目標と試練の文言を修正できます
+        </p>
+      </section>
+
+      {/* form */}
+      <main style={{ padding: "0 22px 0", flex: 1 }}>
+        {/* editable section */}
+        <div style={{ marginBottom: 28 }}>
+          <SecHeadE jp="編集可能" en="EDITABLE" />
+          <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+            <EditField
+              label="目標"
+              en="GOAL"
+              value={goal}
+              onChange={setGoal}
+              max={120}
+              multiline
+              placeholder="達成したい目標を記してください"
+            />
+            <EditField
+              label="試練"
+              en="TRIAL"
+              value={trial}
+              onChange={setTrial}
+              max={200}
+              multiline
+              placeholder="目標達成のために自分に課す試練"
+            />
+          </div>
+        </div>
+
+        {/* locked section */}
+        <div style={{ marginBottom: 26 }}>
+          <SecHeadE jp="変更不可" en="LOCKED" />
+          <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+            <LockedField
+              label="試練の格"
+              en="DIFFICULTY"
+              value={
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <StarE key={i} filled={i <= 4} />
+                  ))}
+                  <span style={{ marginLeft: 8, fontSize: 12, color: "#8b6f47", letterSpacing: "0.08em" }}>4 / 5</span>
+                </span>
+              }
+              note="難易度は変更できません"
+            />
+            <LockedField
+              label="期日"
+              en="DEADLINE"
+              value="2026年 8月 2日 まで"
+              note="期日は変更できません"
+            />
+          </div>
+        </div>
+
+        {/* notes */}
+        <div
+          style={{
+            margin: "0 0 26px",
+            padding: "12px 14px",
+            background: "rgba(201,169,97,0.08)",
+            border: "1px dashed #c9a961",
+            fontSize: 11,
+            color: "#8b6f47",
+            lineHeight: 1.85,
+            letterSpacing: "0.04em",
+            fontFamily: "'Noto Serif JP', serif",
+          }}
+        >
+          <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#a77b1f", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 6 }}>
+            NOTES
+          </div>
+          ・ 契約締結時の難易度判定は変更されません<br />
+          ・ 過去のチェックイン履歴はそのまま引き継がれます
+        </div>
+      </main>
+
+      {/* sticky-ish action bar */}
+      <footer
+        style={{
+          padding: "16px 22px 22px",
+          borderTop: "1px solid rgba(212,200,176,0.7)",
+          background: "rgba(251,246,236,0.85)",
+          display: "flex",
+          gap: 10,
+        }}
+      >
+        <button
+          style={{
+            flex: "0 0 38%", padding: "13px 12px",
+            background: "transparent", color: "#2c1810",
+            border: "1px solid #2c1810", borderRadius: 2,
+            fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 600,
+            letterSpacing: "0.16em", cursor: "pointer",
+          }}
+        >
+          キャンセル
+        </button>
+        <button
+          disabled={!canSave}
+          style={{
+            flex: 1, padding: "13px 12px",
+            background: canSave ? "#8b1a1a" : "#c9a89455",
+            color: canSave ? "#fbf6ec" : "#a89c84",
+            border: canSave ? "1px solid #8b1a1a" : "1px solid #c9a894",
+            borderRadius: 2,
+            fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 700,
+            letterSpacing: "0.16em",
+            cursor: canSave ? "pointer" : "not-allowed",
+            boxShadow: canSave ? "0 8px 18px -10px rgba(139,26,26,0.6)" : "none",
+            display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 8,
+          }}
+        >
+          {canSave && <CheckE size={13} />}
+          変更を保存
+        </button>
+      </footer>
+
+      {showToast && <Toast />}
+    </div>
+  );
+}
+
+Object.assign(window, { EditScreen });

--- a/docs/VowPact_mock/screens/fulfilled.jsx
+++ b/docs/VowPact_mock/screens/fulfilled.jsx
@@ -1,0 +1,770 @@
+/* global React, StarDivider, DifficultyStars, Signature, CornerOrnament, Seal, rtStyle */
+
+const { useState: useStep7State, useEffect: useStep7Effect } = React;
+
+// ============================================================
+// Heraldic Crest — the centerpiece earned at completion
+// ============================================================
+
+// Rarity palettes
+const RARITY = {
+  common: {
+    label: "コモン",
+    en: "COMMON",
+    primary: "#7a7060",
+    secondary: "#a89c84",
+    glow: "rgba(168, 156, 132, 0.25)",
+    badgeBg: "#e8e2d4",
+    badgeText: "#5a5040",
+    decorations: 0,
+  },
+  rare: {
+    label: "レア",
+    en: "RARE",
+    primary: "#3a5a8c",
+    secondary: "#7a9bc2",
+    glow: "rgba(80, 130, 200, 0.35)",
+    badgeBg: "#dde6f3",
+    badgeText: "#1f3a66",
+    decorations: 1,
+  },
+  epic: {
+    label: "エピック",
+    en: "EPIC",
+    primary: "#6b3a8c",
+    secondary: "#a877c7",
+    glow: "rgba(140, 80, 180, 0.4)",
+    badgeBg: "#ebdef3",
+    badgeText: "#4a1f6a",
+    decorations: 2,
+  },
+  legendary: {
+    label: "レジェンダリー",
+    en: "LEGENDARY",
+    primary: "#a77b1f",
+    secondary: "#e8c873",
+    glow: "rgba(232, 200, 115, 0.55)",
+    badgeBg: "#f6ecc8",
+    badgeText: "#6e4d10",
+    decorations: 3,
+  },
+};
+
+let __crestId = 0;
+function HeraldicCrest({ rarity = "epic", size = 140, animate = false }) {
+  const r = RARITY[rarity];
+  const uid = React.useMemo(() => `crest-${++__crestId}`, []);
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        position: "relative",
+        animation: animate ? "vp7-crest 1.1s cubic-bezier(0.2, 1.4, 0.4, 1) 0.3s both" : "none",
+      }}
+      aria-label={`紋章（${r.label}）`}
+    >
+      {/* radial glow */}
+      <div
+        style={{
+          position: "absolute",
+          inset: -size * 0.35,
+          background: `radial-gradient(circle, ${r.glow} 0%, transparent 60%)`,
+          pointerEvents: "none",
+        }}
+      />
+      <svg width={size} height={size} viewBox="0 0 140 140" style={{ position: "relative" }}>
+        <defs>
+          <linearGradient id={`${uid}-shield`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={r.secondary} />
+            <stop offset="100%" stopColor={r.primary} />
+          </linearGradient>
+          <linearGradient id={`${uid}-band`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#fbf6ec" />
+            <stop offset="100%" stopColor="#e8dec6" />
+          </linearGradient>
+          <filter id={`${uid}-rough`}>
+            <feTurbulence baseFrequency="0.9" numOctaves="2" seed="11" />
+            <feDisplacementMap in="SourceGraphic" scale="0.6" />
+          </filter>
+        </defs>
+
+        {/* laurel left */}
+        <g transform="translate(8, 60) rotate(-8)" opacity="0.8">
+          <path
+            d="M0 35 Q-2 25 0 18 Q-3 10 -2 0 Q3 8 5 18 Q3 28 0 35z"
+            fill={r.secondary}
+            opacity="0.6"
+          />
+          <path d="M-4 30 Q-8 25 -10 20" stroke={r.primary} strokeWidth="1" fill="none" />
+          <path d="M-4 18 Q-8 14 -10 10" stroke={r.primary} strokeWidth="1" fill="none" />
+        </g>
+        {/* laurel right */}
+        <g transform="translate(132, 60) rotate(8) scale(-1, 1)" opacity="0.8">
+          <path d="M0 35 Q-2 25 0 18 Q-3 10 -2 0 Q3 8 5 18 Q3 28 0 35z" fill={r.secondary} opacity="0.6" />
+          <path d="M-4 30 Q-8 25 -10 20" stroke={r.primary} strokeWidth="1" fill="none" />
+          <path d="M-4 18 Q-8 14 -10 10" stroke={r.primary} strokeWidth="1" fill="none" />
+        </g>
+
+        {/* shield body */}
+        <path
+          d="M70 14 L108 22 L108 70 Q108 100 70 122 Q32 100 32 70 L32 22 Z"
+          fill={`url(#${uid}-shield)`}
+          stroke={r.primary}
+          strokeWidth="1.5"
+          filter={`url(#${uid}-rough)`}
+        />
+        {/* inner highlight */}
+        <path
+          d="M70 18 L104 25 L104 70 Q104 96 70 116 Q36 96 36 70 L36 25 Z"
+          fill="none"
+          stroke="rgba(255,255,255,0.3)"
+          strokeWidth="0.8"
+        />
+
+        {/* central horizontal band */}
+        <path
+          d="M37 56 L103 56 L103 76 Q103 80 100 82 L70 90 L40 82 Q37 80 37 76 Z"
+          fill={`url(#${uid}-band)`}
+          stroke={r.primary}
+          strokeWidth="1"
+        />
+
+        {/* central kanji 誓 */}
+        <text
+          x="70"
+          y="76"
+          textAnchor="middle"
+          fontFamily="'Noto Serif JP', serif"
+          fontSize="22"
+          fontWeight="700"
+          fill={r.primary}
+          letterSpacing="0"
+        >
+          誓
+        </text>
+
+        {/* upper crown / fleur */}
+        <g transform="translate(70, 28)">
+          <path d="M-12 6 L-8 -2 L-4 4 L0 -6 L4 4 L8 -2 L12 6 Z" fill={r.secondary} stroke={r.primary} strokeWidth="0.8" />
+          <circle cx="0" cy="-6" r="1.6" fill={r.primary} />
+        </g>
+
+        {/* lower flourish — number of stars by rarity */}
+        {r.decorations > 0 && (
+          <g transform="translate(70, 102)">
+            {Array.from({ length: r.decorations + 1 }).map((_, i) => {
+              const offset = (i - r.decorations / 2) * 8;
+              return (
+                <path
+                  key={i}
+                  d={`M${offset} -3 L${offset + 1.4} -0.6 L${offset + 4} -0.2 L${offset + 2} 1.6 L${offset + 2.6} 4.4 L${offset} 3 L${offset - 2.6} 4.4 L${offset - 2} 1.6 L${offset - 4} -0.2 L${offset - 1.4} -0.6 Z`}
+                  fill={r.primary}
+                />
+              );
+            })}
+          </g>
+        )}
+
+        {/* outer ring of accent dots */}
+        <g opacity="0.6">
+          {Array.from({ length: 8 }).map((_, i) => {
+            const angle = (i / 8) * Math.PI * 2 - Math.PI / 2;
+            const cx = 70 + Math.cos(angle) * 60;
+            const cy = 70 + Math.sin(angle) * 60;
+            return <circle key={i} cx={cx} cy={cy} r={i % 2 === 0 ? 1.2 : 0.6} fill={r.primary} />;
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+// ============================================================
+// Achieved contract card — has the crest stamped at top center
+// ============================================================
+
+const accentBodyStyle7 = {
+  fontFamily: "'Noto Serif JP', serif",
+  fontSize: 15,
+  lineHeight: 1.7,
+  color: "#2c1810",
+  borderLeft: "2px solid #8b1a1a",
+  padding: "2px 0 2px 12px",
+  margin: 0,
+  letterSpacing: "0.02em",
+};
+
+function Section7({ label, right, children }) {
+  return (
+    <section style={{ marginBottom: 16 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 6 }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 10,
+            color: "#8b6f47",
+            letterSpacing: "0.45em",
+            fontWeight: 600,
+            paddingLeft: "0.45em",
+          }}
+        >
+          【{label}】
+        </h3>
+        {right}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function AchievedContractCard({ data, rarity, animate }) {
+  const { no, goal, trial, difficulty, deadline, signer } = data;
+  return (
+    <article
+      aria-label="成就した誓約契約書"
+      style={{
+        position: "relative",
+        background: "#f4e8d0",
+        border: "0.5px solid #d4c8b0",
+        boxShadow:
+          "0 1px 0 rgba(255,255,255,0.4) inset, 0 14px 32px -16px rgba(44,24,16,0.4), 0 2px 4px rgba(44,24,16,0.06)",
+        padding: "60px 22px 24px",
+        outline: "1px solid #c9a961",
+        outlineOffset: "-10px",
+      }}
+    >
+      <CornerOrnament position="tl" />
+      <CornerOrnament position="tr" />
+      <CornerOrnament position="bl" />
+      <CornerOrnament position="br" />
+
+      {/* CRESTED SEAL — top center, partially overlapping */}
+      <div
+        style={{
+          position: "absolute",
+          top: -56,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 2,
+        }}
+      >
+        <HeraldicCrest rarity={rarity} size={140} animate={animate} />
+      </div>
+
+      <header style={{ textAlign: "center", marginTop: 20, marginBottom: 14 }}>
+        <h2
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: "clamp(20px, 6vw, 26px)",
+            letterSpacing: "0.45em",
+            color: "#2c1810",
+            margin: 0,
+            paddingLeft: "0.45em",
+          }}
+        >
+          誓約契約書
+        </h2>
+        <p
+          style={{
+            margin: "8px 0 0",
+            fontSize: 10,
+            letterSpacing: "0.3em",
+            color: "#8b6f47",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          }}
+        >
+          VOW PACT &nbsp;·&nbsp; No. {no} &nbsp;·&nbsp; <span style={{ color: "#8b1a1a", fontWeight: 600 }}>FULFILLED</span>
+        </p>
+      </header>
+
+      <div style={{ margin: "12px 4px 18px" }}>
+        <StarDivider />
+      </div>
+
+      <Section7 label="目標">
+        <p style={accentBodyStyle7}>{goal}</p>
+      </Section7>
+
+      <Section7
+        label="試練"
+        right={
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.25em" }}>
+              <ruby>難易度<rt style={{ fontSize: "0.55em", color: "#8b6f47" }}>なんいど</rt></ruby>
+            </span>
+            <DifficultyStars value={difficulty} />
+          </span>
+        }
+      >
+        <p style={accentBodyStyle7}>{trial}</p>
+      </Section7>
+
+      <Section7 label="期日">
+        <p style={accentBodyStyle7}>
+          {deadline} <span style={{ color: "#8b6f47", fontSize: 12, marginLeft: 6 }}>—— 達成</span>
+        </p>
+      </Section7>
+
+      {/* signature row */}
+      <div
+        style={{
+          marginTop: 22,
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 9, letterSpacing: "0.3em", color: "#8b6f47", marginBottom: 8 }}>
+            契約者
+          </div>
+          <div
+            style={{
+              borderBottom: "1px solid #2c1810",
+              paddingBottom: 4,
+              minHeight: 36,
+              display: "flex",
+              alignItems: "flex-end",
+            }}
+          >
+            <Signature name={signer} />
+          </div>
+        </div>
+        <div style={{ marginBottom: -4, marginRight: -2 }}>
+          <Seal size={64} rotate={-8} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+// ============================================================
+// Header — Joju seri
+// ============================================================
+
+function FulfilledHeader({ animate }) {
+  return (
+    <header style={{ textAlign: "center", padding: "32px 24px 20px" }}>
+      <div
+        style={{
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 11,
+          letterSpacing: "0.6em",
+          color: "#a77b1f",
+          fontWeight: 600,
+          paddingLeft: "0.6em",
+          marginBottom: 10,
+          opacity: animate ? 0 : 1,
+          animation: animate ? "vp7-fade 0.6s ease-out 0.0s both" : "none",
+        }}
+      >
+        ── FULFILLED ──
+      </div>
+
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: "clamp(48px, 13vw, 60px)",
+          letterSpacing: "0.18em",
+          color: "#2c1810",
+          lineHeight: 1.1,
+          paddingLeft: "0.18em",
+          textShadow: "0 1px 0 rgba(255,255,255,0.6)",
+          animation: animate ? "vp7-rise 0.8s cubic-bezier(0.2, 1, 0.4, 1) 0.1s both" : "none",
+          background: "linear-gradient(180deg, #2c1810 0%, #4a2818 100%)",
+          WebkitBackgroundClip: "text",
+          WebkitTextFillColor: "transparent",
+          backgroundClip: "text",
+          color: "#2c1810",
+        }}
+      >
+        <ruby>成就<rt style={{ fontSize: "0.32em", color: "#a77b1f", letterSpacing: "0.1em", fontWeight: 600 }}>じょうじゅ</rt></ruby>せり
+      </h1>
+
+      <div
+        style={{
+          margin: "16px auto 0",
+          width: 140,
+          height: 1,
+          background: "linear-gradient(to right, transparent, #c9a961, transparent)",
+        }}
+      />
+
+      <p
+        style={{
+          margin: "12px 0 0",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 14,
+          color: "#8b6f47",
+          letterSpacing: "0.15em",
+          fontStyle: "italic",
+          animation: animate ? "vp7-fade 0.6s ease-out 0.5s both" : "none",
+        }}
+      >
+        あなたは試練を乗り越えた
+      </p>
+    </header>
+  );
+}
+
+// ============================================================
+// Rarity badge + record stats
+// ============================================================
+
+function RarityBadge({ rarity }) {
+  const r = RARITY[rarity];
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 16px 8px 14px",
+        background: r.badgeBg,
+        border: `1px solid ${r.primary}33`,
+        borderRadius: 999,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: "50%",
+          background: `linear-gradient(180deg, ${r.secondary}, ${r.primary})`,
+          boxShadow: `0 0 8px ${r.glow}`,
+        }}
+      />
+      <span style={{ fontSize: 9, letterSpacing: "0.45em", color: r.badgeText, fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 700, paddingLeft: "0.45em" }}>
+        {r.en}
+      </span>
+      <span style={{ width: 1, height: 12, background: `${r.primary}44` }} />
+      <span style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 13, color: r.badgeText, fontWeight: 600, letterSpacing: "0.08em" }}>
+        {r.label}
+      </span>
+    </div>
+  );
+}
+
+function RecordStats({ totalDays, keptDays }) {
+  const pct = Math.round((keptDays / totalDays) * 100);
+  return (
+    <div style={{ display: "flex", gap: 18, justifyContent: "center", marginTop: 14 }}>
+      <Stat label="期間" value={totalDays} unit="日" />
+      <Divider />
+      <Stat label="守れた日数" value={keptDays} unit="日" />
+      <Divider />
+      <Stat label="達成率" value={pct} unit="%" emphasize />
+    </div>
+  );
+}
+
+function Stat({ label, value, unit, emphasize }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ fontSize: 9, letterSpacing: "0.35em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.35em", marginBottom: 4 }}>
+        {label}
+      </div>
+      <div style={{ display: "inline-flex", alignItems: "baseline", gap: 2 }}>
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: emphasize ? 28 : 22,
+            fontWeight: 600,
+            color: emphasize ? "#a77b1f" : "#2c1810",
+            lineHeight: 1,
+            letterSpacing: "0.02em",
+          }}
+        >
+          {value}
+        </span>
+        <span style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.06em" }}>{unit}</span>
+      </div>
+    </div>
+  );
+}
+
+function Divider() {
+  return <span aria-hidden="true" style={{ width: 1, background: "rgba(201,169,97,0.35)" }} />;
+}
+
+// ============================================================
+// Title (称号)
+// ============================================================
+
+function TitleBlock({ title }) {
+  return (
+    <div
+      style={{
+        textAlign: "center",
+        padding: "24px 24px 4px",
+      }}
+    >
+      <div style={{ fontSize: 9, letterSpacing: "0.5em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.5em", marginBottom: 12 }}>
+        ── BESTOWED TITLE · 授かりし称号 ──
+      </div>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: "clamp(22px, 6.4vw, 28px)",
+          letterSpacing: "0.12em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+          padding: "0 16px",
+        }}
+      >
+        「{title}」
+      </h2>
+    </div>
+  );
+}
+
+// ============================================================
+// Action buttons
+// ============================================================
+
+function XIcon({ size = 16, color = "#fbf6ec" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={color} aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+function HallIcon({ size = 16, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 2.5l8 3v6.5c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5V5.5l8-3z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M12 8v6M9 11h6" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+function PlusSmall({ size = 14, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M7 2v10M2 7h10" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ActionButtons() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, padding: "0 20px" }}>
+      {/* primary — share to X */}
+      <button
+        style={{
+          height: 56,
+          background: "linear-gradient(180deg, #2c1810 0%, #3a2418 100%)",
+          color: "#fbf6ec",
+          border: "1px solid #2c1810",
+          outline: "1px solid #c9a961",
+          outlineOffset: "-5px",
+          borderRadius: 4,
+          fontSize: 15,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          letterSpacing: "0.18em",
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 12,
+          boxShadow: "0 8px 18px -10px rgba(44,24,16,0.7)",
+          paddingLeft: "0.18em",
+        }}
+      >
+        <XIcon size={16} color="#c9a961" />
+        <span>
+          <ruby>𝕏<rt style={{ fontSize: 0 }}> </rt></ruby> で<ruby>栄光<rt style={{ ...rtStyle, color: "#c9a961" }}>えいこう</rt></ruby>を示す
+        </span>
+      </button>
+
+      {/* secondary row */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+        <button
+          style={{
+            height: 48,
+            background: "#ffffff",
+            color: "#2c1810",
+            border: "1px solid #d4c8b0",
+            borderRadius: 4,
+            fontSize: 13,
+            fontFamily: "'Noto Sans JP', sans-serif",
+            letterSpacing: "0.08em",
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+          }}
+        >
+          <HallIcon size={14} />
+          <ruby>誓約<rt style={rtStyle}>せいやく</rt></ruby>の<ruby>殿堂<rt style={rtStyle}>でんどう</rt></ruby>
+        </button>
+        <button
+          style={{
+            height: 48,
+            background: "#ffffff",
+            color: "#2c1810",
+            border: "1px solid #d4c8b0",
+            borderRadius: 4,
+            fontSize: 13,
+            fontFamily: "'Noto Sans JP', sans-serif",
+            letterSpacing: "0.08em",
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+          }}
+        >
+          <PlusSmall />
+          新しい<ruby>契約<rt style={rtStyle}>けいやく</rt></ruby>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// Confetti / sparkles overlay
+// ============================================================
+
+function Sparkles({ count = 14, animate }) {
+  const positions = React.useMemo(
+    () =>
+      Array.from({ length: count }).map((_, i) => ({
+        id: i,
+        x: 8 + ((i * 73) % 90),
+        y: 12 + ((i * 47) % 60),
+        size: 3 + (i % 3),
+        delay: 0.3 + (i % 7) * 0.15,
+      })),
+    [count]
+  );
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden" }} aria-hidden="true">
+      {positions.map((p) => (
+        <span
+          key={p.id}
+          style={{
+            position: "absolute",
+            left: `${p.x}%`,
+            top: `${p.y}%`,
+            width: p.size,
+            height: p.size,
+            background: "#c9a961",
+            borderRadius: "50%",
+            boxShadow: "0 0 6px #c9a961cc",
+            opacity: animate ? 0 : 0.8,
+            animation: animate ? `vp7-sparkle 1.6s ease-out ${p.delay}s both` : "none",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ============================================================
+// Screen
+// ============================================================
+
+const FULFILLED_DATA = {
+  no: "001",
+  goal: (
+    <>
+      TOEIC 800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+    </>
+  ),
+  trial: (
+    <>
+      <ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>まで、SNSを1日30分以内に<ruby>制限<rt style={rtStyle}>せいげん</rt></ruby>する
+    </>
+  ),
+  difficulty: 4,
+  deadline: "2026年 8月 2日",
+  signer: "Yuto",
+};
+
+const TITLES = {
+  common: "誓いを守りし者",
+  rare: "鍛錬を続けし者",
+  epic: "異邦の言葉を求めし者",
+  legendary: "鋼の意志を持ちし者",
+};
+
+function FulfilledScreen({ width = 412, rarity = "epic", animate = false, totalDays = 90, keptDays = 85 }) {
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1200,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 65%, #e8dcc0 100%)",
+        boxSizing: "border-box",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <Sparkles animate={animate} />
+
+      <FulfilledHeader animate={animate} />
+
+      {/* contract + crest */}
+      <div style={{ padding: "36px 16px 8px" }}>
+        <AchievedContractCard data={FULFILLED_DATA} rarity={rarity} animate={animate} />
+      </div>
+
+      {/* rarity + record */}
+      <div style={{ padding: "22px 20px 6px", textAlign: "center" }}>
+        <RarityBadge rarity={rarity} />
+        <RecordStats totalDays={totalDays} keptDays={keptDays} />
+      </div>
+
+      {/* title */}
+      <TitleBlock title={TITLES[rarity]} />
+
+      <div style={{ height: 18 }} />
+
+      <ActionButtons />
+
+      <div style={{ height: 32 }} />
+    </div>
+  );
+}
+
+if (typeof document !== "undefined" && !document.getElementById("vp7-style")) {
+  const s = document.createElement("style");
+  s.id = "vp7-style";
+  s.textContent = `
+    @keyframes vp7-crest {
+      0% { transform: scale(2.6) rotate(-22deg); opacity: 0; }
+      45% { transform: scale(1.25) rotate(-6deg); opacity: 1; }
+      75% { transform: scale(0.94) rotate(-2deg); }
+      100% { transform: scale(1) rotate(0); opacity: 1; }
+    }
+    @keyframes vp7-rise {
+      0% { transform: translateY(18px); opacity: 0; }
+      100% { transform: translateY(0); opacity: 1; }
+    }
+    @keyframes vp7-fade {
+      0% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+    @keyframes vp7-sparkle {
+      0% { opacity: 0; transform: scale(0.4); }
+      30% { opacity: 1; transform: scale(1.6); }
+      100% { opacity: 0; transform: scale(0.6) translateY(-12px); }
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+Object.assign(window, { FulfilledScreen, HeraldicCrest, RARITY });

--- a/docs/VowPact_mock/screens/hall.jsx
+++ b/docs/VowPact_mock/screens/hall.jsx
@@ -1,0 +1,796 @@
+/* global React, HeraldicCrest, RARITY, rtStyle */
+
+const { useState: useHallState } = React;
+
+// ============================================================
+// icons
+// ============================================================
+function ArrowIcon8({ dir = "down", size = 12, color = "#2c1810" }) {
+  const rot = { right: 0, left: 180, up: -90, down: 90 }[dir];
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" style={{ transform: `rotate(${rot}deg)` }} fill="none" aria-hidden="true">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function FlameIcon8({ size = 14, color = "#c9a961" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 22c-4.5 0-7-3-7-7 0-3 2-5.5 3-7 0 1.5 1 2.5 2 2.5 0-3 1.5-6 5-8.5-1 4 4 6 4 11 0 5-2.5 9-7 9z" fill={color} stroke="#8b6f47" strokeWidth="0.8" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function HomeIcon8({ size = 22, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M3 11.5L12 4l9 7.5V20a1 1 0 01-1 1h-5v-6h-6v6H4a1 1 0 01-1-1v-8.5z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ShieldIcon8({ size = 22, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 2.5l8 3v6.5c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5V5.5l8-3z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M12 8v6M9 11h6" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+function RankIcon8({ size = 22, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M5 19l9-9M19 19l-9-9M14 4l6 6M10 4L4 10" stroke={color} strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="14" cy="4" r="1" fill={color} />
+      <circle cx="10" cy="4" r="1" fill={color} />
+    </svg>
+  );
+}
+function GearIcon8({ size = 20, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 15.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z" stroke={color} strokeWidth="1.4" />
+      <path d="M19.4 13.6a7.6 7.6 0 000-3.2l1.9-1.5-2-3.4-2.3.8a7.7 7.7 0 00-2.7-1.6L13.7 2h-3.4l-.6 2.7a7.7 7.7 0 00-2.7 1.6l-2.3-.8-2 3.4 1.9 1.5a7.6 7.6 0 000 3.2l-1.9 1.5 2 3.4 2.3-.8a7.7 7.7 0 002.7 1.6l.6 2.7h3.4l.6-2.7a7.7 7.7 0 002.7-1.6l2.3.8 2-3.4-1.9-1.5z" stroke={color} strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ============================================================
+// header
+// ============================================================
+function HallHeader() {
+  return (
+    <header
+      style={{
+        textAlign: "center",
+        padding: "26px 20px 22px",
+        background: "linear-gradient(180deg, rgba(201,169,97,0.10) 0%, transparent 100%)",
+        borderBottom: "1px solid #d4c8b0",
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 10,
+          letterSpacing: "0.6em",
+          color: "#a77b1f",
+          fontWeight: 600,
+          paddingLeft: "0.6em",
+          marginBottom: 10,
+        }}
+      >
+        ── HALL OF VOWS ──
+      </div>
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: "clamp(28px, 7.6vw, 34px)",
+          letterSpacing: "0.16em",
+          color: "#2c1810",
+          paddingLeft: "0.16em",
+          lineHeight: 1.2,
+        }}
+      >
+        <ruby>誓約<rt style={{ fontSize: "0.32em", color: "#a77b1f", letterSpacing: "0.1em", fontWeight: 600 }}>せいやく</rt></ruby>の<ruby>殿堂<rt style={{ fontSize: "0.32em", color: "#a77b1f", letterSpacing: "0.1em", fontWeight: 600 }}>でんどう</rt></ruby>
+      </h1>
+      <div style={{ margin: "12px auto 0", width: 110, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+      <p
+        style={{
+          margin: "10px 0 0",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 12,
+          color: "#8b6f47",
+          letterSpacing: "0.1em",
+          fontStyle: "italic",
+        }}
+      >
+        あなたが乗り越えた試練の記録
+      </p>
+    </header>
+  );
+}
+
+// ============================================================
+// stats
+// ============================================================
+function StatsBlock({ achievedCount, scoreTotal, streak }) {
+  return (
+    <section
+      aria-label="統計"
+      style={{
+        margin: "16px 20px 0",
+        padding: "14px 8px",
+        background: "rgba(255,255,255,0.55)",
+        border: "1px solid #d4c8b0",
+        outline: "1px solid #c9a96155",
+        outlineOffset: "-5px",
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr",
+        gap: 6,
+      }}
+    >
+      <StatCol label="達成" en="ACHIEVED" value={achievedCount} unit="件" emphasize />
+      <StatDivider8 />
+      <StatCol label="スコア" en="SCORE" value={scoreTotal} unit="pt" />
+      <StatDivider8 />
+      <StatCol label="連続" en="STREAK" value={streak} unit="日" icon={<FlameIcon8 size={12} />} />
+    </section>
+  );
+}
+function StatCol({ label, en, value, unit, emphasize, icon }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ fontSize: 8, letterSpacing: "0.4em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 4, display: "inline-flex", alignItems: "center", gap: 4 }}>
+        {icon}
+        <span>{en}</span>
+      </div>
+      <div style={{ display: "inline-flex", alignItems: "baseline", gap: 2 }}>
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: emphasize ? 26 : 22,
+            fontWeight: 600,
+            color: emphasize ? "#a77b1f" : "#2c1810",
+            lineHeight: 1,
+          }}
+        >
+          {value}
+        </span>
+        <span style={{ fontSize: 10, color: "#8b6f47" }}>{unit}</span>
+      </div>
+      <div style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.2em", marginTop: 3 }}>{label}</div>
+    </div>
+  );
+}
+function StatDivider8() {
+  return <span aria-hidden="true" style={{ background: "rgba(201,169,97,0.35)", width: 1, alignSelf: "stretch" }} />;
+}
+
+// ============================================================
+// filter / sort bar
+// ============================================================
+
+const FILTERS = [
+  { id: "all", label: "全て" },
+  { id: "fulfilled", label: "達成" },
+  { id: "active", label: "進行中" },
+  { id: "abandoned", label: "破棄" },
+];
+const SORTS = [
+  { id: "recent", label: "新しい順" },
+  { id: "rarity", label: "レアリティ順" },
+];
+
+function FilterBar({ filter, sort, onFilter, onSort }) {
+  return (
+    <div style={{ padding: "16px 20px 8px", display: "flex", flexDirection: "column", gap: 10 }}>
+      {/* filter pills */}
+      <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 2 }}>
+        {FILTERS.map((f) => {
+          const active = filter === f.id;
+          return (
+            <button
+              key={f.id}
+              onClick={() => onFilter(f.id)}
+              style={{
+                flexShrink: 0,
+                padding: "6px 14px",
+                background: active ? "#2c1810" : "transparent",
+                color: active ? "#fbf6ec" : "#8b6f47",
+                border: `1px solid ${active ? "#2c1810" : "#d4c8b0"}`,
+                borderRadius: 999,
+                fontSize: 12,
+                fontFamily: "'Noto Serif JP', serif",
+                fontWeight: 500,
+                letterSpacing: "0.06em",
+                cursor: "pointer",
+              }}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+      </div>
+      {/* sort */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <span style={{ fontSize: 10, letterSpacing: "0.3em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.3em" }}>
+          {SORTS.find((s) => s.id === sort)?.label === "新しい順" ? "RECENT" : "BY RARITY"}
+        </span>
+        <div style={{ display: "inline-flex", border: "1px solid #d4c8b0", borderRadius: 4, overflow: "hidden" }}>
+          {SORTS.map((s) => {
+            const active = sort === s.id;
+            return (
+              <button
+                key={s.id}
+                onClick={() => onSort(s.id)}
+                style={{
+                  padding: "6px 12px",
+                  background: active ? "#f4e8d0" : "#ffffff",
+                  color: "#2c1810",
+                  border: "none",
+                  fontSize: 11,
+                  fontFamily: "'Noto Serif JP', serif",
+                  fontWeight: active ? 600 : 400,
+                  letterSpacing: "0.06em",
+                  cursor: "pointer",
+                  borderLeft: active ? "1px solid #c9a96155" : "none",
+                }}
+              >
+                {s.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// trophy card (mini contract)
+// ============================================================
+function TrophyCard({ item }) {
+  const { goal, rarity, achievedAt, no, totalDays, keptPct } = item;
+  const r = RARITY[rarity];
+  return (
+    <button
+      style={{
+        background: "#f4e8d0",
+        border: "0.5px solid #d4c8b0",
+        outline: "1px solid #c9a96177",
+        outlineOffset: "-4px",
+        padding: "30px 12px 14px",
+        position: "relative",
+        cursor: "pointer",
+        textAlign: "center",
+        boxShadow: "0 6px 16px -10px rgba(44,24,16,0.35), 0 1px 2px rgba(44,24,16,0.05)",
+        fontFamily: "'Noto Sans JP', sans-serif",
+        color: "#2c1810",
+        overflow: "visible",
+      }}
+      aria-label={`${goal}（${r.label}）の達成記録`}
+    >
+      {/* No. */}
+      <span
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 10,
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 9,
+          letterSpacing: "0.25em",
+          color: "#8b6f47",
+          fontWeight: 600,
+          paddingLeft: "0.25em",
+        }}
+      >
+        No. {no}
+      </span>
+
+      {/* tiny seal corner */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 8,
+          right: 10,
+          fontSize: 9,
+          color: "#8b1a1a",
+          letterSpacing: "0.2em",
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+        }}
+      >
+        ✓
+      </span>
+
+      {/* crest */}
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 10 }}>
+        <HeraldicCrest rarity={rarity} size={84} />
+      </div>
+
+      {/* divider */}
+      <div style={{ width: 60, height: 1, background: `linear-gradient(to right, transparent, ${r.primary}55, transparent)`, margin: "0 auto 8px" }} />
+
+      {/* goal */}
+      <p
+        style={{
+          margin: "0 0 8px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 600,
+          lineHeight: 1.45,
+          color: "#2c1810",
+          letterSpacing: "0.02em",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          minHeight: 36,
+        }}
+      >
+        {goal}
+      </p>
+
+      {/* rarity pill */}
+      <div
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          padding: "3px 8px",
+          background: r.badgeBg,
+          border: `1px solid ${r.primary}33`,
+          borderRadius: 999,
+          marginBottom: 6,
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 5,
+            height: 5,
+            borderRadius: "50%",
+            background: r.primary,
+          }}
+        />
+        <span style={{ fontSize: 9, letterSpacing: "0.2em", color: r.badgeText, fontFamily: "'Noto Serif JP', serif", fontWeight: 600 }}>
+          {r.label}
+        </span>
+      </div>
+
+      {/* date + pct */}
+      <div style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.08em", display: "flex", justifyContent: "center", gap: 10 }}>
+        <span>{achievedAt}</span>
+        <span aria-hidden="true">·</span>
+        <span>
+          <ruby>達成率<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>たっせいりつ</rt></ruby> {keptPct}%
+        </span>
+      </div>
+    </button>
+  );
+}
+
+// ============================================================
+// abandoned card (grayscale)
+// ============================================================
+function AbandonedCard({ item }) {
+  const { goal, no, abandonedAt } = item;
+  return (
+    <article
+      style={{
+        background: "rgba(244, 232, 208, 0.45)",
+        border: "0.5px dashed #b3a890",
+        padding: "30px 12px 14px",
+        position: "relative",
+        textAlign: "center",
+        fontFamily: "'Noto Sans JP', sans-serif",
+        color: "#7a7060",
+        filter: "grayscale(0.85)",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 10,
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 9,
+          letterSpacing: "0.25em",
+          color: "#8b6f47",
+          fontWeight: 600,
+        }}
+      >
+        No. {no}
+      </span>
+      <span
+        style={{
+          position: "absolute",
+          top: 8,
+          right: 10,
+          fontSize: 8,
+          letterSpacing: "0.3em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+        }}
+      >
+        ABANDONED
+      </span>
+
+      {/* placeholder where crest would be — empty silhouette */}
+      <div
+        style={{
+          width: 84,
+          height: 84,
+          margin: "0 auto 10px",
+          borderRadius: "50%",
+          border: "1.5px dashed #a89c84",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#a89c84",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 11,
+          letterSpacing: "0.15em",
+          background: "rgba(255,255,255,0.4)",
+        }}
+        aria-hidden="true"
+      >
+        破棄
+      </div>
+
+      <div style={{ width: 60, height: 1, background: "rgba(168, 156, 132, 0.4)", margin: "0 auto 8px" }} />
+
+      <p
+        style={{
+          margin: "0 0 8px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 500,
+          lineHeight: 1.45,
+          color: "#7a7060",
+          letterSpacing: "0.02em",
+          textDecoration: "line-through",
+          textDecorationColor: "#a89c84",
+          textDecorationThickness: 1,
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          minHeight: 36,
+        }}
+      >
+        {goal}
+      </p>
+
+      <div style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.08em", marginBottom: 8 }}>
+        {abandonedAt} 破棄
+      </div>
+
+      <button
+        style={{
+          padding: "5px 12px",
+          background: "transparent",
+          border: "1px solid #8b6f47",
+          color: "#8b6f47",
+          fontSize: 11,
+          fontFamily: "'Noto Serif JP', serif",
+          letterSpacing: "0.08em",
+          cursor: "pointer",
+          borderRadius: 2,
+        }}
+      >
+        再挑戦する
+      </button>
+    </article>
+  );
+}
+
+// ============================================================
+// active card (in progress)
+// ============================================================
+function ActiveCard({ item }) {
+  const { goal, no, daysLeft, rarity } = item;
+  const r = RARITY[rarity];
+  return (
+    <article
+      style={{
+        background: "#ffffff",
+        border: `0.5px solid ${r.primary}55`,
+        padding: "30px 12px 14px",
+        position: "relative",
+        textAlign: "center",
+        fontFamily: "'Noto Sans JP', sans-serif",
+        color: "#2c1810",
+        boxShadow: "0 4px 12px -8px rgba(44,24,16,0.2)",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 10,
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 9,
+          letterSpacing: "0.25em",
+          color: "#8b6f47",
+          fontWeight: 600,
+        }}
+      >
+        No. {no}
+      </span>
+      <span
+        style={{
+          position: "absolute",
+          top: 8,
+          right: 10,
+          fontSize: 8,
+          letterSpacing: "0.3em",
+          color: "#8b1a1a",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 700,
+        }}
+      >
+        ACTIVE
+      </span>
+
+      {/* faint outlined crest preview */}
+      <div style={{ display: "flex", justifyContent: "center", marginBottom: 10, opacity: 0.35 }}>
+        <HeraldicCrest rarity={rarity} size={84} />
+      </div>
+
+      <div style={{ width: 60, height: 1, background: `linear-gradient(to right, transparent, ${r.primary}66, transparent)`, margin: "0 auto 8px" }} />
+
+      <p
+        style={{
+          margin: "0 0 8px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 600,
+          lineHeight: 1.45,
+          letterSpacing: "0.02em",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          minHeight: 36,
+        }}
+      >
+        {goal}
+      </p>
+
+      <div style={{ fontSize: 11, fontFamily: "'Noto Serif JP', serif", color: "#2c1810", letterSpacing: "0.05em" }}>
+        期日まで <span style={{ fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", color: "#8b1a1a", fontWeight: 700, fontSize: 16 }}>{daysLeft}</span>日
+      </div>
+    </article>
+  );
+}
+
+// ============================================================
+// nav
+// ============================================================
+function NavItem8({ icon, label, active }) {
+  return (
+    <button
+      style={{
+        background: "transparent",
+        border: "none",
+        padding: "12px 8px 14px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 4,
+        cursor: "pointer",
+        color: active ? "#2c1810" : "#6b6b6b",
+        position: "relative",
+        fontFamily: "'Noto Sans JP', sans-serif",
+      }}
+      aria-current={active ? "page" : undefined}
+    >
+      {active && (
+        <span aria-hidden="true" style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", width: 28, height: 2, background: "#8b1a1a" }} />
+      )}
+      <span style={{ opacity: active ? 1 : 0.65 }}>
+        {React.cloneElement(icon, { color: active ? "#2c1810" : "#6b6b6b" })}
+      </span>
+      <span style={{ fontSize: 11, letterSpacing: "0.15em" }}>{label}</span>
+    </button>
+  );
+}
+
+// ============================================================
+// data
+// ============================================================
+const HALL_DATA = [
+  { id: 1, no: "001", goal: "TOEIC 800点を達成する", rarity: "epic", achievedAt: "2026.04", totalDays: 90, keptPct: 94, status: "fulfilled", scoreOrder: 4 },
+  { id: 2, no: "002", goal: "毎日読書1冊を続ける", rarity: "rare", achievedAt: "2026.03", totalDays: 30, keptPct: 87, status: "fulfilled", scoreOrder: 2 },
+  { id: 3, no: "003", goal: "朝5時起床の習慣を作る", rarity: "common", achievedAt: "2026.02", totalDays: 21, keptPct: 81, status: "fulfilled", scoreOrder: 1 },
+  { id: 4, no: "004", goal: "副業で月10万円を達成", rarity: "legendary", achievedAt: "2026.01", totalDays: 180, keptPct: 96, status: "fulfilled", scoreOrder: 5 },
+  { id: 5, no: "005", goal: "体重を5kg減らす", rarity: "rare", achievedAt: "2025.12", totalDays: 60, keptPct: 89, status: "fulfilled", scoreOrder: 3 },
+];
+const ACTIVE_DATA = [
+  { id: 6, no: "006", goal: "毎日30分のランニング", rarity: "rare", daysLeft: 73, status: "active" },
+  { id: 7, no: "007", goal: "週3回の自炊を続ける", rarity: "common", daysLeft: 45, status: "active" },
+];
+const ABANDONED_DATA = [
+  { id: 8, no: "008", goal: "毎朝瞑想を10分行う", abandonedAt: "2026.03", status: "abandoned" },
+  { id: 9, no: "009", goal: "禁酒を1ヶ月続ける", abandonedAt: "2026.02", status: "abandoned" },
+];
+
+// ============================================================
+// screen
+// ============================================================
+
+function HallScreen({ width = 412, initialFilter = "all", initialSort = "recent", initialMode = "default" }) {
+  const [filter, setFilter] = useHallState(initialFilter);
+  const [sort, setSort] = useHallState(initialSort);
+
+  const isEmpty = initialMode === "empty";
+
+  const allItems = [...HALL_DATA, ...ACTIVE_DATA, ...ABANDONED_DATA];
+  let visible = allItems;
+  if (filter === "fulfilled") visible = HALL_DATA;
+  else if (filter === "active") visible = ACTIVE_DATA;
+  else if (filter === "abandoned") visible = ABANDONED_DATA;
+
+  if (sort === "rarity") {
+    visible = [...visible].sort((a, b) => (b.scoreOrder || 0) - (a.scoreOrder || 0));
+  }
+
+  const achievedCount = HALL_DATA.length + 7; // total 12 (5 shown + 7 older)
+  const score = 850;
+  const streak = 7;
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1200,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      {/* top bar — settings only on right */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 20px 0",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 12,
+            letterSpacing: "0.55em",
+            color: "#8b6f47",
+            paddingLeft: "0.55em",
+          }}
+        >
+          VOW PACT
+        </div>
+        <button aria-label="設定" style={{ background: "transparent", border: "none", padding: 6, cursor: "pointer", display: "inline-flex" }}>
+          <GearIcon8 size={20} color="#8b6f47" />
+        </button>
+      </div>
+
+      <HallHeader />
+
+      {!isEmpty && <StatsBlock achievedCount={achievedCount} scoreTotal={score} streak={streak} />}
+
+      {isEmpty ? (
+        <HallEmpty />
+      ) : (
+        <>
+          <FilterBar filter={filter} sort={sort} onFilter={setFilter} onSort={setSort} />
+
+          <main style={{ flex: 1, padding: "8px 20px 24px" }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 12,
+              }}
+            >
+              {visible.map((item) =>
+                item.status === "fulfilled" ? (
+                  <TrophyCard key={item.id} item={item} />
+                ) : item.status === "abandoned" ? (
+                  <AbandonedCard key={item.id} item={item} />
+                ) : (
+                  <ActiveCard key={item.id} item={item} />
+                )
+              )}
+            </div>
+
+            {visible.length === 0 && (
+              <div style={{ padding: "60px 20px", textAlign: "center", color: "#8b6f47", fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontStyle: "italic" }}>
+                該当する契約はありません。
+              </div>
+            )}
+          </main>
+        </>
+      )}
+
+      {/* bottom nav */}
+      <nav
+        aria-label="メインナビゲーション"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          borderTop: "1px solid #d4c8b0",
+          background: "rgba(251,246,236,0.85)",
+        }}
+      >
+        <NavItem8 icon={<HomeIcon8 />} label="ホーム" />
+        <NavItem8 icon={<ShieldIcon8 size={22} />} label="殿堂" active />
+        <NavItem8 icon={<RankIcon8 size={22} />} label="ランキング" />
+      </nav>
+    </div>
+  );
+}
+
+function HallEmpty() {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 28px", textAlign: "center" }}>
+      <div style={{ marginBottom: 18, opacity: 0.4 }}>
+        <HeraldicCrest rarity="common" size={120} />
+      </div>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 22,
+          fontWeight: 600,
+          letterSpacing: "0.1em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+        }}
+      >
+        殿堂はまだ静かだ
+      </h2>
+      <p
+        style={{
+          margin: "10px 0 24px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 13,
+          color: "#6b6b6b",
+          lineHeight: 1.7,
+          letterSpacing: "0.04em",
+          maxWidth: 260,
+        }}
+      >
+        最初の試練を乗り越えたとき、
+        <br />
+        ここにあなたの紋章が刻まれる。
+      </p>
+      <button
+        style={{
+          padding: "12px 24px",
+          background: "#2c1810",
+          color: "#fbf6ec",
+          border: "1px solid #2c1810",
+          borderRadius: 4,
+          fontSize: 13,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          cursor: "pointer",
+          boxShadow: "0 6px 14px -8px rgba(44,24,16,0.6)",
+        }}
+      >
+        契約を結ぶ
+      </button>
+    </div>
+  );
+}
+
+Object.assign(window, { HallScreen });

--- a/docs/VowPact_mock/screens/home.jsx
+++ b/docs/VowPact_mock/screens/home.jsx
@@ -1,0 +1,574 @@
+/* global React, Seal */
+
+const { useState: useHomeState } = React;
+
+// ===== rtStyle (local) =====
+const _rt = { fontSize: "0.45em", letterSpacing: "0.05em", color: "#8b6f47", fontWeight: 400 };
+
+// ===== icons =====
+const GearIcon = ({ size = 20, color = "#2c1810" }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M12 15.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z" stroke={color} strokeWidth="1.4" />
+    <path d="M19.4 13.6a7.6 7.6 0 000-3.2l1.9-1.5-2-3.4-2.3.8a7.7 7.7 0 00-2.7-1.6L13.7 2h-3.4l-.6 2.7a7.7 7.7 0 00-2.7 1.6l-2.3-.8-2 3.4 1.9 1.5a7.6 7.6 0 000 3.2l-1.9 1.5 2 3.4 2.3-.8a7.7 7.7 0 002.7 1.6l.6 2.7h3.4l.6-2.7a7.7 7.7 0 002.7-1.6l2.3.8 2-3.4-1.9-1.5z" stroke={color} strokeWidth="1.2" strokeLinejoin="round" />
+  </svg>
+);
+const ShieldIcon = ({ size = 22, color = "#2c1810" }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M12 2.5l8 3v6.5c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5V5.5l8-3z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+    <path d="M12 8v6M9 11h6" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+);
+const RankIcon = ({ size = 22, color = "#2c1810" }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M5 19l9-9M19 19l-9-9M14 4l6 6M10 4L4 10" stroke={color} strokeWidth="1.4" strokeLinecap="round" />
+    <circle cx="14" cy="4" r="1" fill={color} />
+    <circle cx="10" cy="4" r="1" fill={color} />
+  </svg>
+);
+const HomeIcon = ({ size = 22, color = "#2c1810" }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M3 11.5L12 4l9 7.5V20a1 1 0 01-1 1h-5v-6h-6v6H4a1 1 0 01-1-1v-8.5z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+  </svg>
+);
+const FlameIcon = ({ size = 14, color = "#c9a961" }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M12 22c-4.5 0-7-3-7-7 0-3 2-5.5 3-7 0 1.5 1 2.5 2 2.5 0-3 1.5-6 5-8.5-1 4 4 6 4 11 0 5-2.5 9-7 9z" fill={color} stroke="#8b6f47" strokeWidth="0.8" strokeLinejoin="round" />
+  </svg>
+);
+const PlusIcon = ({ size = 16, color = "#2c1810" }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M8 3v10M3 8h10" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+// ===== stars =====
+function Stars({ value = 4, max = 5 }) {
+  return (
+    <span aria-label={`難易度 ${value}/${max}`} style={{ color: "#8b1a1a", letterSpacing: "0.1em", fontSize: 12 }}>
+      {"★".repeat(value)}<span style={{ color: "#d4b8b8" }}>{"★".repeat(max - value)}</span>
+    </span>
+  );
+}
+
+// ===== contract card =====
+function ContractCard({ contract, onCheckin }) {
+  const { no, goal, trial, difficulty, daysLeft, checkin } = contract;
+  const done = checkin !== null;
+
+  return (
+    <article
+      style={{
+        background: "#ffffff",
+        border: "1px solid #d4c8b0",
+        boxShadow: "0 8px 22px -16px rgba(44,24,16,0.35), 0 1px 2px rgba(44,24,16,0.04)",
+        overflow: "hidden",
+      }}
+    >
+      {/* Top bar — meta */}
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "10px 14px",
+          borderBottom: "1px solid #ead9b8",
+          background: "linear-gradient(180deg, rgba(201,169,97,0.08) 0%, rgba(201,169,97,0.02) 100%)",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontSize: 11,
+            letterSpacing: "0.3em",
+            color: "#8b6f47",
+            fontWeight: 600,
+            paddingLeft: "0.3em",
+          }}
+        >
+          No. {no}
+        </span>
+        <Stars value={difficulty} />
+      </header>
+
+      {/* parchment preview */}
+      <button
+        onClick={() => {}}
+        aria-label={`契約 No.${no} の詳細を見る`}
+        style={{
+          width: "100%",
+          textAlign: "left",
+          background: "#f4e8d0",
+          border: "none",
+          borderBottom: "1px solid #ead9b8",
+          padding: "16px 16px 14px",
+          cursor: "pointer",
+          position: "relative",
+          fontFamily: "'Noto Serif JP', serif",
+          color: "#2c1810",
+          display: "flex",
+          gap: 14,
+          alignItems: "stretch",
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* days remaining */}
+          <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginBottom: 8 }}>
+            <span style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.1em" }}>期日まで</span>
+            <span
+              style={{
+                fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+                fontSize: 28,
+                fontWeight: 600,
+                color: "#8b1a1a",
+                lineHeight: 1,
+              }}
+            >
+              {daysLeft}
+            </span>
+            <span style={{ fontSize: 13, color: "#2c1810", letterSpacing: "0.05em" }}>日</span>
+          </div>
+
+          {/* goal */}
+          <div style={{ marginBottom: 8 }}>
+            <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, marginBottom: 3, paddingLeft: "0.4em" }}>
+              【目標】
+            </div>
+            <p
+              style={{
+                margin: 0,
+                fontFamily: "'Noto Serif JP', serif",
+                fontSize: 15,
+                fontWeight: 600,
+                lineHeight: 1.5,
+                color: "#2c1810",
+                borderLeft: "2px solid #8b1a1a",
+                paddingLeft: 10,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {goal}
+            </p>
+          </div>
+
+          {/* trial */}
+          <div>
+            <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, marginBottom: 3, paddingLeft: "0.4em" }}>
+              【試練】
+            </div>
+            <p
+              style={{
+                margin: 0,
+                fontFamily: "'Noto Serif JP', serif",
+                fontSize: 13,
+                lineHeight: 1.55,
+                color: "#6b6b6b",
+                borderLeft: "2px solid rgba(139,26,26,0.4)",
+                paddingLeft: 10,
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {trial}
+            </p>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "flex-end", paddingBottom: 2 }}>
+          <span aria-hidden="true" style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.1em", fontFamily: "'Noto Serif JP', serif" }}>詳細 ›</span>
+          <Seal size={56} rotate={-8} />
+        </div>
+      </button>
+
+      {/* check-in section */}
+      <div style={{ padding: "12px 14px 14px", background: "#ffffff" }}>
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.2em",
+            color: done ? "#8b6f47" : "#2c1810",
+            fontWeight: 600,
+            fontFamily: "'Noto Sans JP', sans-serif",
+            marginBottom: 8,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span>今日のチェックイン</span>
+          {done && (
+            <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.15em" }}>
+              {checkin === "kept" ? "✓ 守れた" : checkin === "failed" ? "× 守れなかった" : "— スキップ"}
+            </span>
+          )}
+        </div>
+
+        {done ? (
+          <div
+            style={{
+              padding: "10px 12px",
+              border: "1px dashed #d4c8b0",
+              background: "rgba(201,169,97,0.05)",
+              fontSize: 12,
+              color: "#8b6f47",
+              letterSpacing: "0.05em",
+              fontFamily: "'Noto Sans JP', sans-serif",
+              textAlign: "center",
+            }}
+          >
+            今日の記録は完了しています
+          </div>
+        ) : (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 8 }}>
+              <button
+                onClick={() => onCheckin("kept")}
+                style={{
+                  height: 44,
+                  background: "#8b1a1a",
+                  color: "#fbf6ec",
+                  border: "1px solid #6b1414",
+                  borderRadius: 4,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  letterSpacing: "0.1em",
+                  cursor: "pointer",
+                  fontFamily: "'Noto Sans JP', sans-serif",
+                  boxShadow: "0 4px 10px -6px rgba(139,26,26,0.6)",
+                }}
+              >
+                守れた
+              </button>
+              <button
+                onClick={() => onCheckin("failed")}
+                style={{
+                  height: 44,
+                  background: "#ffffff",
+                  color: "#2c1810",
+                  border: "1px solid #d4c8b0",
+                  borderRadius: 4,
+                  fontSize: 12,
+                  letterSpacing: "0.08em",
+                  cursor: "pointer",
+                  fontFamily: "'Noto Sans JP', sans-serif",
+                }}
+              >
+                守れなかった
+              </button>
+            </div>
+            <button
+              onClick={() => onCheckin("skipped")}
+              style={{
+                marginTop: 6,
+                width: "100%",
+                height: 32,
+                background: "transparent",
+                border: "none",
+                color: "#8b6f47",
+                fontSize: 12,
+                cursor: "pointer",
+                letterSpacing: "0.1em",
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+                textDecorationColor: "#d4c8b0",
+                fontFamily: "'Noto Sans JP', sans-serif",
+              }}
+            >
+              スキップ
+            </button>
+          </>
+        )}
+      </div>
+    </article>
+  );
+}
+
+// ===== new contract button =====
+function NewContractButton({ disabled }) {
+  return (
+    <button
+      disabled={disabled}
+      style={{
+        width: "100%",
+        background: disabled ? "rgba(244,232,208,0.4)" : "#fbf6ec",
+        border: `2px dashed ${disabled ? "#d4c8b099" : "#c9a961"}`,
+        padding: "20px 16px",
+        cursor: disabled ? "not-allowed" : "pointer",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 6,
+        color: disabled ? "#bdab8e" : "#2c1810",
+        fontFamily: "'Noto Sans JP', sans-serif",
+      }}
+    >
+      <div style={{ display: "inline-flex", alignItems: "center", gap: 8, fontSize: 15, fontWeight: 600, letterSpacing: "0.08em", fontFamily: "'Noto Serif JP', serif" }}>
+        <PlusIcon color={disabled ? "#bdab8e" : "#2c1810"} />
+        <ruby>新規契約<rt style={_rt}>しんきけいやく</rt></ruby>を<ruby>結<rt style={_rt}>むす</rt></ruby>ぶ
+      </div>
+      {disabled && (
+        <span style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.1em" }}>
+          契約は最大3つまで
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ===== status bar =====
+function StatusBar({ streak, active, max }) {
+  return (
+    <div
+      style={{
+        margin: "0 20px",
+        padding: "12px 14px",
+        background: "linear-gradient(180deg, rgba(201,169,97,0.10) 0%, rgba(201,169,97,0.02) 100%)",
+        border: "1px solid #c9a96155",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <FlameIcon size={18} />
+        <div>
+          <div style={{ fontSize: 9, letterSpacing: "0.35em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.35em" }}>
+            STREAK
+          </div>
+          <div style={{ fontSize: 13, fontFamily: "'Noto Serif JP', serif", color: "#2c1810", letterSpacing: "0.04em" }}>
+            <span style={{ color: "#8b1a1a", fontWeight: 600, fontSize: 16 }}>{streak}</span>日連続でチェックイン中
+          </div>
+        </div>
+      </div>
+      <div style={{ textAlign: "right" }}>
+        <div style={{ fontSize: 9, letterSpacing: "0.35em", color: "#8b6f47", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600, paddingLeft: "0.35em" }}>
+          PACTS
+        </div>
+        <div style={{ fontSize: 13, fontFamily: "'Noto Serif JP', serif", color: "#2c1810" }}>
+          契約 <span style={{ color: "#2c1810", fontWeight: 600, fontSize: 16 }}>{active}</span>
+          <span style={{ color: "#8b6f47" }}>/{max}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ===== nav =====
+function NavItem({ icon, label, active }) {
+  return (
+    <button
+      style={{
+        background: "transparent",
+        border: "none",
+        padding: "12px 8px 14px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 4,
+        cursor: "pointer",
+        color: active ? "#2c1810" : "#6b6b6b",
+        position: "relative",
+        fontFamily: "'Noto Sans JP', sans-serif",
+      }}
+      aria-current={active ? "page" : undefined}
+    >
+      {active && (
+        <span aria-hidden="true" style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", width: 28, height: 2, background: "#8b1a1a" }} />
+      )}
+      <span style={{ opacity: active ? 1 : 0.65 }}>
+        {React.cloneElement(icon, { color: active ? "#2c1810" : "#6b6b6b" })}
+      </span>
+      <span style={{ fontSize: 11, letterSpacing: "0.15em" }}>{label}</span>
+    </button>
+  );
+}
+
+// ===== main screen =====
+
+const SAMPLE = [
+  {
+    no: "001",
+    goal: "TOEIC 800点を達成する",
+    trial: <>達成までSNSを1日30分以内に<ruby>制限<rt style={_rt}>せいげん</rt></ruby>する</>,
+    difficulty: 4,
+    daysLeft: 73,
+    checkin: null,
+  },
+  {
+    no: "002",
+    goal: "体重を5kg減らす",
+    trial: <>平日は<ruby>飲酒<rt style={_rt}>いんしゅ</rt></ruby>を<ruby>断<rt style={_rt}>た</rt></ruby>つ</>,
+    difficulty: 3,
+    daysLeft: 45,
+    checkin: "kept",
+  },
+];
+
+const SAMPLE_THREE = [
+  ...SAMPLE,
+  {
+    no: "003",
+    goal: "毎朝5時に起きて読書する",
+    trial: <>22時以降は<ruby>画面<rt style={_rt}>がめん</rt></ruby>を見ない</>,
+    difficulty: 5,
+    daysLeft: 12,
+    checkin: null,
+  },
+];
+
+function HomeScreen({ width = 412, variant = "default" }) {
+  // variant: 'default' (2/3), 'full' (3/3), 'empty' (0/3)
+  const [contracts, setContracts] = useHomeState(
+    variant === "full" ? SAMPLE_THREE : variant === "empty" ? [] : SAMPLE
+  );
+
+  const handleCheckin = (idx, value) => {
+    setContracts((prev) => prev.map((c, i) => (i === idx ? { ...c, checkin: value } : c)));
+  };
+
+  const isEmpty = contracts.length === 0;
+  const isFull = contracts.length >= 3;
+  const streak = isEmpty ? 0 : 7;
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 900,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* header */}
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "16px 20px",
+          borderBottom: "1px solid rgba(201,169,97,0.35)",
+          background: "rgba(251,246,236,0.6)",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 13,
+            letterSpacing: "0.55em",
+            color: "#2c1810",
+            paddingLeft: "0.55em",
+          }}
+        >
+          VOW PACT
+        </div>
+        <button aria-label="設定" style={{ background: "transparent", border: "none", padding: 6, cursor: "pointer", display: "inline-flex" }}>
+          <GearIcon size={20} />
+        </button>
+      </header>
+
+      <main style={{ flex: 1, padding: "16px 0 24px", display: "flex", flexDirection: "column", gap: 16 }}>
+        {!isEmpty && <StatusBar streak={streak} active={contracts.length} max={3} />}
+
+        {isEmpty ? (
+          <EmptyState />
+        ) : (
+          <div style={{ padding: "0 20px", display: "flex", flexDirection: "column", gap: 14 }}>
+            {contracts.map((c, i) => (
+              <ContractCard key={c.no} contract={c} onCheckin={(v) => handleCheckin(i, v)} />
+            ))}
+            <NewContractButton disabled={isFull} />
+          </div>
+        )}
+      </main>
+
+      {/* nav */}
+      <nav
+        aria-label="メインナビゲーション"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          borderTop: "1px solid #d4c8b0",
+          background: "rgba(251,246,236,0.85)",
+        }}
+      >
+        <NavItem icon={<HomeIcon />} label="ホーム" active />
+        <NavItem icon={<ShieldIcon size={22} />} label="殿堂" />
+        <NavItem icon={<RankIcon size={22} />} label="ランキング" />
+      </nav>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "40px 28px", textAlign: "center" }}>
+      <div style={{ marginBottom: 18 }}>
+        <Seal size={104} rotate={-8} />
+      </div>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 22,
+          fontWeight: 600,
+          letterSpacing: "0.1em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+        }}
+      >
+        まだ<ruby>誓<rt style={_rt}>ちか</rt></ruby>いはない
+      </h2>
+      <p
+        style={{
+          margin: "10px 0 28px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 14,
+          color: "#6b6b6b",
+          lineHeight: 1.7,
+          letterSpacing: "0.04em",
+          maxWidth: 280,
+        }}
+      >
+        最初の<ruby>契約書<rt style={_rt}>けいやくしょ</rt></ruby>を結び、自分との<ruby>約束<rt style={_rt}>やくそく</rt></ruby>を刻もう。
+      </p>
+      <button
+        style={{
+          width: "100%",
+          maxWidth: 320,
+          height: 52,
+          background: "#2c1810",
+          color: "#fbf6ec",
+          border: "1px solid #2c1810",
+          borderRadius: 4,
+          fontSize: 15,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          letterSpacing: "0.16em",
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 10,
+          boxShadow: "0 6px 14px -8px rgba(44,24,16,0.6)",
+        }}
+      >
+        <PlusIcon color="#fbf6ec" />
+        <ruby>最初<rt style={{ ..._rt, color: "#c9a961" }}>さいしょ</rt></ruby>の<ruby>契約<rt style={{ ..._rt, color: "#c9a961" }}>けいやく</rt></ruby>を<ruby>結<rt style={{ ..._rt, color: "#c9a961" }}>むす</rt></ruby>ぶ
+      </button>
+      <div style={{ marginTop: 14, fontSize: 11, color: "#8b6f47", letterSpacing: "0.15em" }}>
+        契約は最大3つまで保持できます
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { HomeScreen });

--- a/docs/VowPact_mock/screens/rank.jsx
+++ b/docs/VowPact_mock/screens/rank.jsx
@@ -1,0 +1,879 @@
+/* global React, HeraldicCrest, RARITY */
+
+const { useState: useRankState } = React;
+
+// ============================================================
+// icons (reuse-pattern)
+// ============================================================
+function GearIconR({ size = 20, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 15.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z" stroke={color} strokeWidth="1.4" />
+      <path d="M19.4 13.6a7.6 7.6 0 000-3.2l1.9-1.5-2-3.4-2.3.8a7.7 7.7 0 00-2.7-1.6L13.7 2h-3.4l-.6 2.7a7.7 7.7 0 00-2.7 1.6l-2.3-.8-2 3.4 1.9 1.5a7.6 7.6 0 000 3.2l-1.9 1.5 2 3.4 2.3-.8a7.7 7.7 0 002.7 1.6l.6 2.7h3.4l.6-2.7a7.7 7.7 0 002.7-1.6l2.3.8 2-3.4-1.9-1.5z" stroke={color} strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function HomeIconR({ size = 22, color = "#6b6b6b" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M3 11.5L12 4l9 7.5V20a1 1 0 01-1 1h-5v-6h-6v6H4a1 1 0 01-1-1v-8.5z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ShieldIconR({ size = 22, color = "#6b6b6b" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 2.5l8 3v6.5c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5V5.5l8-3z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M12 8v6M9 11h6" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+function RankIconR({ size = 22, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M5 19l9-9M19 19l-9-9M14 4l6 6M10 4L4 10" stroke={color} strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="14" cy="4" r="1" fill={color} />
+      <circle cx="10" cy="4" r="1" fill={color} />
+    </svg>
+  );
+}
+function LockIconR({ size = 12, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="5" y="11" width="14" height="9" rx="1.5" stroke={color} strokeWidth="1.6" />
+      <path d="M8 11V8a4 4 0 118 0v3" stroke={color} strokeWidth="1.6" />
+    </svg>
+  );
+}
+function ArrowUpIconR({ size = 10, color = "#2f7d3a" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M7 11V3M3 7l4-4 4 4" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ArrowDownIconR({ size = 10, color = "#a8651e" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M7 3v8M3 7l4 4 4-4" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ============================================================
+// header
+// ============================================================
+function RankHeader({ period, onPeriod }) {
+  return (
+    <header
+      style={{
+        textAlign: "center",
+        padding: "26px 20px 0",
+        background: "linear-gradient(180deg, rgba(201,169,97,0.10) 0%, transparent 100%)",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 10,
+          letterSpacing: "0.6em",
+          color: "#a77b1f",
+          fontWeight: 600,
+          paddingLeft: "0.6em",
+          marginBottom: 10,
+        }}
+      >
+        ── LEADERBOARD ──
+      </div>
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: 32,
+          letterSpacing: "0.16em",
+          color: "#2c1810",
+          paddingLeft: "0.16em",
+          lineHeight: 1.2,
+        }}
+      >
+        ランキング
+      </h1>
+      <div style={{ margin: "12px auto 14px", width: 110, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+
+      {/* period tabs */}
+      <div style={{ display: "inline-flex", borderBottom: "1px solid #d4c8b0" }}>
+        {[{ id: "month", label: "今月" }, { id: "all", label: "累計" }].map((p) => {
+          const active = period === p.id;
+          return (
+            <button
+              key={p.id}
+              onClick={() => onPeriod(p.id)}
+              style={{
+                padding: "10px 28px 12px",
+                background: "transparent",
+                border: "none",
+                borderBottom: active ? "2px solid #8b1a1a" : "2px solid transparent",
+                color: active ? "#2c1810" : "#8b6f47",
+                fontFamily: "'Noto Serif JP', serif",
+                fontSize: 13,
+                fontWeight: active ? 700 : 500,
+                letterSpacing: "0.12em",
+                cursor: "pointer",
+                marginBottom: -1,
+              }}
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </header>
+  );
+}
+
+// ============================================================
+// type segment
+// ============================================================
+function TypeSegment({ type, onType }) {
+  return (
+    <div style={{ padding: "16px 20px 12px" }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          background: "rgba(255,255,255,0.6)",
+          border: "1px solid #d4c8b0",
+          borderRadius: 4,
+          padding: 3,
+        }}
+      >
+        {[
+          { id: "achievements", label: "達成数", en: "ACHIEVEMENTS" },
+          { id: "score", label: "レアリティスコア", en: "RARITY SCORE" },
+        ].map((t) => {
+          const active = type === t.id;
+          return (
+            <button
+              key={t.id}
+              onClick={() => onType(t.id)}
+              style={{
+                padding: "9px 8px 10px",
+                background: active ? "#2c1810" : "transparent",
+                border: "none",
+                borderRadius: 3,
+                color: active ? "#fbf6ec" : "#8b6f47",
+                fontFamily: "'Noto Serif JP', serif",
+                fontWeight: active ? 600 : 500,
+                fontSize: 12,
+                letterSpacing: "0.08em",
+                cursor: "pointer",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 2,
+              }}
+            >
+              <span>{t.label}</span>
+              <span style={{ fontSize: 8, letterSpacing: "0.3em", opacity: 0.7, fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600 }}>
+                {t.en}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// podium (top 3)
+// ============================================================
+
+const MEDAL = {
+  1: { primary: "#c9a961", dark: "#8b6f1f", light: "#fff8de", glow: "rgba(201,169,97,0.45)", label: "GOLD" },
+  2: { primary: "#a8a8a8", dark: "#6b6b6b", light: "#f4f4f4", glow: "rgba(168,168,168,0.4)", label: "SILVER" },
+  3: { primary: "#c98a4b", dark: "#7e5a35", light: "#fbeede", glow: "rgba(201,138,75,0.4)", label: "BRONZE" },
+};
+
+function MedalNumeral({ rank, size = 56 }) {
+  const m = MEDAL[rank];
+  const numerals = { 1: "Ⅰ", 2: "Ⅱ", 3: "Ⅲ" };
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      aria-label={`${rank}位`}
+    >
+      {/* ribbons left/right */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: -2,
+          top: "50%",
+          width: 6,
+          height: size + 16,
+          background: `linear-gradient(180deg, ${m.primary}, ${m.dark})`,
+          clipPath: "polygon(0 0, 100% 0, 100% 100%, 50% 85%, 0 100%)",
+          transform: "translateY(-50%) rotate(-12deg)",
+          opacity: 0.85,
+        }}
+      />
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          right: -2,
+          top: "50%",
+          width: 6,
+          height: size + 16,
+          background: `linear-gradient(180deg, ${m.primary}, ${m.dark})`,
+          clipPath: "polygon(0 0, 100% 0, 100% 100%, 50% 85%, 0 100%)",
+          transform: "translateY(-50%) rotate(12deg)",
+          opacity: 0.85,
+        }}
+      />
+      {/* coin */}
+      <span
+        style={{
+          position: "relative",
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          background: `radial-gradient(circle at 35% 30%, ${m.light} 0%, ${m.primary} 55%, ${m.dark} 100%)`,
+          border: `1.5px solid ${m.dark}`,
+          boxShadow: `0 4px 14px -4px ${m.glow}, inset 0 1px 1px rgba(255,255,255,0.5), inset 0 -2px 3px rgba(0,0,0,0.18)`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 700,
+          fontSize: size * 0.5,
+          color: m.dark,
+          letterSpacing: "0.02em",
+          textShadow: "0 1px 0 rgba(255,255,255,0.4)",
+        }}
+      >
+        {numerals[rank]}
+      </span>
+    </div>
+  );
+}
+
+function PodiumRow({ entry, type }) {
+  const m = MEDAL[entry.rank];
+  const big = entry.rank === 1;
+  const value = type === "score" ? entry.score : entry.achievements;
+  const unit = type === "score" ? "pt" : "件";
+  return (
+    <article
+      style={{
+        position: "relative",
+        background: `linear-gradient(135deg, ${m.light} 0%, #fbf6ec 60%)`,
+        border: `1px solid ${m.primary}`,
+        outline: `1px solid ${m.primary}40`,
+        outlineOffset: -5,
+        padding: big ? "16px 16px 16px 14px" : "13px 14px 13px 12px",
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        boxShadow: big
+          ? `0 10px 24px -16px ${m.glow}, 0 2px 4px rgba(44,24,16,0.08)`
+          : `0 6px 16px -12px ${m.glow}, 0 1px 2px rgba(44,24,16,0.06)`,
+      }}
+    >
+      <MedalNumeral rank={entry.rank} size={big ? 60 : 48} />
+
+      {/* identity */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+          <span
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: big ? 18 : 16,
+              fontWeight: 700,
+              color: "#2c1810",
+              letterSpacing: "0.04em",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {entry.name}
+          </span>
+          {entry.isMe && <MeBadge />}
+        </div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+          <span
+            style={{
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontSize: big ? 30 : 26,
+              fontWeight: 700,
+              color: m.dark,
+              lineHeight: 1,
+            }}
+          >
+            {value}
+          </span>
+          <span style={{ fontSize: 11, color: "#8b6f47", letterSpacing: "0.06em" }}>{unit}</span>
+          {entry.delta !== undefined && <DeltaPill delta={entry.delta} />}
+        </div>
+      </div>
+
+      {/* recent crest */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: 4,
+          background: "rgba(255,255,255,0.6)",
+          border: `1px solid ${m.primary}55`,
+          borderRadius: 2,
+        }}
+        title={`直近: ${RARITY[entry.recent].label}`}
+      >
+        <HeraldicCrest rarity={entry.recent} size={big ? 56 : 48} />
+      </div>
+    </article>
+  );
+}
+
+function DeltaPill({ delta }) {
+  if (delta === 0) {
+    return (
+      <span style={{ marginLeft: 6, fontSize: 10, color: "#8b6f47", letterSpacing: "0.1em" }}>
+        ─
+      </span>
+    );
+  }
+  const up = delta > 0;
+  return (
+    <span
+      style={{
+        marginLeft: 6,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        fontSize: 10,
+        color: up ? "#2f7d3a" : "#a8651e",
+        fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+        fontWeight: 700,
+        letterSpacing: "0.04em",
+      }}
+    >
+      {up ? <ArrowUpIconR /> : <ArrowDownIconR />}
+      {Math.abs(delta)}
+    </span>
+  );
+}
+
+function MeBadge() {
+  return (
+    <span
+      style={{
+        fontSize: 9,
+        letterSpacing: "0.3em",
+        background: "#8b1a1a",
+        color: "#fbf6ec",
+        padding: "2px 6px 2px 8px",
+        borderRadius: 2,
+        fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+        fontWeight: 700,
+      }}
+    >
+      YOU
+    </span>
+  );
+}
+
+// ============================================================
+// regular row (4-10)
+// ============================================================
+function RankRow({ entry, type, highlight }) {
+  const value = type === "score" ? entry.score : entry.achievements;
+  const unit = type === "score" ? "pt" : "件";
+  const bg = highlight ? "rgba(139,26,26,0.06)" : "transparent";
+  const border = highlight ? "1px solid #8b1a1a" : "1px solid transparent";
+  return (
+    <article
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        padding: "12px 14px",
+        background: bg,
+        border,
+        borderLeft: highlight ? "3px solid #8b1a1a" : "3px solid transparent",
+        position: "relative",
+      }}
+    >
+      <span
+        style={{
+          width: 32,
+          textAlign: "center",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 22,
+          fontWeight: 600,
+          color: highlight ? "#8b1a1a" : "#8b6f47",
+          letterSpacing: "0.02em",
+          flexShrink: 0,
+        }}
+      >
+        {entry.rank}
+      </span>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+          <span
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 14,
+              fontWeight: highlight ? 700 : 500,
+              color: "#2c1810",
+              letterSpacing: "0.04em",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {entry.name}
+          </span>
+          {entry.isMe && <MeBadge />}
+        </div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+          <span
+            style={{
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontSize: 18,
+              fontWeight: 600,
+              color: "#2c1810",
+              lineHeight: 1,
+            }}
+          >
+            {value}
+          </span>
+          <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.06em" }}>{unit}</span>
+          {entry.delta !== undefined && <DeltaPill delta={entry.delta} />}
+        </div>
+      </div>
+
+      <div
+        style={{
+          flexShrink: 0,
+          padding: 3,
+          background: "rgba(255,255,255,0.6)",
+          border: "1px solid #d4c8b0",
+          borderRadius: 2,
+        }}
+        title={`直近: ${RARITY[entry.recent].label}`}
+      >
+        <HeraldicCrest rarity={entry.recent} size={36} />
+      </div>
+    </article>
+  );
+}
+
+function RowDivider() {
+  return <div style={{ height: 1, background: "linear-gradient(to right, transparent, rgba(212,200,176,0.7) 20%, rgba(212,200,176,0.7) 80%, transparent)" }} />;
+}
+
+// ============================================================
+// privacy section
+// ============================================================
+function PrivacySection({ visible, anonymous, onVisible, onAnonymous }) {
+  return (
+    <section
+      aria-label="公開設定"
+      style={{
+        margin: "24px 20px 16px",
+        padding: "14px 16px",
+        background: "rgba(255,255,255,0.55)",
+        border: "1px dashed #d4c8b0",
+        borderRadius: 2,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 10 }}>
+        <LockIconR />
+        <span
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.3em",
+            color: "#8b6f47",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.3em",
+          }}
+        >
+          PRIVACY · 公開設定
+        </span>
+      </div>
+
+      <ToggleRow
+        label="ランキングに自分を表示する"
+        sub="OFF にすると順位は計算されない"
+        checked={visible}
+        onChange={onVisible}
+      />
+      <div style={{ height: 1, background: "rgba(212,200,176,0.5)", margin: "12px 0" }} />
+      <ToggleRow
+        label="匿名で表示する"
+        sub="ニックネームの代わりに「匿名の挑戦者」と表示"
+        checked={anonymous}
+        disabled={!visible}
+        onChange={onAnonymous}
+      />
+    </section>
+  );
+}
+
+function ToggleRow({ label, sub, checked, disabled, onChange }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, opacity: disabled ? 0.45 : 1 }}>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 600, color: "#2c1810", letterSpacing: "0.04em" }}>{label}</div>
+        <div style={{ fontSize: 11, color: "#8b6f47", marginTop: 2, letterSpacing: "0.04em" }}>{sub}</div>
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => !disabled && onChange(!checked)}
+        style={{
+          width: 44,
+          height: 24,
+          borderRadius: 999,
+          background: checked ? "#2c1810" : "#d4c8b0",
+          border: `1px solid ${checked ? "#2c1810" : "#b3a890"}`,
+          position: "relative",
+          cursor: disabled ? "not-allowed" : "pointer",
+          padding: 0,
+          flexShrink: 0,
+          transition: "background 0.15s",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            top: 2,
+            left: checked ? 22 : 2,
+            width: 18,
+            height: 18,
+            borderRadius: "50%",
+            background: checked ? "#fbf6ec" : "#fff",
+            boxShadow: "0 1px 2px rgba(44,24,16,0.25)",
+            transition: "left 0.15s",
+          }}
+        />
+      </button>
+    </div>
+  );
+}
+
+// ============================================================
+// nav (re-defined to avoid scope leaks)
+// ============================================================
+function NavItemR({ icon, label, active }) {
+  return (
+    <button
+      style={{
+        background: "transparent",
+        border: "none",
+        padding: "12px 8px 14px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 4,
+        cursor: "pointer",
+        color: active ? "#2c1810" : "#6b6b6b",
+        position: "relative",
+        fontFamily: "'Noto Sans JP', sans-serif",
+      }}
+      aria-current={active ? "page" : undefined}
+    >
+      {active && (
+        <span aria-hidden="true" style={{ position: "absolute", top: 0, left: "50%", transform: "translateX(-50%)", width: 28, height: 2, background: "#8b1a1a" }} />
+      )}
+      <span style={{ opacity: active ? 1 : 0.65 }}>
+        {React.cloneElement(icon, { color: active ? "#2c1810" : "#6b6b6b" })}
+      </span>
+      <span style={{ fontSize: 11, letterSpacing: "0.15em" }}>{label}</span>
+    </button>
+  );
+}
+
+// ============================================================
+// data
+// ============================================================
+// 今月 / 達成数
+const MONTHLY_ACH = [
+  { rank: 1, name: "玄武", achievements: 12, score: 1240, recent: "legendary", delta: 2 },
+  { rank: 2, name: "朱雀", achievements: 10, score: 980, recent: "epic", delta: -1 },
+  { rank: 3, name: "白虎", achievements: 9, score: 920, recent: "epic", delta: 1 },
+  { rank: 4, name: "青龍", achievements: 8, score: 760, recent: "rare", delta: 0 },
+  { rank: 5, name: "麒麟", achievements: 7, score: 880, recent: "epic", delta: 3 },
+  { rank: 6, name: "鳳凰", achievements: 6, score: 540, recent: "rare", delta: -2 },
+  { rank: 7, name: "天狗", achievements: 6, score: 480, recent: "rare", delta: 1 },
+  { rank: 8, name: "Yuto", achievements: 5, score: 510, recent: "epic", delta: 4, isMe: true },
+  { rank: 9, name: "river_42", achievements: 5, score: 420, recent: "rare", delta: 0 },
+  { rank: 10, name: "kintsugi", achievements: 4, score: 380, recent: "common", delta: -3 },
+];
+
+// 累計 / レアリティスコア — user out of top 10
+const ALL_SCORE = [
+  { rank: 1, name: "玄武", achievements: 86, score: 12480, recent: "legendary", delta: 0 },
+  { rank: 2, name: "白虎", achievements: 74, score: 10920, recent: "legendary", delta: 1 },
+  { rank: 3, name: "朱雀", achievements: 71, score: 10560, recent: "epic", delta: -1 },
+  { rank: 4, name: "麒麟", achievements: 64, score: 9810, recent: "epic", delta: 2 },
+  { rank: 5, name: "青龍", achievements: 62, score: 8930, recent: "epic", delta: 0 },
+  { rank: 6, name: "鳳凰", achievements: 55, score: 7820, recent: "rare", delta: 0 },
+  { rank: 7, name: "天狗", achievements: 49, score: 6740, recent: "rare", delta: 1 },
+  { rank: 8, name: "yamabushi", achievements: 47, score: 6210, recent: "rare", delta: -1 },
+  { rank: 9, name: "kintsugi", achievements: 43, score: 5830, recent: "rare", delta: 0 },
+  { rank: 10, name: "river_42", achievements: 41, score: 5440, recent: "rare", delta: 2 },
+];
+const ME_OUT = { rank: 23, name: "Yuto", achievements: 18, score: 1860, recent: "epic", delta: 5, isMe: true };
+
+// ============================================================
+// screen
+// ============================================================
+function RankScreen({ width = 412, initialPeriod = "month", initialType = "achievements", initialMode = "default" }) {
+  const [period, setPeriod] = useRankState(initialPeriod);
+  const [type, setType] = useRankState(initialType);
+  const [visible, setVisible] = useRankState(initialMode !== "hidden");
+  const [anonymous, setAnonymous] = useRankState(false);
+
+  // pick dataset
+  const list = period === "all" || type === "score" ? ALL_SCORE : MONTHLY_ACH;
+  const userInList = list.find((e) => e.isMe);
+  const top3 = list.slice(0, 3);
+  const rest = list.slice(3, 10);
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1320,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      {/* top bar */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px 0" }}>
+        <div
+          style={{
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 12,
+            letterSpacing: "0.55em",
+            color: "#8b6f47",
+            paddingLeft: "0.55em",
+          }}
+        >
+          VOW PACT
+        </div>
+        <button aria-label="設定" style={{ background: "transparent", border: "none", padding: 6, cursor: "pointer", display: "inline-flex" }}>
+          <GearIconR size={20} color="#8b6f47" />
+        </button>
+      </div>
+
+      <RankHeader period={period} onPeriod={setPeriod} />
+      <TypeSegment type={type} onType={setType} />
+
+      {!visible ? (
+        <PrivateOverlay onShow={() => setVisible(true)} />
+      ) : (
+        <>
+          {/* podium */}
+          <section aria-label="トップ3" style={{ padding: "8px 20px 0", display: "flex", flexDirection: "column", gap: 10 }}>
+            {top3.map((e) => (
+              <PodiumRow key={e.rank} entry={e} type={type} />
+            ))}
+          </section>
+
+          {/* divider */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "18px 20px 6px" }}>
+            <span style={{ flex: 1, height: 1, background: "linear-gradient(to right, transparent, #c9a96155 50%, transparent)" }} />
+            <span
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.4em",
+                color: "#8b6f47",
+                fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+                fontWeight: 600,
+                paddingLeft: "0.4em",
+              }}
+            >
+              ── RANK 4 – 10 ──
+            </span>
+            <span style={{ flex: 1, height: 1, background: "linear-gradient(to right, transparent, #c9a96155 50%, transparent)" }} />
+          </div>
+
+          {/* rest */}
+          <section style={{ margin: "0 20px", border: "1px solid #d4c8b0", background: "rgba(255,255,255,0.45)" }}>
+            {rest.map((e, i) => (
+              <React.Fragment key={e.rank}>
+                <RankRow entry={e} type={type} highlight={!!e.isMe} />
+                {i < rest.length - 1 && <RowDivider />}
+              </React.Fragment>
+            ))}
+          </section>
+
+          {/* user out of top 10 */}
+          {!userInList && (
+            <section style={{ margin: "16px 20px 0" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 4px 10px",
+                }}
+              >
+                <span style={{ flex: 1, height: 1, borderTop: "1px dashed #c9a961" }} />
+                <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.3em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600 }}>
+                  ⋯
+                </span>
+                <span style={{ flex: 1, height: 1, borderTop: "1px dashed #c9a961" }} />
+              </div>
+              <div
+                style={{
+                  border: "1px solid #8b1a1a",
+                  background: "rgba(139,26,26,0.06)",
+                  borderLeft: "3px solid #8b1a1a",
+                }}
+              >
+                <RankRow entry={ME_OUT} type={type} highlight />
+              </div>
+              <p
+                style={{
+                  margin: "10px 14px 0",
+                  fontSize: 11,
+                  color: "#8b6f47",
+                  fontFamily: "'Noto Serif JP', serif",
+                  letterSpacing: "0.05em",
+                  fontStyle: "italic",
+                  lineHeight: 1.6,
+                }}
+              >
+                10位まであと <strong style={{ color: "#8b1a1a", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontSize: 14 }}>3,580</strong> pt。次の契約で殿堂入りを。
+              </p>
+            </section>
+          )}
+        </>
+      )}
+
+      <PrivacySection
+        visible={visible}
+        anonymous={anonymous}
+        onVisible={setVisible}
+        onAnonymous={setAnonymous}
+      />
+
+      {/* footer note */}
+      <p
+        style={{
+          margin: "0 20px 18px",
+          fontSize: 10,
+          color: "#8b6f47",
+          textAlign: "center",
+          letterSpacing: "0.06em",
+          lineHeight: 1.7,
+          fontStyle: "italic",
+          fontFamily: "'Noto Serif JP', serif",
+        }}
+      >
+        ランキングは毎日 0:00（JST）に更新されます。
+      </p>
+
+      {/* nav */}
+      <nav
+        aria-label="メインナビゲーション"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          borderTop: "1px solid #d4c8b0",
+          background: "rgba(251,246,236,0.85)",
+          marginTop: "auto",
+        }}
+      >
+        <NavItemR icon={<HomeIconR />} label="ホーム" />
+        <NavItemR icon={<ShieldIconR size={22} />} label="殿堂" />
+        <NavItemR icon={<RankIconR size={22} />} label="ランキング" active />
+      </nav>
+    </div>
+  );
+}
+
+function PrivateOverlay({ onShow }) {
+  return (
+    <section
+      style={{
+        margin: "8px 20px 0",
+        padding: "40px 24px",
+        textAlign: "center",
+        background: "rgba(255,255,255,0.5)",
+        border: "1px dashed #b3a890",
+      }}
+    >
+      <div style={{ marginBottom: 14, opacity: 0.55, display: "flex", justifyContent: "center" }}>
+        <LockIconR size={28} color="#8b6f47" />
+      </div>
+      <h3
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 16,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          color: "#2c1810",
+        }}
+      >
+        ランキングは非公開
+      </h3>
+      <p
+        style={{
+          margin: "8px 0 18px",
+          fontSize: 12,
+          color: "#8b6f47",
+          lineHeight: 1.7,
+          letterSpacing: "0.04em",
+          fontFamily: "'Noto Serif JP', serif",
+        }}
+      >
+        公開設定をオンにすると
+        <br />
+        他の挑戦者と順位を競えます。
+      </p>
+      <button
+        onClick={onShow}
+        style={{
+          padding: "10px 22px",
+          background: "#2c1810",
+          color: "#fbf6ec",
+          border: "1px solid #2c1810",
+          borderRadius: 4,
+          fontSize: 12,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          cursor: "pointer",
+        }}
+      >
+        参加する
+      </button>
+    </section>
+  );
+}
+
+Object.assign(window, { RankScreen });

--- a/docs/VowPact_mock/screens/settings.jsx
+++ b/docs/VowPact_mock/screens/settings.jsx
@@ -1,0 +1,557 @@
+/* global React */
+
+const { useState: useSetState } = React;
+
+// ============================================================
+// chrome icons
+// ============================================================
+function ChevronS({ size = 14, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M5 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function BackArrowS({ size = 18, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M11 4L6 9l5 5" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function PencilS({ size = 14, color = "#8b6f47" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 13L4 10l7-7 3 3-7 7-3 1z M10 4l3 3" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function WarningS({ size = 18, color = "#8b1a1a" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 3l10 17H2L12 3z" stroke={color} strokeWidth="1.6" strokeLinejoin="round" />
+      <path d="M12 10v5M12 17.5v0.5" stroke={color} strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ============================================================
+// section header
+// ============================================================
+function SectionHeader({ title, en }) {
+  return (
+    <div style={{ padding: "22px 20px 8px", display: "flex", alignItems: "baseline", gap: 10 }}>
+      <span
+        style={{
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 700,
+          color: "#2c1810",
+          letterSpacing: "0.2em",
+        }}
+      >
+        {title}
+      </span>
+      <span
+        style={{
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 9,
+          letterSpacing: "0.4em",
+          color: "#a77b1f",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+        }}
+      >
+        {en}
+      </span>
+      <span style={{ flex: 1, height: 1, background: "linear-gradient(to right, #c9a96155, transparent)", marginBottom: 2 }} />
+    </div>
+  );
+}
+
+// ============================================================
+// list (group container)
+// ============================================================
+function List({ children }) {
+  return (
+    <div
+      style={{
+        margin: "0 20px",
+        background: "rgba(255,255,255,0.65)",
+        border: "1px solid #d4c8b0",
+      }}
+    >
+      {React.Children.toArray(children).map((c, i, arr) => (
+        <React.Fragment key={i}>
+          {c}
+          {i < arr.length - 1 && <div style={{ height: 1, background: "rgba(212,200,176,0.7)", margin: "0 16px" }} />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================
+// rows
+// ============================================================
+function Row({ label, sub, value, action, danger, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "14px 16px",
+        background: "transparent",
+        border: "none",
+        width: "100%",
+        textAlign: "left",
+        cursor: onClick ? "pointer" : "default",
+        fontFamily: "'Noto Sans JP', sans-serif",
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 14,
+            fontWeight: 600,
+            color: danger ? "#8b1a1a" : "#2c1810",
+            letterSpacing: "0.04em",
+            lineHeight: 1.4,
+          }}
+        >
+          {label}
+        </div>
+        {sub && (
+          <div style={{ fontSize: 11, color: "#8b6f47", marginTop: 3, letterSpacing: "0.04em", lineHeight: 1.5 }}>
+            {sub}
+          </div>
+        )}
+      </div>
+      {value && (
+        <span style={{ fontSize: 13, color: "#8b6f47", fontFamily: "'Noto Serif JP', serif", letterSpacing: "0.02em" }}>
+          {value}
+        </span>
+      )}
+      {action}
+      {onClick && !action && <ChevronS />}
+    </button>
+  );
+}
+
+function ToggleRowS({ label, sub, checked, onChange, disabled }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "14px 16px", opacity: disabled ? 0.5 : 1 }}>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 14, fontWeight: 600, color: "#2c1810", letterSpacing: "0.04em", lineHeight: 1.4 }}>{label}</div>
+        {sub && <div style={{ fontSize: 11, color: "#8b6f47", marginTop: 3, letterSpacing: "0.04em", lineHeight: 1.5 }}>{sub}</div>}
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => !disabled && onChange(!checked)}
+        style={{
+          width: 44, height: 24, borderRadius: 999,
+          background: checked ? "#2c1810" : "#d4c8b0",
+          border: `1px solid ${checked ? "#2c1810" : "#b3a890"}`,
+          position: "relative", cursor: disabled ? "not-allowed" : "pointer", padding: 0,
+          flexShrink: 0,
+        }}
+      >
+        <span aria-hidden="true" style={{
+          position: "absolute", top: 2, left: checked ? 22 : 2,
+          width: 18, height: 18, borderRadius: "50%",
+          background: checked ? "#fbf6ec" : "#fff",
+          boxShadow: "0 1px 2px rgba(44,24,16,0.25)", transition: "left 0.15s",
+        }} />
+      </button>
+    </div>
+  );
+}
+
+// ============================================================
+// edit name field (inline)
+// ============================================================
+function EditableNameRow({ value, onChange }) {
+  const [editing, setEditing] = useSetState(false);
+  const [draft, setDraft] = useSetState(value);
+
+  return (
+    <div style={{ padding: "14px 16px", display: "flex", alignItems: "center", gap: 12, fontFamily: "'Noto Sans JP', sans-serif" }}>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 14, fontWeight: 600, color: "#2c1810", letterSpacing: "0.04em" }}>
+          <ruby>契約者名<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>けいやくしゃめい</rt></ruby>
+        </div>
+        <div style={{ fontSize: 11, color: "#8b6f47", marginTop: 3, letterSpacing: "0.04em" }}>契約書と紋章に刻まれる名前</div>
+        {editing ? (
+          <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+            <input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              style={{
+                flex: 1,
+                padding: "8px 10px",
+                background: "#fff",
+                border: "1px solid #8b6f47",
+                outline: "1px solid #c9a96155",
+                outlineOffset: "-3px",
+                borderRadius: 2,
+                fontFamily: "'Noto Sans JP', sans-serif",
+                fontSize: 14,
+                color: "#2c1810",
+              }}
+              autoFocus
+            />
+            <button
+              onClick={() => { onChange?.(draft); setEditing(false); }}
+              style={{
+                padding: "8px 14px", background: "#2c1810", color: "#fbf6ec",
+                border: "1px solid #2c1810", borderRadius: 2,
+                fontFamily: "'Noto Serif JP', serif", fontSize: 12, fontWeight: 600,
+                letterSpacing: "0.1em", cursor: "pointer",
+              }}
+            >
+              保存
+            </button>
+            <button
+              onClick={() => { setDraft(value); setEditing(false); }}
+              style={{
+                padding: "8px 14px", background: "transparent", color: "#8b6f47",
+                border: "1px solid #d4c8b0", borderRadius: 2,
+                fontFamily: "'Noto Serif JP', serif", fontSize: 12,
+                letterSpacing: "0.1em", cursor: "pointer",
+              }}
+            >
+              取消
+            </button>
+          </div>
+        ) : (
+          <div style={{ marginTop: 6, fontFamily: "'Noto Serif JP', serif", fontSize: 16, fontWeight: 700, color: "#2c1810", letterSpacing: "0.06em" }}>
+            {value}
+          </div>
+        )}
+      </div>
+      {!editing && (
+        <button
+          onClick={() => setEditing(true)}
+          aria-label="名前を編集"
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 4,
+            background: "transparent", border: "1px solid #d4c8b0",
+            padding: "6px 10px", borderRadius: 2, cursor: "pointer",
+            color: "#8b6f47", fontSize: 11, letterSpacing: "0.08em",
+            fontFamily: "'Noto Serif JP', serif",
+          }}
+        >
+          <PencilS />
+          編集
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// confirm modal
+// ============================================================
+function DeleteConfirmModal({ onCancel, onConfirm }) {
+  const [text, setText] = useSetState("");
+  const required = "契約破棄";
+  const ok = text === required;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: "absolute", inset: 0,
+        background: "rgba(28,16,10,0.55)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: 20, zIndex: 10,
+        backdropFilter: "blur(2px)",
+      }}
+    >
+      <div
+        style={{
+          background: "#fbf6ec",
+          border: "1px solid #8b1a1a",
+          outline: "1px solid #8b1a1a55",
+          outlineOffset: -5,
+          padding: "22px 22px 18px",
+          width: "100%",
+          maxWidth: 340,
+          boxShadow: "0 24px 48px -16px rgba(44,24,16,0.5)",
+          fontFamily: "'Noto Sans JP', sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+          <WarningS />
+          <h3
+            style={{
+              margin: 0,
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 16, fontWeight: 700,
+              color: "#8b1a1a",
+              letterSpacing: "0.1em",
+            }}
+          >
+            アカウント削除
+          </h3>
+        </div>
+        <p
+          style={{
+            margin: "0 0 14px",
+            fontSize: 12,
+            color: "#2c1810",
+            lineHeight: 1.7,
+            fontFamily: "'Noto Serif JP', serif",
+            letterSpacing: "0.04em",
+          }}
+        >
+          すべての契約・紋章・殿堂の記録が
+          <strong style={{ color: "#8b1a1a" }}> 永久に失われます </strong>
+          。この操作は取り消せません。
+        </p>
+        <div
+          style={{
+            padding: "10px 12px",
+            background: "rgba(139,26,26,0.06)",
+            border: "1px dashed #8b1a1a",
+            marginBottom: 12,
+            fontSize: 11,
+            color: "#2c1810",
+            lineHeight: 1.7,
+            letterSpacing: "0.04em",
+          }}
+        >
+          続行するには下の欄に<br />
+          <strong style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 13, color: "#8b1a1a", letterSpacing: "0.1em" }}>「{required}」</strong>
+          {" "}と入力してください。
+        </div>
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={required}
+          style={{
+            width: "100%", boxSizing: "border-box",
+            padding: "10px 12px", background: "#fff",
+            border: ok ? "1px solid #8b1a1a" : "1px solid #d4c8b0",
+            borderRadius: 2,
+            fontFamily: "'Noto Serif JP', serif", fontSize: 14,
+            color: "#2c1810", letterSpacing: "0.06em",
+          }}
+        />
+        <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+          <button
+            onClick={onCancel}
+            style={{
+              flex: 1, padding: "11px 12px",
+              background: "transparent", color: "#2c1810",
+              border: "1px solid #2c1810", borderRadius: 2,
+              fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 600,
+              letterSpacing: "0.14em", cursor: "pointer",
+            }}
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={ok ? onConfirm : undefined}
+            disabled={!ok}
+            style={{
+              flex: 1, padding: "11px 12px",
+              background: ok ? "#8b1a1a" : "#c9a89455",
+              color: ok ? "#fbf6ec" : "#a89c84",
+              border: ok ? "1px solid #8b1a1a" : "1px solid #c9a894",
+              borderRadius: 2,
+              fontFamily: "'Noto Serif JP', serif", fontSize: 13, fontWeight: 700,
+              letterSpacing: "0.14em",
+              cursor: ok ? "pointer" : "not-allowed",
+            }}
+          >
+            破棄する
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// screen
+// ============================================================
+function SettingsScreen({ width = 412, mode = "default" }) {
+  const [name, setName] = useSetState("Yuto");
+  const [dark, setDark] = useSetState(false);
+  const [rankVisible, setRankVisible] = useSetState(true);
+  const [hallPublic, setHallPublic] = useSetState(true);
+  const [anonymous, setAnonymous] = useSetState(false);
+  const [confirm, setConfirm] = useSetState(mode === "confirm-delete");
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1200,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      {/* status bar spacer */}
+      <div style={{ height: 12 }} />
+
+      {/* top bar */}
+      <header
+        style={{
+          display: "grid",
+          gridTemplateColumns: "44px 1fr 44px",
+          alignItems: "center",
+          padding: "8px 12px 8px",
+          borderBottom: "1px solid #d4c8b0",
+        }}
+      >
+        <button
+          aria-label="戻る"
+          style={{
+            background: "transparent", border: "none",
+            padding: 10, cursor: "pointer",
+            display: "inline-flex", alignItems: "center", justifyContent: "center",
+          }}
+        >
+          <BackArrowS />
+        </button>
+        <h1
+          style={{
+            margin: 0,
+            textAlign: "center",
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 700,
+            fontSize: 17,
+            letterSpacing: "0.24em",
+            color: "#2c1810",
+            paddingLeft: "0.24em",
+          }}
+        >
+          設定
+        </h1>
+        <span />
+      </header>
+
+      {/* PROFILE */}
+      <SectionHeader title="プロフィール" en="PROFILE" />
+      <List>
+        <EditableNameRow value={name} onChange={setName} />
+        <Row
+          label="メールアドレス"
+          sub="認証およびリマインドの送信先"
+          value="yuto@example.com"
+          onClick={() => {}}
+        />
+        <Row
+          label="パスワード変更"
+          sub="安全のため定期的な変更を推奨"
+          onClick={() => {}}
+        />
+      </List>
+
+      {/* DISPLAY */}
+      <SectionHeader title="表示" en="DISPLAY" />
+      <List>
+        <ToggleRowS
+          label="ダークモード"
+          sub="夜間に目に優しい暗色テーマで表示"
+          checked={dark}
+          onChange={setDark}
+        />
+        <Row
+          label="通知設定"
+          sub="チェックインのリマインド・期日通知"
+          value="ON"
+          onClick={() => {}}
+        />
+      </List>
+
+      {/* PRIVACY */}
+      <SectionHeader title="プライバシー" en="PRIVACY" />
+      <List>
+        <ToggleRowS
+          label="ランキングに表示する"
+          sub="OFF にすると順位は計算されない"
+          checked={rankVisible}
+          onChange={setRankVisible}
+        />
+        <ToggleRowS
+          label="殿堂を公開する"
+          sub="他のユーザーがあなたの達成記録を閲覧可能"
+          checked={hallPublic}
+          onChange={setHallPublic}
+        />
+        <ToggleRowS
+          label="匿名で表示する"
+          sub="ニックネームの代わりに「匿名の挑戦者」と表示"
+          checked={anonymous}
+          onChange={setAnonymous}
+          disabled={!rankVisible && !hallPublic}
+        />
+      </List>
+
+      {/* ACCOUNT */}
+      <SectionHeader title="アカウント" en="ACCOUNT" />
+      <List>
+        <Row label="ログアウト" sub="このデバイスからサインアウトします" onClick={() => {}} />
+        <Row
+          label="アカウント削除"
+          sub="すべての契約・紋章・記録が永久に失われます"
+          danger
+          action={<ChevronS color="#8b1a1a" />}
+          onClick={() => setConfirm(true)}
+        />
+      </List>
+
+      {/* INFO */}
+      <SectionHeader title="アプリ情報" en="ABOUT" />
+      <List>
+        <Row label="利用規約" onClick={() => {}} />
+        <Row label="プライバシーポリシー" onClick={() => {}} />
+        <Row label="お問い合わせ" onClick={() => {}} />
+      </List>
+
+      {/* footer */}
+      <div
+        style={{
+          padding: "28px 24px 24px",
+          textAlign: "center",
+          marginTop: "auto",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.4em",
+            color: "#a77b1f",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.4em",
+          }}
+        >
+          ── VOW PACT · ANNO MMXXVI ──
+        </div>
+      </div>
+
+      {confirm && (
+        <DeleteConfirmModal
+          onCancel={() => setConfirm(false)}
+          onConfirm={() => setConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { SettingsScreen });

--- a/docs/VowPact_mock/screens/share-card.jsx
+++ b/docs/VowPact_mock/screens/share-card.jsx
@@ -1,0 +1,429 @@
+/* global React, Seal, StarDivider, rtStyle */
+
+// X投稿用 正方形シェアカード（1080×1080想定）— A. 羊皮紙
+function ShareCard({ size = 540 }) {
+  return <ShareCardParchment size={size} />;
+}
+
+function ShareCardParchment({ size }) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        background:
+          "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 60%, #ead9b8 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        padding: 36,
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+        overflow: "hidden",
+      }}
+    >
+      {/* 内側の二重罫線 */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 24,
+          border: "1px solid #c9a961",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          inset: 30,
+          border: "0.5px solid #c9a961aa",
+        }}
+      />
+
+      <div style={{ position: "relative", height: "100%", display: "flex", flexDirection: "column" }}>
+        {/* ヘッダー */}
+        <div style={{ textAlign: "center" }}>
+          <div
+            style={{
+              fontSize: 12,
+              letterSpacing: "0.6em",
+              color: "#c9a961",
+              fontWeight: 600,
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              paddingLeft: "0.6em",
+            }}
+          >
+            VOW PACT
+          </div>
+          <h1
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              fontSize: 40,
+              color: "#2c1810",
+              margin: "16px 0 0",
+              letterSpacing: "0.08em",
+              lineHeight: 1.3,
+            }}
+          >
+            <ruby>誓<rt style={rtStyle}>ちか</rt></ruby>いは<ruby>刻<rt style={rtStyle}>きざ</rt></ruby>まれた
+          </h1>
+          <div style={{ margin: "20px auto 0", width: 160 }}>
+            <StarDivider />
+          </div>
+        </div>
+
+        {/* 中央：契約内容 */}
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            margin: "20px 8px",
+            gap: 18,
+          }}
+        >
+          <ShareField label="目標">
+            TOEIC 800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+          </ShareField>
+          <ShareField
+            label="試練"
+            right={
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.25em" }}>
+                  <ruby>難易度<rt style={{ fontSize: "0.55em", color: "#8b6f47" }}>なんいど</rt></ruby>
+                </span>
+                <Stars value={4} />
+              </span>
+            }
+          >
+            SNSを1日30分以内に<ruby>制限<rt style={rtStyle}>せいげん</rt></ruby>する
+          </ShareField>
+          <ShareField label="期日">2026年 8月 2日 まで</ShareField>
+        </div>
+
+        {/* 称号バッジ — 金枠で目立たせる */}
+        <div
+          role="figure"
+          aria-label="授かりし称号"
+          style={{
+            position: "relative",
+            margin: "8px 0 18px",
+            padding: "18px 20px 16px",
+            background:
+              "linear-gradient(180deg, rgba(201,169,97,0.12) 0%, rgba(201,169,97,0.04) 100%)",
+            border: "1px solid #c9a961",
+            outline: "1px solid #c9a96155",
+            outlineOffset: "-5px",
+            textAlign: "center",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: -10,
+              left: "50%",
+              transform: "translateX(-50%)",
+              background: "#f4ecd6",
+              padding: "0 14px",
+              fontSize: 11,
+              letterSpacing: "0.5em",
+              color: "#c9a961",
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontWeight: 600,
+              paddingLeft: "calc(14px + 0.5em)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            TITLE GRANTED
+          </div>
+          <div
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              fontSize: 24,
+              letterSpacing: "0.08em",
+              color: "#2c1810",
+              lineHeight: 1.5,
+            }}
+          >
+            <ruby>沈黙<rt style={rtStyle}>ちんもく</rt></ruby>の
+            <ruby>試練<rt style={rtStyle}>しれん</rt></ruby>を
+            <ruby>背負<rt style={rtStyle}>せお</rt></ruby>いし
+            <span style={{ color: "#8b1a1a" }}>者</span>
+          </div>
+          <div
+            style={{
+              marginTop: 6,
+              fontFamily: "'Noto Serif JP', serif",
+              fontStyle: "italic",
+              color: "#8b6f47",
+              fontSize: 11,
+              letterSpacing: "0.18em",
+            }}
+          >
+            — One who bears the silent trial —
+          </div>
+        </div>
+
+        {/* フッター：署名 + 朱印 */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "space-between",
+            gap: 16,
+            paddingTop: 16,
+            borderTop: "1px solid #c9a96155",
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 10, letterSpacing: "0.35em", color: "#8b6f47", marginBottom: 6 }}>
+              契約者
+            </div>
+            <div
+              style={{
+                fontFamily: "'Caveat','Noto Serif JP',cursive",
+                fontSize: 38,
+                transform: "rotate(-2deg)",
+                color: "#2c1810",
+                lineHeight: 1,
+              }}
+            >
+              Yuto
+            </div>
+          </div>
+          <Seal size={104} rotate={-8} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// （B/Cバリエーションは廃止）
+function _UnusedDark({ size }) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        background:
+          "radial-gradient(ellipse at center, #3a2418 0%, #2c1810 60%, #1a0e08 100%)",
+        position: "relative",
+        boxSizing: "border-box",
+        padding: 40,
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#f4e8d0",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 28,
+          border: "1px solid #c9a96166",
+        }}
+      />
+      <div style={{ position: "relative", height: "100%", display: "flex", flexDirection: "column", textAlign: "center" }}>
+        <div
+          style={{
+            fontSize: 12,
+            letterSpacing: "0.6em",
+            color: "#c9a961",
+            fontWeight: 600,
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            paddingLeft: "0.6em",
+          }}
+        >
+          VOW PACT · No. 001
+        </div>
+
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", gap: 30 }}>
+          <h1
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              fontSize: 56,
+              margin: 0,
+              letterSpacing: "0.1em",
+              lineHeight: 1.3,
+              color: "#f4e8d0",
+            }}
+          >
+            <ruby>誓<rt style={{ ...rtStyle, color: "#c9a961" }}>ちか</rt></ruby>いは
+            <br />
+            <ruby>刻<rt style={{ ...rtStyle, color: "#c9a961" }}>きざ</rt></ruby>まれた
+          </h1>
+
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <Seal size={130} rotate={-8} />
+          </div>
+
+          <div
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 18,
+              color: "#f4e8d0cc",
+              letterSpacing: "0.08em",
+              lineHeight: 1.7,
+            }}
+          >
+            TOEIC 800<ruby>点<rt style={{ ...rtStyle, color: "#c9a961" }}>てん</rt></ruby>を
+            <ruby>達成<rt style={{ ...rtStyle, color: "#c9a961" }}>たっせい</rt></ruby>する
+            <br />
+            <span style={{ color: "#c9a961", fontStyle: "italic" }}>—— 期日 2026.08.02</span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontStyle: "italic",
+            color: "#c9a961",
+            fontSize: 14,
+            letterSpacing: "0.08em",
+          }}
+        >
+          沈黙の<ruby>試練<rt style={{ ...rtStyle, color: "#c9a961" }}>しれん</rt></ruby>を
+          <ruby>背負<rt style={{ ...rtStyle, color: "#c9a961" }}>せお</rt></ruby>いし者
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// （ミニマル案は廃止）
+function _UnusedMinimal({ size }) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        background: "#f4e8d0",
+        position: "relative",
+        boxSizing: "border-box",
+        padding: 56,
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 12,
+          letterSpacing: "0.6em",
+          color: "#8b6f47",
+          fontWeight: 600,
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          paddingLeft: "0.6em",
+        }}
+      >
+        VOW PACT
+      </div>
+
+      <div style={{ flex: 1, display: "flex", alignItems: "center" }}>
+        <div>
+          <div
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.4em",
+              color: "#8b6f47",
+              marginBottom: 18,
+            }}
+          >
+            我、ここに以下を誓う。
+          </div>
+          <h1
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              fontSize: 56,
+              margin: 0,
+              letterSpacing: "0.04em",
+              lineHeight: 1.35,
+              color: "#2c1810",
+              borderLeft: "3px solid #8b1a1a",
+              paddingLeft: 22,
+            }}
+          >
+            TOEIC<br />800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<br />
+            <ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+          </h1>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 10, letterSpacing: "0.35em", color: "#8b6f47", marginBottom: 8 }}>
+            期日
+          </div>
+          <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 22, letterSpacing: "0.06em" }}>
+            2026年 8月 2日
+          </div>
+          <div
+            style={{
+              fontFamily: "'Caveat','Noto Serif JP',cursive",
+              fontSize: 32,
+              transform: "rotate(-2deg)",
+              color: "#2c1810",
+              marginTop: 14,
+            }}
+          >
+            Yuto
+          </div>
+        </div>
+        <Seal size={110} rotate={-8} />
+      </div>
+    </div>
+  );
+}
+
+function ShareField({ label, right, children }) {
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 6,
+        }}
+      >
+        <div style={{ fontSize: 10, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em" }}>
+          【{label}】
+        </div>
+        {right}
+      </div>
+      <div
+        style={{
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 18,
+          color: "#2c1810",
+          borderLeft: "2px solid #8b1a1a",
+          paddingLeft: 12,
+          lineHeight: 1.6,
+          letterSpacing: "0.02em",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Stars({ value = 4, max = 5 }) {
+  return (
+    <span style={{ color: "#8b1a1a", letterSpacing: "0.15em", fontSize: 13 }}>
+      {"★".repeat(value)}
+      <span style={{ color: "#d4b8b8" }}>{"★".repeat(max - value)}</span>
+    </span>
+  );
+}
+
+Object.assign(window, { ShareCard });

--- a/docs/VowPact_mock/screens/signed.jsx
+++ b/docs/VowPact_mock/screens/signed.jsx
@@ -1,0 +1,586 @@
+/* global React */
+const { useState } = React;
+
+// ---------- SVG パーツ ----------
+
+const StarDivider = ({ color = "#c9a961" }) => (
+  <div style={{ display: "flex", alignItems: "center", gap: 12, width: "100%" }} aria-hidden="true">
+    <span style={{ flex: 1, height: 1, background: `linear-gradient(to right, transparent, ${color}66, ${color})` }} />
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M7 0.5 L8.3 5.2 L13 5.7 L9.4 8.6 L10.6 13.3 L7 10.6 L3.4 13.3 L4.6 8.6 L1 5.7 L5.7 5.2 Z"
+        fill={color}
+      />
+    </svg>
+    <span style={{ flex: 1, height: 1, background: `linear-gradient(to left, transparent, ${color}66, ${color})` }} />
+  </div>
+);
+
+const DifficultyStars = ({ value = 4, max = 5 }) => (
+  <span
+    role="img"
+    aria-label={`難易度 ${value} / ${max}`}
+    style={{ color: "#8b1a1a", letterSpacing: "0.15em", fontSize: 13 }}
+  >
+    {"★".repeat(value)}
+    <span style={{ color: "#d4b8b8" }}>{"★".repeat(max - value)}</span>
+  </span>
+);
+
+// 朱印（中世ファンタジー紋章 × 篆刻風）
+let __sealIdCounter = 0;
+const Seal = ({ size = 88, rotate = -8 }) => {
+  // 同一ページ内に複数置かれてもfilter idが衝突しないようにユニーク化
+  const uid = React.useMemo(() => `seal-${++__sealIdCounter}`, []);
+  return (
+    <div
+      aria-label="朱印 誓約"
+      role="img"
+      style={{
+        transform: `rotate(${rotate}deg)`,
+        filter: "drop-shadow(0 2px 1px rgba(139,26,26,0.2))",
+        flexShrink: 0,
+      }}
+    >
+      <svg width={size} height={size} viewBox="0 0 100 100">
+        <defs>
+          {/* 押印のかすれ */}
+          <filter id={`${uid}-rough`} x="-10%" y="-10%" width="120%" height="120%">
+            <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="7" />
+            <feDisplacementMap in="SourceGraphic" scale="1.6" />
+          </filter>
+          {/* インクむら */}
+          <filter id={`${uid}-ink`}>
+            <feTurbulence type="fractalNoise" baseFrequency="2.5" numOctaves="2" seed="11" />
+            <feColorMatrix values="0 0 0 0 0.55  0 0 0 0 0.10  0 0 0 0 0.10  0 0 0 0.4 0" />
+            <feComposite in2="SourceGraphic" operator="in" />
+            <feComposite in="SourceGraphic" operator="over" />
+          </filter>
+          {/* 円周文字パス */}
+          <path id={`${uid}-arc`} d="M 50 50 m -34 0 a 34 34 0 1 1 68 0 a 34 34 0 1 1 -68 0" />
+        </defs>
+
+        <g filter={`url(#${uid}-rough)`}>
+          {/* 背景の薄い朱 */}
+          <circle cx="50" cy="50" r="46" fill="rgba(139,26,26,0.10)" />
+          {/* 外円（太） */}
+          <circle cx="50" cy="50" r="46" fill="none" stroke="#8b1a1a" strokeWidth="3.2" />
+          {/* 二重外円（細） */}
+          <circle cx="50" cy="50" r="42" fill="none" stroke="#8b1a1a" strokeWidth="0.7" opacity="0.7" />
+          {/* 内円（紋章エリア） */}
+          <circle cx="50" cy="50" r="28" fill="none" stroke="#8b1a1a" strokeWidth="1" opacity="0.85" />
+
+          {/* 円周の篆刻風文字 上半 */}
+          <text fill="#8b1a1a" fontFamily="'Cormorant Garamond','Noto Serif JP',serif" fontSize="6.5" fontWeight="700" letterSpacing="3">
+            <textPath href={`#${uid}-arc`} startOffset="50%" textAnchor="middle">
+              VOW · PACT · MMXXVI
+            </textPath>
+          </text>
+
+          {/* 中央の紋章：剣を交差 + 月桂冠 */}
+          <g transform="translate(50 50)">
+            {/* 月桂冠 左 */}
+            <path
+              d="M -22 -2 Q -26 -10 -22 -18 M -22 -2 Q -28 -6 -27 -12 M -22 -2 Q -28 2 -27 8 M -22 -2 Q -26 6 -22 14"
+              stroke="#8b1a1a"
+              strokeWidth="1.2"
+              fill="none"
+              strokeLinecap="round"
+            />
+            {/* 月桂冠 右 */}
+            <path
+              d="M 22 -2 Q 26 -10 22 -18 M 22 -2 Q 28 -6 27 -12 M 22 -2 Q 28 2 27 8 M 22 -2 Q 26 6 22 14"
+              stroke="#8b1a1a"
+              strokeWidth="1.2"
+              fill="none"
+              strokeLinecap="round"
+            />
+            {/* 交差した剣 */}
+            <g stroke="#8b1a1a" strokeWidth="1.4" fill="none" strokeLinecap="round">
+              {/* 剣1 \ 方向 */}
+              <line x1="-14" y1="-14" x2="14" y2="14" />
+              <line x1="-16" y1="-12" x2="-12" y2="-16" />{/* 鍔 */}
+              <line x1="-18" y1="-18" x2="-15" y2="-15" />{/* 柄頭 */}
+              {/* 剣2 / 方向 */}
+              <line x1="14" y1="-14" x2="-14" y2="14" />
+              <line x1="16" y1="-12" x2="12" y2="-16" />
+              <line x1="18" y1="-18" x2="15" y2="-15" />
+            </g>
+            {/* 中央のひし形（要石） */}
+            <path d="M 0 -3 L 3 0 L 0 3 L -3 0 Z" fill="#8b1a1a" />
+          </g>
+
+          {/* 下部の小さなラベル */}
+          <text
+            x="50"
+            y="86"
+            textAnchor="middle"
+            fontFamily="'Noto Serif JP', serif"
+            fontSize="7"
+            fontWeight="700"
+            fill="#8b1a1a"
+            letterSpacing="2"
+          >
+            誓 約
+          </text>
+        </g>
+      </svg>
+    </div>
+  );
+};
+
+// 角飾り（コーナー装飾、控えめ）
+const CornerOrnament = ({ position }) => {
+  const map = {
+    tl: { top: 10, left: 10, transform: "rotate(0deg)" },
+    tr: { top: 10, right: 10, transform: "rotate(90deg)" },
+    bl: { bottom: 10, left: 10, transform: "rotate(-90deg)" },
+    br: { bottom: 10, right: 10, transform: "rotate(180deg)" },
+  };
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+      style={{ position: "absolute", ...map[position], opacity: 0.55 }}
+      aria-hidden="true"
+    >
+      <path
+        d="M2 8 L2 2 L8 2 M2 2 L7 7"
+        stroke="#c9a961"
+        strokeWidth="1"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+// 手書き署名風
+const Signature = ({ name = "Yuto" }) => (
+  <span
+    style={{
+      fontFamily: "'Caveat', 'Dancing Script', 'Noto Serif JP', cursive",
+      fontSize: 30,
+      color: "#2c1810",
+      lineHeight: 1,
+      transform: "rotate(-2deg)",
+      display: "inline-block",
+    }}
+  >
+    {name}
+  </span>
+);
+
+// ---------- 契約書カード本体 ----------
+
+function ContractCard({ data }) {
+  const {
+    no = "001",
+    goal,
+    trial,
+    difficulty = 4,
+    deadline,
+    signer = "Yuto",
+  } = data;
+
+  return (
+    <article
+      aria-label="誓約契約書"
+      style={{
+        position: "relative",
+        background: "#f4e8d0",
+        border: "0.5px solid #d4c8b0",
+        boxShadow:
+          "0 1px 0 rgba(255,255,255,0.4) inset, 0 12px 28px -16px rgba(44,24,16,0.35), 0 2px 4px rgba(44,24,16,0.06)",
+        padding: "36px 26px 28px",
+        // 内側の二重罫線
+        outline: "1px solid #c9a961",
+        outlineOffset: "-10px",
+      }}
+    >
+      <CornerOrnament position="tl" />
+      <CornerOrnament position="tr" />
+      <CornerOrnament position="bl" />
+      <CornerOrnament position="br" />
+
+      {/* タイトル */}
+      <header style={{ textAlign: "center", marginBottom: 18 }}>
+        <h2
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: "clamp(22px, 6.4vw, 28px)",
+            letterSpacing: "0.45em",
+            color: "#2c1810",
+            margin: 0,
+            paddingLeft: "0.45em" /* letter-spacing分の中央調整 */,
+          }}
+        >
+          誓約契約書
+        </h2>
+        <p
+          style={{
+            margin: "8px 0 0",
+            fontSize: 10,
+            letterSpacing: "0.3em",
+            color: "#8b6f47",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          }}
+        >
+          VOW PACT &nbsp;·&nbsp; No. {no}
+        </p>
+      </header>
+
+      <div style={{ margin: "16px 4px 22px" }}>
+        <StarDivider />
+      </div>
+
+      {/* 前文 */}
+      <p
+        style={{
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 15,
+          color: "#2c1810",
+          textAlign: "center",
+          letterSpacing: "0.08em",
+          margin: "0 0 26px",
+        }}
+      >
+        我、ここに以下を誓う。
+      </p>
+
+      {/* 目標 */}
+      <Section label="目標">
+        <p style={accentBodyStyle}>{goal}</p>
+      </Section>
+
+      {/* 試練 */}
+      <Section
+        label="試練"
+        right={
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.25em" }}>
+              <ruby>難易度<rt style={{ fontSize: "0.55em", color: "#8b6f47" }}>なんいど</rt></ruby>
+            </span>
+            <DifficultyStars value={difficulty} />
+          </span>
+        }
+      >
+        <p style={accentBodyStyle}>{trial}</p>
+      </Section>
+
+      {/* 期日 */}
+      <Section label="期日">
+        <p style={accentBodyStyle}>{deadline}</p>
+      </Section>
+
+      {/* 署名欄 */}
+      <div
+        style={{
+          marginTop: 28,
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          gap: 16,
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.3em",
+              color: "#8b6f47",
+              marginBottom: 10,
+            }}
+          >
+            契約者
+          </div>
+          <div
+            style={{
+              borderBottom: "1px solid #2c1810",
+              paddingBottom: 4,
+              minHeight: 36,
+              display: "flex",
+              alignItems: "flex-end",
+            }}
+          >
+            <Signature name={signer} />
+          </div>
+        </div>
+        <div style={{ marginBottom: -6, marginRight: -4 }}>
+          <Seal />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+const accentBodyStyle = {
+  fontFamily: "'Noto Serif JP', serif",
+  fontSize: 16,
+  lineHeight: 1.7,
+  color: "#2c1810",
+  borderLeft: "2px solid #8b1a1a",
+  padding: "2px 0 2px 12px",
+  margin: 0,
+  letterSpacing: "0.02em",
+};
+
+function Section({ label, right, children }) {
+  return (
+    <section style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 10,
+            color: "#8b6f47",
+            letterSpacing: "0.45em",
+            fontWeight: 600,
+            paddingLeft: "0.45em",
+          }}
+        >
+          【{label}】
+        </h3>
+        {right}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+// ---------- 画面本体 ----------
+
+function SignedScreen({ width = 412 }) {
+  const data = {
+    no: "001",
+    goal: (
+      <>
+        TOEIC 800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+      </>
+    ),
+    trial: (
+      <>
+        <ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>まで、SNSを1日30分以内に<ruby>制限<rt style={rtStyle}>せいげん</rt></ruby>する
+      </>
+    ),
+    difficulty: 4,
+    deadline: "2026年 8月 2日 まで",
+    signer: "Yuto",
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 900,
+        background: "#fbf6ec",
+        backgroundImage:
+          "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        padding: "28px 20px 36px",
+        boxSizing: "border-box",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      {/* 上部：成立アナウンス */}
+      <header style={{ textAlign: "center", marginBottom: 22 }}>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.55em",
+            color: "#c9a961",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+            fontWeight: 600,
+            paddingLeft: "0.55em",
+            marginBottom: 14,
+          }}
+        >
+          VOW PACT
+        </div>
+        <h1
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: "clamp(28px, 8vw, 34px)",
+            color: "#2c1810",
+            margin: 0,
+            letterSpacing: "0.08em",
+            lineHeight: 1.4,
+          }}
+        >
+          <ruby>
+            誓<rt style={rtStyle}>ちか</rt>
+          </ruby>
+          いは
+          <ruby>
+            刻<rt style={rtStyle}>きざ</rt>
+          </ruby>
+          まれた
+        </h1>
+        <div style={{ margin: "16px auto 0", width: 120 }}>
+          <StarDivider />
+        </div>
+      </header>
+
+      {/* 中央：契約書 */}
+      <ContractCard data={data} />
+
+      {/* 下部：称号 + アクション */}
+      <div style={{ marginTop: 32, textAlign: "center" }}>
+        {/* 称号カード — 金枠で「授かりもの」感を出す */}
+        <div
+          role="figure"
+          aria-label="授かりし称号"
+          style={{
+            position: "relative",
+            padding: "22px 18px 20px",
+            background:
+              "linear-gradient(180deg, rgba(201,169,97,0.10) 0%, rgba(201,169,97,0.04) 100%)",
+            border: "1px solid #c9a961",
+            outline: "1px solid #c9a96155",
+            outlineOffset: "-5px",
+          }}
+        >
+          {/* ラベル — 上部のリボン風 */}
+          <div
+            style={{
+              position: "absolute",
+              top: -10,
+              left: "50%",
+              transform: "translateX(-50%)",
+              background: "#fbf6ec",
+              padding: "0 12px",
+              fontSize: 10,
+              letterSpacing: "0.5em",
+              color: "#c9a961",
+              fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+              fontWeight: 600,
+              paddingLeft: "calc(12px + 0.5em)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            TITLE GRANTED
+          </div>
+
+          {/* 上の装飾 */}
+          <div style={{ display: "flex", justifyContent: "center", marginBottom: 10 }}>
+            <svg width="44" height="14" viewBox="0 0 44 14" aria-hidden="true">
+              <path d="M0 7 L18 7" stroke="#c9a961" strokeWidth="0.8" />
+              <path
+                d="M22 1.5 L23.4 5.5 L27.5 5.7 L24.2 8.2 L25.4 12.2 L22 9.8 L18.6 12.2 L19.8 8.2 L16.5 5.7 L20.6 5.5 Z"
+                fill="#c9a961"
+              />
+              <path d="M26 7 L44 7" stroke="#c9a961" strokeWidth="0.8" />
+            </svg>
+          </div>
+
+          <div
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              color: "#2c1810",
+              fontSize: 22,
+              letterSpacing: "0.08em",
+              lineHeight: 1.5,
+            }}
+          >
+            <ruby>沈黙<rt style={rtStyle}>ちんもく</rt></ruby>の
+            <ruby>試練<rt style={rtStyle}>しれん</rt></ruby>を
+            <ruby>背負<rt style={rtStyle}>せお</rt></ruby>いし
+            <span style={{ color: "#8b1a1a" }}>者</span>
+          </div>
+
+          <div
+            style={{
+              marginTop: 10,
+              fontFamily: "'Noto Serif JP', serif",
+              fontStyle: "italic",
+              color: "#8b6f47",
+              fontSize: 11,
+              letterSpacing: "0.18em",
+            }}
+          >
+            — One who bears the silent trial —
+          </div>
+        </div>
+
+        <div style={{ marginTop: 24, display: "flex", flexDirection: "column", gap: 10 }}>
+          <PrimaryButton>
+            <span style={{ fontFamily: "'Noto Sans JP', sans-serif", fontWeight: 700 }}>
+              𝕏
+            </span>
+            <span>で<ruby>天下<rt style={rtStyle}>てんか</rt></ruby>に<ruby>宣<rt style={rtStyle}>せん</rt></ruby>する</span>
+          </PrimaryButton>
+          <SecondaryButton>ホームに戻る</SecondaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const rtStyle = {
+  fontSize: "0.45em",
+  letterSpacing: "0.05em",
+  color: "#8b6f47",
+  fontWeight: 400,
+};
+
+function PrimaryButton({ children, ...rest }) {
+  return (
+    <button
+      {...rest}
+      style={{
+        height: 48,
+        width: "100%",
+        background: "#2c1810",
+        color: "#f4e8d0",
+        border: "1px solid #2c1810",
+        borderRadius: 4,
+        fontSize: 15,
+        fontFamily: "'Noto Serif JP', serif",
+        letterSpacing: "0.12em",
+        cursor: "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 8,
+        boxShadow: "0 1px 0 rgba(255,255,255,0.06) inset, 0 6px 14px -8px rgba(44,24,16,0.6)",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SecondaryButton({ children, ...rest }) {
+  return (
+    <button
+      {...rest}
+      style={{
+        height: 44,
+        width: "100%",
+        background: "#ffffff",
+        color: "#2c1810",
+        border: "1px solid #d4c8b0",
+        borderRadius: 4,
+        fontSize: 14,
+        fontFamily: "'Noto Sans JP', sans-serif",
+        cursor: "pointer",
+        letterSpacing: "0.08em",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+Object.assign(window, { SignedScreen, ContractCard, Seal, StarDivider, rtStyle, DifficultyStars, Signature, CornerOrnament });

--- a/docs/VowPact_mock/screens/step1-goal.jsx
+++ b/docs/VowPact_mock/screens/step1-goal.jsx
@@ -1,0 +1,530 @@
+/* global React, rtStyle */
+
+const { useState: useStep1State } = React;
+
+// ステップインジケータ
+function StepIndicator({ current = 1, total = 4, labels = ["目標", "試練", "期日", "署名"] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        {Array.from({ length: total }).map((_, i) => {
+          const idx = i + 1;
+          const isActive = idx === current;
+          const isDone = idx < current;
+          return (
+            <React.Fragment key={i}>
+              <span
+                aria-current={isActive ? "step" : undefined}
+                style={{
+                  width: isActive ? 26 : 8,
+                  height: 8,
+                  borderRadius: 4,
+                  background: isDone ? "#8b1a1a" : isActive ? "#8b1a1a" : "rgba(44,24,16,0.18)",
+                  transition: "all 0.25s",
+                }}
+              />
+              {i < total - 1 && (
+                <span style={{ width: 8, height: 1, background: "rgba(201,169,97,0.45)" }} aria-hidden="true" />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.4em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+        }}
+      >
+        STEP {current} / {total} · {labels[current - 1]}
+      </div>
+    </div>
+  );
+}
+
+// 巻物アイコン
+function ScrollIcon({ size = 16, color = "#2c1810" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M5 4h11a3 3 0 013 3v10a3 3 0 003 3H8a3 3 0 01-3-3V4z"
+        stroke={color}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <path d="M5 4a3 3 0 00-3 3v0a3 3 0 003 3" stroke={color} strokeWidth="1.4" />
+      <path d="M9 9h6M9 13h6" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// 矢印
+function ArrowIcon({ dir = "right", size = 14, color = "#2c1810" }) {
+  const rot = { right: 0, left: 180, up: -90, down: 90 }[dir];
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" style={{ transform: `rotate(${rot}deg)` }} fill="none" aria-hidden="true">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// くるくるローダー
+function Spinner({ size = 16, color = "#c9a961" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ animation: "vp-spin 0.9s linear infinite" }}>
+      <circle cx="12" cy="12" r="9" stroke={`${color}33`} strokeWidth="2" fill="none" />
+      <path d="M12 3a9 9 0 019 9" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}
+
+// 共通：ヘッダーセクション
+function FormHeader({ step }) {
+  return (
+    <header style={{ padding: "20px 20px 14px", textAlign: "center" }}>
+      <StepIndicator current={step} />
+      <h1
+        style={{
+          margin: "18px 0 4px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          fontSize: 18,
+          letterSpacing: "0.18em",
+        }}
+      >
+        <ruby>契約書<rt style={rtStyle}>けいやくしょ</rt></ruby>を<ruby>結<rt style={rtStyle}>むす</rt></ruby>ぶ
+      </h1>
+      <p style={{ margin: 0, fontSize: 12, color: "#8b6f47", letterSpacing: "0.15em", fontFamily: "'Noto Serif JP', serif" }}>
+        Step {step}：目標を定める
+      </p>
+    </header>
+  );
+}
+
+// 質問見出し
+function Prompt() {
+  return (
+    <div style={{ padding: "18px 24px 14px", textAlign: "center" }}>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          fontSize: "clamp(22px, 6.4vw, 26px)",
+          letterSpacing: "0.06em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+        }}
+      >
+        <ruby>今<rt style={rtStyle}>いま</rt></ruby>、<ruby>何<rt style={rtStyle}>なに</rt></ruby>を
+        <ruby>成<rt style={rtStyle}>な</rt></ruby>し
+        <ruby>遂<rt style={rtStyle}>と</rt></ruby>げたい？
+      </h2>
+      <div style={{ margin: "12px auto 0", width: 80, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+    </div>
+  );
+}
+
+// テキストエリア
+function GoalTextarea({ value, onChange, placeholder }) {
+  return (
+    <div style={{ position: "relative" }}>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={4}
+        style={{
+          width: "100%",
+          background: "#ffffff",
+          border: "1px solid #d4c8b0",
+          outline: "1px solid transparent",
+          padding: "14px 16px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 16,
+          lineHeight: 1.7,
+          color: "#2c1810",
+          resize: "vertical",
+          minHeight: 110,
+          boxSizing: "border-box",
+          letterSpacing: "0.02em",
+        }}
+        onFocus={(e) => {
+          e.target.style.borderColor = "#8b6f47";
+          e.target.style.outlineColor = "#c9a96155";
+        }}
+        onBlur={(e) => {
+          e.target.style.borderColor = "#d4c8b0";
+          e.target.style.outlineColor = "transparent";
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 8,
+          right: 12,
+          fontSize: 10,
+          color: "#8b6f47",
+          letterSpacing: "0.1em",
+          pointerEvents: "none",
+        }}
+      >
+        {value.length}/120
+      </div>
+    </div>
+  );
+}
+
+// AI生成ボタン
+function OracleButton({ onClick, loading }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      style={{
+        width: "100%",
+        height: 48,
+        background:
+          "linear-gradient(180deg, #fbf6ec 0%, #f1e7d2 100%)",
+        color: "#2c1810",
+        border: "1px solid #c9a961",
+        outline: "1px solid #c9a96155",
+        outlineOffset: "-4px",
+        borderRadius: 4,
+        fontSize: 15,
+        fontFamily: "'Noto Serif JP', serif",
+        fontWeight: 600,
+        letterSpacing: "0.18em",
+        cursor: loading ? "wait" : "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        position: "relative",
+      }}
+      aria-label="AIによる目標案を受ける"
+    >
+      {loading ? <Spinner /> : <ScrollIcon size={16} color="#8b1a1a" />}
+      <span>
+        {loading ? (
+          <>
+            <ruby>天啓<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>てんけい</rt></ruby>を<ruby>授<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>さず</rt></ruby>かり中…
+          </>
+        ) : (
+          <>
+            <ruby>天啓<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>てんけい</rt></ruby>を<ruby>受<rt style={{ fontSize: "0.5em", color: "#8b6f47" }}>う</rt></ruby>ける
+          </>
+        )}
+      </span>
+    </button>
+  );
+}
+
+// 提案カード
+function OracleCard({ index, text, onSelect, selected }) {
+  return (
+    <div
+      style={{
+        background: selected ? "#f4e8d0" : "#ffffff",
+        border: `1px solid ${selected ? "#8b6f47" : "#d4c8b0"}`,
+        position: "relative",
+        padding: "14px 16px 14px 44px",
+      }}
+    >
+      {/* 番号 */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 14,
+          left: 12,
+          width: 24,
+          height: 24,
+          borderRadius: "50%",
+          border: "1px solid #c9a961",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 600,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "rgba(201,169,97,0.08)",
+        }}
+      >
+        {["Ⅰ", "Ⅱ", "Ⅲ"][index]}
+      </span>
+      <p
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 15,
+          lineHeight: 1.6,
+          color: "#2c1810",
+          letterSpacing: "0.02em",
+          borderLeft: "2px solid #8b1a1a",
+          paddingLeft: 10,
+        }}
+      >
+        {text}
+      </p>
+      <div style={{ display: "flex", gap: 10, marginTop: 12, alignItems: "center", justifyContent: "space-between" }}>
+        <button
+          onClick={onSelect}
+          style={{
+            background: selected ? "#2c1810" : "transparent",
+            color: selected ? "#fbf6ec" : "#2c1810",
+            border: "1px solid #2c1810",
+            padding: "8px 14px",
+            fontSize: 12,
+            letterSpacing: "0.12em",
+            fontFamily: "'Noto Sans JP', sans-serif",
+            cursor: "pointer",
+            borderRadius: 2,
+          }}
+        >
+          {selected ? "✓ 選択中" : "これを選ぶ"}
+        </button>
+        <button
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#8b6f47",
+            fontSize: 12,
+            letterSpacing: "0.08em",
+            cursor: "pointer",
+            textDecoration: "underline",
+            textUnderlineOffset: 3,
+            textDecorationColor: "#d4c8b0",
+            fontFamily: "'Noto Sans JP', sans-serif",
+          }}
+        >
+          自由に編集する
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// フッター（戻る/次へ）
+function StepFooter({ canProceed, onBack, onNext }) {
+  return (
+    <footer
+      style={{
+        padding: "14px 20px 22px",
+        background: "rgba(251,246,236,0.85)",
+        borderTop: "1px solid #d4c8b0",
+        display: "grid",
+        gridTemplateColumns: "1fr 1.4fr",
+        gap: 10,
+      }}
+    >
+      <button
+        onClick={onBack}
+        style={{
+          height: 48,
+          background: "#ffffff",
+          border: "1px solid #d4c8b0",
+          color: "#2c1810",
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          letterSpacing: "0.12em",
+          cursor: "pointer",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+        }}
+      >
+        <ArrowIcon dir="left" />
+        戻る
+      </button>
+      <button
+        onClick={onNext}
+        disabled={!canProceed}
+        style={{
+          height: 48,
+          background: canProceed ? "#2c1810" : "#cfc4ad",
+          color: canProceed ? "#fbf6ec" : "#8b6f47aa",
+          border: `1px solid ${canProceed ? "#2c1810" : "#cfc4ad"}`,
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          cursor: canProceed ? "pointer" : "not-allowed",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          boxShadow: canProceed ? "0 6px 14px -8px rgba(44,24,16,0.6)" : "none",
+        }}
+      >
+        次へ進む
+        <ArrowIcon dir="right" color={canProceed ? "#fbf6ec" : "#8b6f47aa"} />
+      </button>
+    </footer>
+  );
+}
+
+// ---------- 画面本体 ----------
+
+const ORACLE_SUGGESTIONS = [
+  "TOEIC 800点を3ヶ月で達成する",
+  "英会話アプリを毎日30分続ける",
+  "英語の本を5冊読破する",
+];
+
+function Step1Screen({ width = 412, initialMode = "empty" }) {
+  // mode: 'empty' | 'loading' | 'suggestions' | 'filled' | 'selected'
+  const [mode, setMode] = useStep1State(initialMode);
+  const [value, setValue] = useStep1State(
+    initialMode === "filled" ? "TOEIC 800点を達成する" : ""
+  );
+  const [selectedIdx, setSelectedIdx] = useStep1State(initialMode === "selected" ? 0 : -1);
+
+  // initialModeに合わせた表示状態を作る
+  const showSuggestions = mode === "suggestions" || mode === "selected";
+  const isLoading = mode === "loading";
+  const canProceed = value.trim().length > 0 || selectedIdx >= 0;
+
+  const handleOracle = () => {
+    setMode("loading");
+    setTimeout(() => setMode("suggestions"), 1100);
+  };
+
+  const handleSelect = (idx) => {
+    setSelectedIdx(idx);
+    setValue(ORACLE_SUGGESTIONS[idx]);
+    setMode("selected");
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 900,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      <FormHeader step={1} />
+
+      <main style={{ flex: 1, padding: "0 20px 20px", display: "flex", flexDirection: "column" }}>
+        <Prompt />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <GoalTextarea
+            value={value}
+            onChange={(v) => {
+              setValue(v);
+              setSelectedIdx(-1);
+            }}
+            placeholder="例：TOEIC 800点を達成する"
+          />
+
+          <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "4px 0" }}>
+            <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+            <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.4em", paddingLeft: "0.4em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600 }}>
+              OR
+            </span>
+            <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+          </div>
+
+          <OracleButton onClick={handleOracle} loading={isLoading} />
+        </div>
+
+        {/* Loading state hint */}
+        {isLoading && (
+          <div
+            style={{
+              marginTop: 22,
+              textAlign: "center",
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 13,
+              color: "#8b6f47",
+              fontStyle: "italic",
+              letterSpacing: "0.08em",
+              lineHeight: 1.8,
+            }}
+          >
+            <ruby>古<rt style={rtStyle}>いにしえ</rt></ruby>の
+            <ruby>知恵<rt style={rtStyle}>ちえ</rt></ruby>に
+            <ruby>問<rt style={rtStyle}>と</rt></ruby>うている……
+          </div>
+        )}
+
+        {/* Suggestions */}
+        {showSuggestions && (
+          <section style={{ marginTop: 24 }} aria-label="目標案">
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontFamily: "'Noto Serif JP', serif",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  letterSpacing: "0.15em",
+                  color: "#2c1810",
+                }}
+              >
+                <ruby>授<rt style={rtStyle}>さず</rt></ruby>かりし
+                <ruby>三<rt style={rtStyle}>みっ</rt></ruby>つの
+                <ruby>道<rt style={rtStyle}>みち</rt></ruby>
+              </h3>
+              <button
+                onClick={handleOracle}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "#8b6f47",
+                  fontSize: 12,
+                  fontFamily: "'Noto Serif JP', serif",
+                  cursor: "pointer",
+                  letterSpacing: "0.06em",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                ↻ もう一度問う
+              </button>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {ORACLE_SUGGESTIONS.map((text, i) => (
+                <OracleCard
+                  key={i}
+                  index={i}
+                  text={text}
+                  selected={selectedIdx === i}
+                  onSelect={() => handleSelect(i)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      <StepFooter canProceed={canProceed} onBack={() => {}} onNext={() => {}} />
+    </div>
+  );
+}
+
+// CSS for spinner
+if (typeof document !== "undefined" && !document.getElementById("vp-spin-style")) {
+  const s = document.createElement("style");
+  s.id = "vp-spin-style";
+  s.textContent = `@keyframes vp-spin { to { transform: rotate(360deg); } }`;
+  document.head.appendChild(s);
+}
+
+Object.assign(window, { Step1Screen });

--- a/docs/VowPact_mock/screens/step2-trial.jsx
+++ b/docs/VowPact_mock/screens/step2-trial.jsx
@@ -1,0 +1,555 @@
+/* global React */
+
+const { useState: useStep2State } = React;
+const _rt2 = { fontSize: "0.45em", letterSpacing: "0.05em", color: "#8b6f47", fontWeight: 400 };
+
+// ========== icons ==========
+function SwordsIcon({ size = 16, color = "#8b1a1a" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M3 21l8-8M21 21l-8-8M14 3l7 7-3 3-7-7 3-3zM10 21l-3-3M3 3l7 7-3 3-7-7 3-3z" stroke={color} strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ArrowIcon({ dir = "right", size = 14, color = "#2c1810" }) {
+  const rot = { right: 0, left: 180 }[dir];
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" style={{ transform: `rotate(${rot}deg)` }} fill="none" aria-hidden="true">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function Spinner2({ size = 16, color = "#c9a961" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ animation: "vp-spin 0.9s linear infinite" }}>
+      <circle cx="12" cy="12" r="9" stroke={`${color}33`} strokeWidth="2" fill="none" />
+      <path d="M12 3a9 9 0 019 9" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}
+
+// ========== step indicator ==========
+function StepBar2({ current = 2, total = 4, labels = ["目標", "試練", "期日", "署名"] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        {Array.from({ length: total }).map((_, i) => {
+          const idx = i + 1;
+          const isActive = idx === current;
+          const isDone = idx < current;
+          return (
+            <React.Fragment key={i}>
+              <span
+                style={{
+                  width: isActive ? 26 : 8,
+                  height: 8,
+                  borderRadius: 4,
+                  background: isDone || isActive ? "#8b1a1a" : "rgba(44,24,16,0.18)",
+                }}
+              />
+              {i < total - 1 && <span style={{ width: 8, height: 1, background: "rgba(201,169,97,0.45)" }} />}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.4em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+        }}
+      >
+        STEP {current} / {total} · {labels[current - 1]}
+      </div>
+    </div>
+  );
+}
+
+// ========== rarity stars ==========
+function RarityStars({ value = 3, max = 5 }) {
+  return (
+    <span aria-label={`格 ${value}/${max}`} style={{ display: "inline-flex", alignItems: "center", gap: 2 }}>
+      {Array.from({ length: max }).map((_, i) => (
+        <Star key={i} filled={i < value} size={14} />
+      ))}
+    </span>
+  );
+}
+function Star({ filled, size = 14 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" aria-hidden="true">
+      <path
+        d="M7 1l1.6 4.3 4.4.3-3.4 3 1 4.4L7 10.6 3.4 13l1-4.4-3.4-3 4.4-.3z"
+        fill={filled ? "#8b1a1a" : "transparent"}
+        stroke={filled ? "#8b1a1a" : "#d4b8b8"}
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// ========== goal recap (read-only) ==========
+function GoalRecap() {
+  return (
+    <div
+      style={{
+        margin: "0 20px 18px",
+        padding: "10px 14px",
+        background: "rgba(255,255,255,0.6)",
+        border: "1px solid #d4c8b0",
+        borderLeft: "2px solid #8b1a1a",
+      }}
+    >
+      <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 3 }}>
+        あなたの目標
+      </div>
+      <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 14, color: "#2c1810", letterSpacing: "0.03em" }}>
+        TOEIC 800点を<ruby>達成<rt style={_rt2}>たっせい</rt></ruby>する
+      </div>
+    </div>
+  );
+}
+
+// ========== prompt ==========
+function Prompt2() {
+  return (
+    <div style={{ padding: "4px 24px 14px", textAlign: "center" }}>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          fontSize: "clamp(22px, 6.4vw, 26px)",
+          letterSpacing: "0.06em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+        }}
+      >
+        <ruby>達成<rt style={_rt2}>たっせい</rt></ruby>までの<ruby>試練<rt style={_rt2}>しれん</rt></ruby>を
+        <ruby>授<rt style={_rt2}>さず</rt></ruby>ける
+      </h2>
+      <div style={{ margin: "12px auto 0", width: 80, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+    </div>
+  );
+}
+
+// ========== textarea ==========
+function TrialTextarea({ value, onChange }) {
+  return (
+    <div style={{ position: "relative" }}>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="例：達成までSNSを1日30分以内に制限する"
+        rows={3}
+        style={{
+          width: "100%",
+          background: "#ffffff",
+          border: "1px solid #d4c8b0",
+          padding: "14px 16px",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 16,
+          lineHeight: 1.7,
+          color: "#2c1810",
+          resize: "vertical",
+          minHeight: 92,
+          boxSizing: "border-box",
+          letterSpacing: "0.02em",
+        }}
+        onFocus={(e) => (e.target.style.borderColor = "#8b6f47")}
+        onBlur={(e) => (e.target.style.borderColor = "#d4c8b0")}
+      />
+      <div style={{ position: "absolute", bottom: 8, right: 12, fontSize: 10, color: "#8b6f47", letterSpacing: "0.1em", pointerEvents: "none" }}>
+        {value.length}/120
+      </div>
+    </div>
+  );
+}
+
+// ========== gacha button ==========
+function GachaButton({ onClick, loading }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      style={{
+        width: "100%",
+        height: 52,
+        background:
+          "linear-gradient(180deg, #2c1810 0%, #3a2418 100%)",
+        color: "#fbf6ec",
+        border: "1px solid #2c1810",
+        outline: "1px solid #c9a961",
+        outlineOffset: "-4px",
+        borderRadius: 4,
+        fontSize: 15,
+        fontFamily: "'Noto Serif JP', serif",
+        fontWeight: 600,
+        letterSpacing: "0.18em",
+        cursor: loading ? "wait" : "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        boxShadow: "0 6px 16px -8px rgba(44,24,16,0.7)",
+        position: "relative",
+      }}
+      aria-label="AIから試練を授かる"
+    >
+      {loading ? <Spinner2 /> : <SwordsIcon size={18} color="#c9a961" />}
+      <span>
+        {loading ? (
+          <>
+            <ruby>試練<rt style={{ ..._rt2, color: "#c9a961" }}>しれん</rt></ruby>を
+            <ruby>授<rt style={{ ..._rt2, color: "#c9a961" }}>さず</rt></ruby>かり中…
+          </>
+        ) : (
+          <>
+            <ruby>試練<rt style={{ ..._rt2, color: "#c9a961" }}>しれん</rt></ruby>を
+            <ruby>授<rt style={{ ..._rt2, color: "#c9a961" }}>さず</rt></ruby>かる
+          </>
+        )}
+      </span>
+    </button>
+  );
+}
+
+// ========== trial card ==========
+function TrialCard({ index, text, rarity, selected, onToggle }) {
+  return (
+    <div
+      style={{
+        background: selected ? "#f4e8d0" : "#ffffff",
+        border: `1px solid ${selected ? "#8b6f47" : "#d4c8b0"}`,
+        outline: selected ? "1px solid #c9a961" : "none",
+        outlineOffset: "-4px",
+        position: "relative",
+        padding: "12px 14px 14px 44px",
+        transition: "all 0.15s",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 12,
+          left: 10,
+          width: 26,
+          height: 26,
+          borderRadius: "50%",
+          border: "1px solid #c9a961",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontSize: 12,
+          fontWeight: 600,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: selected ? "#fbf6ec" : "rgba(201,169,97,0.08)",
+        }}
+        aria-hidden="true"
+      >
+        {["Ⅰ", "Ⅱ", "Ⅲ", "Ⅳ", "Ⅴ"][index]}
+      </span>
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+        <span style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em" }}>
+          <ruby>難易度<rt style={{ fontSize: "0.55em", color: "#8b6f47" }}>なんいど</rt></ruby>
+        </span>
+        <RarityStars value={rarity} />
+      </div>
+
+      <p
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 15,
+          lineHeight: 1.6,
+          color: "#2c1810",
+          letterSpacing: "0.02em",
+          borderLeft: "2px solid #8b1a1a",
+          paddingLeft: 10,
+          marginBottom: 12,
+        }}
+      >
+        {text}
+      </p>
+
+      <button
+        onClick={onToggle}
+        aria-pressed={selected}
+        style={{
+          background: selected ? "#2c1810" : "transparent",
+          color: selected ? "#fbf6ec" : "#2c1810",
+          border: "1px solid #2c1810",
+          padding: "8px 14px",
+          fontSize: 12,
+          letterSpacing: "0.12em",
+          fontFamily: "'Noto Sans JP', sans-serif",
+          cursor: "pointer",
+          borderRadius: 2,
+        }}
+      >
+        {selected ? "✓ 選択中" : "これを選ぶ"}
+      </button>
+    </div>
+  );
+}
+
+// ========== footer ==========
+function StepFooter2({ canProceed, onBack, onNext }) {
+  return (
+    <footer
+      style={{
+        padding: "14px 20px 22px",
+        background: "rgba(251,246,236,0.85)",
+        borderTop: "1px solid #d4c8b0",
+        display: "grid",
+        gridTemplateColumns: "1fr 1.4fr",
+        gap: 10,
+      }}
+    >
+      <button
+        onClick={onBack}
+        style={{
+          height: 48,
+          background: "#ffffff",
+          border: "1px solid #d4c8b0",
+          color: "#2c1810",
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          letterSpacing: "0.12em",
+          cursor: "pointer",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+        }}
+      >
+        <ArrowIcon dir="left" />
+        戻る
+      </button>
+      <button
+        onClick={onNext}
+        disabled={!canProceed}
+        style={{
+          height: 48,
+          background: canProceed ? "#2c1810" : "#cfc4ad",
+          color: canProceed ? "#fbf6ec" : "#8b6f47aa",
+          border: `1px solid ${canProceed ? "#2c1810" : "#cfc4ad"}`,
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          cursor: canProceed ? "pointer" : "not-allowed",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          boxShadow: canProceed ? "0 6px 14px -8px rgba(44,24,16,0.6)" : "none",
+        }}
+      >
+        次へ進む
+        <ArrowIcon dir="right" color={canProceed ? "#fbf6ec" : "#8b6f47aa"} />
+      </button>
+    </footer>
+  );
+}
+
+// ========== screen ==========
+
+const TRIAL_SUGGESTIONS = [
+  { text: "SNSを1日30分以内に制限する", rarity: 2 },
+  { text: "平日は飲酒を断つ", rarity: 3 },
+  { text: "朝6時起床を厳守する", rarity: 4 },
+  { text: "動画配信サービスを全て解約する", rarity: 5 },
+  { text: "毎晩30分の英語学習を欠かさない", rarity: 2 },
+];
+
+function Step2Screen({ width = 412, initialMode = "empty" }) {
+  // empty | loading | suggestions | selected | filled | multi
+  const [mode, setMode] = useStep2State(initialMode);
+  const [value, setValue] = useStep2State(
+    initialMode === "filled" ? "達成までSNSを1日30分以内に制限する" : ""
+  );
+  const [selectedIdxs, setSelectedIdxs] = useStep2State(
+    initialMode === "selected" ? [0] :
+    initialMode === "multi" ? [0, 2] : []
+  );
+
+  const showSuggestions = mode === "suggestions" || mode === "selected" || mode === "multi";
+  const isLoading = mode === "loading";
+  const canProceed = value.trim().length > 0 || selectedIdxs.length > 0;
+
+  const handleGacha = () => {
+    setMode("loading");
+    setTimeout(() => setMode("suggestions"), 1100);
+  };
+
+  const toggle = (idx) => {
+    setSelectedIdxs((prev) => {
+      const next = prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx];
+      setMode(next.length > 1 ? "multi" : next.length === 1 ? "selected" : "suggestions");
+      return next;
+    });
+    setValue("");
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 900,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      <header style={{ padding: "20px 20px 14px", textAlign: "center" }}>
+        <StepBar2 current={2} />
+        <h1
+          style={{
+            margin: "18px 0 4px",
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 18,
+            letterSpacing: "0.18em",
+          }}
+        >
+          <ruby>契約書<rt style={_rt2}>けいやくしょ</rt></ruby>を<ruby>結<rt style={_rt2}>むす</rt></ruby>ぶ
+        </h1>
+        <p style={{ margin: 0, fontSize: 12, color: "#8b6f47", letterSpacing: "0.15em", fontFamily: "'Noto Serif JP', serif" }}>
+          Step 2：試練を定める
+        </p>
+      </header>
+
+      <GoalRecap />
+
+      <main style={{ flex: 1, padding: "0 20px 20px", display: "flex", flexDirection: "column" }}>
+        <Prompt2 />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <TrialTextarea
+            value={value}
+            onChange={(v) => {
+              setValue(v);
+              if (v) setSelectedIdxs([]);
+            }}
+          />
+
+          <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "4px 0" }}>
+            <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+            <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.4em", paddingLeft: "0.4em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600 }}>
+              OR
+            </span>
+            <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+          </div>
+
+          <GachaButton onClick={handleGacha} loading={isLoading} />
+          <p
+            style={{
+              margin: 0,
+              textAlign: "center",
+              fontSize: 11,
+              color: "#8b6f47",
+              fontFamily: "'Noto Sans JP', sans-serif",
+              letterSpacing: "0.04em",
+              lineHeight: 1.7,
+            }}
+          >
+            ★が多いほど、達成時の<ruby>紋章<rt style={{ fontSize: "0.7em", color: "#8b6f47" }}>もんしょう</rt></ruby>のレアリティが上がる
+          </p>
+        </div>
+
+        {isLoading && (
+          <div
+            style={{
+              marginTop: 22,
+              textAlign: "center",
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 13,
+              color: "#8b6f47",
+              fontStyle: "italic",
+              letterSpacing: "0.08em",
+              lineHeight: 1.8,
+            }}
+          >
+            <ruby>運命<rt style={_rt2}>うんめい</rt></ruby>の<ruby>賽<rt style={_rt2}>さい</rt></ruby>が<ruby>転<rt style={_rt2}>ころ</rt></ruby>がっている……
+          </div>
+        )}
+
+        {showSuggestions && (
+          <section style={{ marginTop: 24 }} aria-label="試練案">
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontFamily: "'Noto Serif JP', serif",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  letterSpacing: "0.15em",
+                  color: "#2c1810",
+                }}
+              >
+                <ruby>授<rt style={_rt2}>さず</rt></ruby>かりし<ruby>五<rt style={_rt2}>いつ</rt></ruby>つの<ruby>試練<rt style={_rt2}>しれん</rt></ruby>
+                {selectedIdxs.length > 0 && (
+                  <span style={{ marginLeft: 8, fontSize: 11, color: "#8b1a1a", letterSpacing: "0.1em" }}>
+                    （{selectedIdxs.length}件選択中）
+                  </span>
+                )}
+              </h3>
+              <button
+                onClick={handleGacha}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "#8b6f47",
+                  fontSize: 12,
+                  fontFamily: "'Noto Serif JP', serif",
+                  cursor: "pointer",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                ↻ もう一度引く
+              </button>
+            </div>
+            <div style={{ marginBottom: 8, fontSize: 11, color: "#8b6f47", letterSpacing: "0.04em" }}>
+              ※複数選択可
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {TRIAL_SUGGESTIONS.map((t, i) => (
+                <TrialCard
+                  key={i}
+                  index={i}
+                  text={t.text}
+                  rarity={t.rarity}
+                  selected={selectedIdxs.includes(i)}
+                  onToggle={() => toggle(i)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      <StepFooter2 canProceed={canProceed} onBack={() => {}} onNext={() => {}} />
+    </div>
+  );
+}
+
+if (typeof document !== "undefined" && !document.getElementById("vp-spin-style")) {
+  const s = document.createElement("style");
+  s.id = "vp-spin-style";
+  s.textContent = `@keyframes vp-spin { to { transform: rotate(360deg); } }`;
+  document.head.appendChild(s);
+}
+
+Object.assign(window, { Step2Screen });

--- a/docs/VowPact_mock/screens/step3-deadline.jsx
+++ b/docs/VowPact_mock/screens/step3-deadline.jsx
@@ -1,0 +1,543 @@
+/* global React */
+
+const { useState: useStep3State, useMemo: useStep3Memo } = React;
+const _rt3 = { fontSize: "0.45em", letterSpacing: "0.05em", color: "#8b6f47", fontWeight: 400 };
+
+// reference "today" so the calendar is deterministic
+const TODAY = new Date(2026, 4, 1); // 2026-05-01 (month is 0-indexed)
+const MIN_DATE = new Date(2026, 4, 8); // today + 7
+
+// ========== icons ==========
+function ArrowIcon3({ dir = "right", size = 14, color = "#2c1810" }) {
+  const rot = { right: 0, left: 180, up: -90, down: 90 }[dir];
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" style={{ transform: `rotate(${rot}deg)` }} fill="none" aria-hidden="true">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ========== step indicator ==========
+function StepBar3({ current = 3, total = 4, labels = ["目標", "試練", "期日", "署名"] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        {Array.from({ length: total }).map((_, i) => {
+          const idx = i + 1;
+          const isActive = idx === current;
+          const isDone = idx < current;
+          return (
+            <React.Fragment key={i}>
+              <span
+                style={{
+                  width: isActive ? 26 : 8,
+                  height: 8,
+                  borderRadius: 4,
+                  background: isDone || isActive ? "#8b1a1a" : "rgba(44,24,16,0.18)",
+                }}
+              />
+              {i < total - 1 && <span style={{ width: 8, height: 1, background: "rgba(201,169,97,0.45)" }} />}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.4em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+        }}
+      >
+        STEP {current} / {total} · {labels[current - 1]}
+      </div>
+    </div>
+  );
+}
+
+// ========== contract recap ==========
+function ContractRecap3({ goal, trials }) {
+  return (
+    <div
+      style={{
+        margin: "0 20px 14px",
+        padding: "10px 14px",
+        background: "rgba(255,255,255,0.6)",
+        border: "1px solid #d4c8b0",
+        borderLeft: "2px solid #8b1a1a",
+      }}
+    >
+      <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 3 }}>
+        あなたの目標
+      </div>
+      <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 14, color: "#2c1810", letterSpacing: "0.03em", marginBottom: 8 }}>
+        {goal}
+      </div>
+      <div style={{ fontSize: 9, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 3 }}>
+        授かりし試練（{trials.length}）
+      </div>
+      <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+        {trials.map((t, i) => (
+          <li
+            key={i}
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: 12,
+              color: "#3a2418",
+              letterSpacing: "0.02em",
+              lineHeight: 1.6,
+              paddingLeft: 12,
+              position: "relative",
+            }}
+          >
+            <span style={{ position: "absolute", left: 0, color: "#8b1a1a" }}>・</span>
+            {t}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ========== prompt ==========
+function Prompt3() {
+  return (
+    <div style={{ padding: "4px 24px 18px", textAlign: "center" }}>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "'Noto Serif JP', serif",
+          fontWeight: 600,
+          fontSize: "clamp(22px, 6.4vw, 26px)",
+          letterSpacing: "0.06em",
+          lineHeight: 1.5,
+          color: "#2c1810",
+        }}
+      >
+        いつまでに<ruby>達成<rt style={_rt3}>たっせい</rt></ruby>する？
+      </h2>
+      <div style={{ margin: "12px auto 0", width: 80, height: 1, background: "linear-gradient(to right, transparent, #c9a961, transparent)" }} />
+    </div>
+  );
+}
+
+// ========== preset chips ==========
+const PRESETS = [
+  { label: "7日後", days: 7 },
+  { label: "30日後", days: 30 },
+  { label: "90日後", days: 90 },
+  { label: "180日後", days: 180 },
+  { label: "1年後", days: 365 },
+];
+
+function PresetChips({ selectedDays, onSelect }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8, justifyContent: "center" }}>
+      {PRESETS.map((p) => {
+        const active = selectedDays === p.days;
+        return (
+          <button
+            key={p.days}
+            onClick={() => onSelect(p.days)}
+            aria-pressed={active}
+            style={{
+              padding: "8px 16px",
+              background: active ? "#2c1810" : "#ffffff",
+              color: active ? "#fbf6ec" : "#2c1810",
+              border: `1px solid ${active ? "#2c1810" : "#d4c8b0"}`,
+              outline: active ? "1px solid #c9a961" : "none",
+              outlineOffset: "-3px",
+              borderRadius: 999,
+              fontSize: 13,
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              letterSpacing: "0.08em",
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+          >
+            {p.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ========== calendar ==========
+function sameDay(a, b) {
+  return a && b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+function daysBetween(a, b) {
+  const ms = b.setHours(0, 0, 0, 0) - a.setHours(0, 0, 0, 0);
+  return Math.round(ms / (1000 * 60 * 60 * 24));
+}
+function addDays(d, n) {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
+}
+
+function Calendar({ value, onChange, viewMonth, onViewMonthChange }) {
+  const year = viewMonth.getFullYear();
+  const month = viewMonth.getMonth();
+  const firstOfMonth = new Date(year, month, 1);
+  const startWeekday = firstOfMonth.getDay(); // 0=Sun
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const prevMonthDays = new Date(year, month, 0).getDate();
+
+  const cells = [];
+  for (let i = 0; i < startWeekday; i++) {
+    cells.push({ day: prevMonthDays - startWeekday + i + 1, otherMonth: true, date: new Date(year, month - 1, prevMonthDays - startWeekday + i + 1) });
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({ day: d, otherMonth: false, date: new Date(year, month, d) });
+  }
+  while (cells.length % 7 !== 0) {
+    const d = cells.length - daysInMonth - startWeekday + 1;
+    cells.push({ day: d, otherMonth: true, date: new Date(year, month + 1, d) });
+  }
+
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+
+  return (
+    <div
+      style={{
+        background: "#ffffff",
+        border: "1px solid #d4c8b0",
+        padding: "14px 12px 10px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 6px 10px" }}>
+        <button
+          onClick={() => onViewMonthChange(new Date(year, month - 1, 1))}
+          aria-label="前の月"
+          style={{ background: "none", border: "1px solid #d4c8b0", borderRadius: 4, width: 28, height: 28, cursor: "pointer", display: "inline-flex", alignItems: "center", justifyContent: "center" }}
+        >
+          <ArrowIcon3 dir="left" size={12} color="#8b6f47" />
+        </button>
+        <div style={{ fontFamily: "'Noto Serif JP', serif", fontSize: 15, fontWeight: 600, letterSpacing: "0.1em", color: "#2c1810" }}>
+          {year}年 {month + 1}月
+        </div>
+        <button
+          onClick={() => onViewMonthChange(new Date(year, month + 1, 1))}
+          aria-label="次の月"
+          style={{ background: "none", border: "1px solid #d4c8b0", borderRadius: 4, width: 28, height: 28, cursor: "pointer", display: "inline-flex", alignItems: "center", justifyContent: "center" }}
+        >
+          <ArrowIcon3 dir="right" size={12} color="#8b6f47" />
+        </button>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 2, marginBottom: 4 }}>
+        {weekdays.map((w, i) => (
+          <div
+            key={w}
+            style={{
+              textAlign: "center",
+              fontSize: 10,
+              letterSpacing: "0.15em",
+              color: i === 0 ? "#8b1a1a" : i === 6 ? "#5b6f8b" : "#8b6f47",
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              padding: "4px 0",
+            }}
+          >
+            {w}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 2 }}>
+        {cells.map((c, i) => {
+          const isSelected = sameDay(value, c.date);
+          const isToday = sameDay(TODAY, c.date);
+          const tooEarly = c.date < MIN_DATE;
+          const disabled = c.otherMonth || tooEarly;
+          const dow = c.date.getDay();
+          const baseColor = c.otherMonth ? "#cdbfa0" : dow === 0 ? "#8b1a1a" : dow === 6 ? "#5b6f8b" : "#2c1810";
+          return (
+            <button
+              key={i}
+              onClick={() => !disabled && onChange(c.date)}
+              disabled={disabled}
+              style={{
+                aspectRatio: "1 / 1",
+                background: isSelected ? "#8b1a1a" : isToday ? "rgba(201,169,97,0.18)" : "transparent",
+                color: isSelected ? "#fbf6ec" : disabled ? "#cdbfa0" : baseColor,
+                border: isSelected ? "1px solid #6b1414" : isToday ? "1px solid #c9a961" : "1px solid transparent",
+                borderRadius: "50%",
+                fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+                fontSize: 14,
+                fontWeight: isSelected || isToday ? 600 : 500,
+                cursor: disabled ? "not-allowed" : "pointer",
+                opacity: tooEarly && !c.otherMonth ? 0.35 : 1,
+                position: "relative",
+                padding: 0,
+                lineHeight: 1,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              aria-label={`${c.date.getMonth() + 1}月${c.day}日`}
+            >
+              {c.day}
+              {isToday && !isSelected && (
+                <span
+                  style={{
+                    position: "absolute",
+                    bottom: 4,
+                    fontSize: 7,
+                    color: "#8b6f47",
+                    letterSpacing: "0.1em",
+                    fontFamily: "'Noto Serif JP', serif",
+                  }}
+                  aria-hidden="true"
+                >
+                  今日
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 8, padding: "6px 4px 0", borderTop: "1px dashed #e8dec6", display: "flex", gap: 12, fontSize: 9, color: "#8b6f47", letterSpacing: "0.08em", justifyContent: "center" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <span style={{ width: 8, height: 8, borderRadius: "50%", background: "#8b1a1a" }} />選択中
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <span style={{ width: 8, height: 8, borderRadius: "50%", border: "1px solid #c9a961", background: "rgba(201,169,97,0.18)" }} />今日
+        </span>
+        <span>※ 最短7日後から</span>
+      </div>
+    </div>
+  );
+}
+
+// ========== preview ==========
+function DatePreview({ date }) {
+  if (!date) {
+    return (
+      <div
+        style={{
+          padding: "18px 16px",
+          textAlign: "center",
+          background: "rgba(255,255,255,0.4)",
+          border: "1px dashed #d4c8b0",
+          color: "#8b6f47",
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 13,
+          letterSpacing: "0.08em",
+          fontStyle: "italic",
+        }}
+      >
+        期日が定まっていない
+      </div>
+    );
+  }
+  const days = daysBetween(new Date(TODAY), new Date(date));
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  return (
+    <div
+      style={{
+        padding: "18px 16px",
+        textAlign: "center",
+        background: "linear-gradient(180deg, #fbf6ec 0%, #f4e8d0 100%)",
+        border: "1px solid #c9a961",
+        outline: "1px solid #d4c8b0",
+        outlineOffset: "-5px",
+        position: "relative",
+      }}
+    >
+      <div style={{ fontSize: 9, letterSpacing: "0.5em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.5em", marginBottom: 8 }}>
+        DEADLINE · 期日
+      </div>
+      <div
+        style={{
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 22,
+          fontWeight: 600,
+          color: "#2c1810",
+          letterSpacing: "0.04em",
+          lineHeight: 1.4,
+        }}
+      >
+        {date.getFullYear()}年{date.getMonth() + 1}月{date.getDate()}日
+        <span style={{ fontSize: 14, color: "#8b6f47", marginLeft: 6 }}>（{weekdays[date.getDay()]}）</span>
+      </div>
+      <div
+        style={{
+          marginTop: 8,
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 13,
+          color: "#3a2418",
+          letterSpacing: "0.05em",
+        }}
+      >
+        まで <span style={{ color: "#8b1a1a", fontWeight: 700, fontSize: 28, fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", margin: "0 2px" }}>{days}</span> 日
+      </div>
+    </div>
+  );
+}
+
+// ========== footer ==========
+function StepFooter3({ canProceed, onBack, onNext }) {
+  return (
+    <footer
+      style={{
+        padding: "14px 20px 22px",
+        background: "rgba(251,246,236,0.85)",
+        borderTop: "1px solid #d4c8b0",
+        display: "grid",
+        gridTemplateColumns: "1fr 1.4fr",
+        gap: 10,
+      }}
+    >
+      <button
+        onClick={onBack}
+        style={{
+          height: 48,
+          background: "#ffffff",
+          border: "1px solid #d4c8b0",
+          color: "#2c1810",
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          letterSpacing: "0.12em",
+          cursor: "pointer",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+        }}
+      >
+        <ArrowIcon3 dir="left" />
+        戻る
+      </button>
+      <button
+        onClick={onNext}
+        disabled={!canProceed}
+        style={{
+          height: 48,
+          background: canProceed ? "#2c1810" : "#cfc4ad",
+          color: canProceed ? "#fbf6ec" : "#8b6f47aa",
+          border: `1px solid ${canProceed ? "#2c1810" : "#cfc4ad"}`,
+          fontSize: 14,
+          fontFamily: "'Noto Sans JP', sans-serif",
+          fontWeight: 600,
+          letterSpacing: "0.14em",
+          cursor: canProceed ? "pointer" : "not-allowed",
+          borderRadius: 4,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          boxShadow: canProceed ? "0 6px 14px -8px rgba(44,24,16,0.6)" : "none",
+        }}
+      >
+        次へ進む
+        <ArrowIcon3 dir="right" color={canProceed ? "#fbf6ec" : "#8b6f47aa"} />
+      </button>
+    </footer>
+  );
+}
+
+// ========== screen ==========
+
+const SAMPLE_GOAL = "TOEIC 800点を達成する";
+const SAMPLE_TRIALS = ["SNSを1日30分以内に制限する", "朝6時起床を厳守する"];
+
+function Step3Screen({ width = 412, initialMode = "empty" }) {
+  // empty | preset30 | preset365 | custom
+  const presetByMode = { preset30: 30, preset365: 365 };
+  const customDate = new Date(2026, 6, 15); // July 15
+
+  const initialDate =
+    initialMode === "preset30" ? addDays(TODAY, 30) :
+    initialMode === "preset365" ? addDays(TODAY, 365) :
+    initialMode === "custom" ? customDate : null;
+
+  const [date, setDate] = useStep3State(initialDate);
+  const [presetDays, setPresetDays] = useStep3State(presetByMode[initialMode] || null);
+  const [viewMonth, setViewMonth] = useStep3State(initialDate || new Date(TODAY.getFullYear(), TODAY.getMonth(), 1));
+
+  const onPreset = (days) => {
+    const d = addDays(TODAY, days);
+    setDate(d);
+    setPresetDays(days);
+    setViewMonth(new Date(d.getFullYear(), d.getMonth(), 1));
+  };
+
+  const onCalendarPick = (d) => {
+    setDate(d);
+    setPresetDays(null);
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1100,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      <header style={{ padding: "20px 20px 14px", textAlign: "center" }}>
+        <StepBar3 current={3} />
+        <h1
+          style={{
+            margin: "18px 0 4px",
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 18,
+            letterSpacing: "0.18em",
+          }}
+        >
+          <ruby>契約書<rt style={_rt3}>けいやくしょ</rt></ruby>を<ruby>結<rt style={_rt3}>むす</rt></ruby>ぶ
+        </h1>
+        <p style={{ margin: 0, fontSize: 12, color: "#8b6f47", letterSpacing: "0.15em", fontFamily: "'Noto Serif JP', serif" }}>
+          Step 3：期日を定める
+        </p>
+      </header>
+
+      <ContractRecap3 goal={SAMPLE_GOAL} trials={SAMPLE_TRIALS} />
+
+      <main style={{ flex: 1, padding: "0 20px 20px", display: "flex", flexDirection: "column" }}>
+        <Prompt3 />
+
+        {/* preview at top so it's visually anchored */}
+        <DatePreview date={date} />
+
+        {/* preset chips */}
+        <div style={{ marginTop: 18, marginBottom: 8 }}>
+          <div style={{ fontSize: 10, letterSpacing: "0.4em", color: "#8b6f47", fontWeight: 600, paddingLeft: "0.4em", marginBottom: 10, fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif" }}>
+            QUICK · 早見
+          </div>
+          <PresetChips selectedDays={presetDays} onSelect={onPreset} />
+        </div>
+
+        {/* divider */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "16px 0 12px" }}>
+          <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+          <span style={{ fontSize: 10, color: "#8b6f47", letterSpacing: "0.4em", paddingLeft: "0.4em", fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif", fontWeight: 600 }}>
+            OR
+          </span>
+          <span style={{ flex: 1, height: 1, background: "rgba(201,169,97,0.4)" }} />
+        </div>
+
+        {/* calendar */}
+        <Calendar value={date} onChange={onCalendarPick} viewMonth={viewMonth} onViewMonthChange={setViewMonth} />
+      </main>
+
+      <StepFooter3 canProceed={!!date} onBack={() => {}} onNext={() => {}} />
+    </div>
+  );
+}
+
+Object.assign(window, { Step3Screen });

--- a/docs/VowPact_mock/screens/step4-sign.jsx
+++ b/docs/VowPact_mock/screens/step4-sign.jsx
@@ -1,0 +1,562 @@
+/* global React, StarDivider, DifficultyStars, Seal, Signature, CornerOrnament, rtStyle */
+
+const { useState: useStep4State } = React;
+
+// ========== icons ==========
+function ArrowIcon4({ dir = "right", size = 14, color = "#2c1810" }) {
+  const rot = { right: 0, left: 180 }[dir];
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" style={{ transform: `rotate(${rot}deg)` }} fill="none" aria-hidden="true">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke={color} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ScaleIcon({ size = 18, color = "#c9a961" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M12 3v18M5 21h14M5 7l3 7h-6zM19 7l3 7h-6zM5 7h14M5 7L3 5M19 7l2-2"
+        stroke={color}
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="3" r="1.2" fill={color} />
+    </svg>
+  );
+}
+
+// ========== step indicator ==========
+function StepBar4({ current = 4, total = 4, labels = ["目標", "試練", "期日", "署名"] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        {Array.from({ length: total }).map((_, i) => {
+          const idx = i + 1;
+          const isActive = idx === current;
+          const isDone = idx < current;
+          return (
+            <React.Fragment key={i}>
+              <span
+                style={{
+                  width: isActive ? 26 : 8,
+                  height: 8,
+                  borderRadius: 4,
+                  background: isDone || isActive ? "#8b1a1a" : "rgba(44,24,16,0.18)",
+                }}
+              />
+              {i < total - 1 && <span style={{ width: 8, height: 1, background: "rgba(201,169,97,0.45)" }} />}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.4em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+        }}
+      >
+        STEP {current} / {total} · {labels[current - 1]}
+      </div>
+    </div>
+  );
+}
+
+// ========== unsigned contract card ==========
+
+const accentBodyStyle4 = {
+  fontFamily: "'Noto Serif JP', serif",
+  fontSize: 16,
+  lineHeight: 1.7,
+  color: "#2c1810",
+  borderLeft: "2px solid #8b1a1a",
+  padding: "2px 0 2px 12px",
+  margin: 0,
+  letterSpacing: "0.02em",
+};
+
+function Section4({ label, right, children }) {
+  return (
+    <section style={{ marginBottom: 18 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 10,
+            color: "#8b6f47",
+            letterSpacing: "0.45em",
+            fontWeight: 600,
+            paddingLeft: "0.45em",
+          }}
+        >
+          【{label}】
+        </h3>
+        {right}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function SealPlaceholder({ size = 64 }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        border: "1.5px dashed #c9a961",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "#a08866",
+        fontFamily: "'Noto Serif JP', serif",
+        fontSize: 9,
+        letterSpacing: "0.2em",
+        lineHeight: 1.3,
+        opacity: 0.7,
+        background: "rgba(255,255,255,0.25)",
+      }}
+    >
+      <span style={{ fontSize: 11, marginBottom: 2 }}>未</span>
+      <span>押印</span>
+    </div>
+  );
+}
+
+function StampedSeal({ animate = false }) {
+  return (
+    <div
+      style={{
+        animation: animate ? "vp-stamp 0.6s cubic-bezier(0.2, 1.4, 0.4, 1) 0.1s both" : "none",
+        transformOrigin: "center",
+      }}
+    >
+      <Seal size={64} rotate={-8} />
+    </div>
+  );
+}
+
+function UnsignedContractCard({ data, signer, sealed = false, sealAnimate = false }) {
+  const { no = "—", goal, trial, difficulty = 4, deadline } = data;
+  const showSignature = signer && signer.trim().length > 0;
+
+  return (
+    <article
+      aria-label="誓約契約書（草稿）"
+      style={{
+        position: "relative",
+        background: "#f4e8d0",
+        border: "0.5px solid #d4c8b0",
+        boxShadow: "0 1px 0 rgba(255,255,255,0.4) inset, 0 12px 28px -16px rgba(44,24,16,0.35), 0 2px 4px rgba(44,24,16,0.06)",
+        padding: "32px 22px 24px",
+        outline: "1px solid #c9a961",
+        outlineOffset: "-10px",
+      }}
+    >
+      <CornerOrnament position="tl" />
+      <CornerOrnament position="tr" />
+      <CornerOrnament position="bl" />
+      <CornerOrnament position="br" />
+
+      <header style={{ textAlign: "center", marginBottom: 14 }}>
+        <h2
+          style={{
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: "clamp(20px, 6vw, 26px)",
+            letterSpacing: "0.45em",
+            color: "#2c1810",
+            margin: 0,
+            paddingLeft: "0.45em",
+          }}
+        >
+          誓約契約書
+        </h2>
+        <p
+          style={{
+            margin: "8px 0 0",
+            fontSize: 10,
+            letterSpacing: "0.3em",
+            color: "#8b6f47",
+            fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          }}
+        >
+          VOW PACT &nbsp;·&nbsp; {sealed ? `No. ${no}` : "草稿"}
+        </p>
+      </header>
+
+      <div style={{ margin: "12px 4px 18px" }}>
+        <StarDivider />
+      </div>
+
+      <p
+        style={{
+          fontFamily: "'Noto Serif JP', serif",
+          fontSize: 14,
+          color: "#2c1810",
+          textAlign: "center",
+          letterSpacing: "0.08em",
+          margin: "0 0 22px",
+        }}
+      >
+        我、ここに以下を誓う。
+      </p>
+
+      <Section4 label="目標">
+        <p style={accentBodyStyle4}>{goal}</p>
+      </Section4>
+
+      <Section4
+        label="試練"
+        right={
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 9, color: "#8b6f47", letterSpacing: "0.25em" }}>
+              <ruby>難易度<rt style={{ fontSize: "0.55em", color: "#8b6f47" }}>なんいど</rt></ruby>
+            </span>
+            <DifficultyStars value={difficulty} />
+          </span>
+        }
+      >
+        <p style={accentBodyStyle4}>{trial}</p>
+      </Section4>
+
+      <Section4 label="期日">
+        <p style={accentBodyStyle4}>{deadline}</p>
+      </Section4>
+
+      <div
+        style={{
+          marginTop: 24,
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 9, letterSpacing: "0.3em", color: "#8b6f47", marginBottom: 8 }}>
+            契約者
+          </div>
+          <div
+            style={{
+              borderBottom: showSignature ? "1px solid #2c1810" : "1px dashed #a08866",
+              paddingBottom: 4,
+              minHeight: 36,
+              display: "flex",
+              alignItems: "flex-end",
+              transition: "border-color 0.2s",
+            }}
+          >
+            {showSignature ? (
+              <Signature name={signer} />
+            ) : (
+              <span
+                style={{
+                  fontFamily: "'Noto Serif JP', serif",
+                  fontStyle: "italic",
+                  fontSize: 14,
+                  color: "#a08866",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                ここに署名
+              </span>
+            )}
+          </div>
+        </div>
+        <div style={{ marginBottom: -4, marginRight: -2 }}>
+          {sealed ? <StampedSeal animate={sealAnimate} /> : <SealPlaceholder size={64} />}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+// ========== signature input ==========
+function SignatureInput({ value, onChange }) {
+  return (
+    <div>
+      <label
+        style={{
+          display: "block",
+          fontSize: 10,
+          letterSpacing: "0.4em",
+          color: "#8b6f47",
+          fontFamily: "'Cormorant Garamond', 'Noto Serif JP', serif",
+          fontWeight: 600,
+          paddingLeft: "0.4em",
+          marginBottom: 8,
+        }}
+      >
+        SIGNATURE · 契約者の名前
+      </label>
+      <div style={{ position: "relative" }}>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="名前を入力"
+          maxLength={32}
+          style={{
+            width: "100%",
+            background: "#ffffff",
+            border: "1px solid #d4c8b0",
+            padding: "14px 16px 14px 36px",
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 17,
+            color: "#2c1810",
+            letterSpacing: "0.05em",
+            boxSizing: "border-box",
+            borderRadius: 4,
+          }}
+          onFocus={(e) => (e.target.style.borderColor = "#8b6f47")}
+          onBlur={(e) => (e.target.style.borderColor = "#d4c8b0")}
+        />
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 12,
+            top: "50%",
+            transform: "translateY(-50%)",
+            fontFamily: "'Noto Serif JP', serif",
+            fontSize: 18,
+            color: "#8b6f47",
+            opacity: 0.5,
+          }}
+        >
+          ✎
+        </span>
+      </div>
+      <p
+        style={{
+          margin: "8px 0 0",
+          fontSize: 11,
+          color: "#8b6f47",
+          letterSpacing: "0.04em",
+          lineHeight: 1.6,
+        }}
+      >
+        この名前で契約書に署名されます。
+      </p>
+    </div>
+  );
+}
+
+// ========== vow button ==========
+function VowButton({ enabled, sealing, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={!enabled || sealing}
+      aria-label="ここに誓う"
+      style={{
+        width: "100%",
+        height: 64,
+        background: enabled ? "linear-gradient(180deg, #2c1810 0%, #3a2418 100%)" : "#cfc4ad",
+        color: enabled ? "#fbf6ec" : "#8b6f47aa",
+        border: `1px solid ${enabled ? "#2c1810" : "#cfc4ad"}`,
+        outline: enabled ? "1px solid #c9a961" : "none",
+        outlineOffset: "-5px",
+        borderRadius: 4,
+        fontSize: 17,
+        fontFamily: "'Noto Serif JP', serif",
+        fontWeight: 700,
+        letterSpacing: "0.3em",
+        cursor: enabled && !sealing ? "pointer" : sealing ? "wait" : "not-allowed",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 12,
+        boxShadow: enabled ? "0 10px 22px -10px rgba(44,24,16,0.7)" : "none",
+        position: "relative",
+        paddingLeft: "0.3em",
+      }}
+    >
+      <ScaleIcon size={20} color={enabled ? "#c9a961" : "#a89c84"} />
+      <span>{sealing ? "押印中…" : "ここに誓う"}</span>
+    </button>
+  );
+}
+
+// ========== screen ==========
+
+const sampleData = {
+  no: "001",
+  goal: (
+    <>
+      TOEIC 800<ruby>点<rt style={rtStyle}>てん</rt></ruby>を<ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>する
+    </>
+  ),
+  trial: (
+    <>
+      <ruby>達成<rt style={rtStyle}>たっせい</rt></ruby>まで、SNSを1日30分以内に<ruby>制限<rt style={rtStyle}>せいげん</rt></ruby>する
+    </>
+  ),
+  difficulty: 4,
+  deadline: (
+    <>
+      2026<ruby>年<rt style={rtStyle}>ねん</rt></ruby> 8<ruby>月<rt style={rtStyle}>がつ</rt></ruby> 2<ruby>日<rt style={rtStyle}>にち</rt></ruby> まで（あと92日）
+    </>
+  ),
+};
+
+function Step4Screen({ width = 412, initialMode = "prefilled" }) {
+  // empty | prefilled | edited | sealing | sealed
+  const [signer, setSigner] = useStep4State(
+    initialMode === "empty" ? "" :
+    initialMode === "edited" ? "Yuto Tanaka" :
+    "Yuto"
+  );
+  const [sealed, setSealed] = useStep4State(initialMode === "sealed");
+  const [sealing, setSealing] = useStep4State(initialMode === "sealing");
+
+  const enabled = signer.trim().length > 0 && !sealed;
+
+  const handleVow = () => {
+    setSealing(true);
+    setTimeout(() => {
+      setSealing(false);
+      setSealed(true);
+    }, 700);
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        minHeight: 1200,
+        background: "radial-gradient(ellipse at top, #fbf6ec 0%, #f1e7d2 100%)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Noto Sans JP', system-ui, sans-serif",
+        color: "#2c1810",
+      }}
+    >
+      <header style={{ padding: "20px 20px 14px", textAlign: "center" }}>
+        <StepBar4 current={4} />
+        <h1
+          style={{
+            margin: "18px 0 6px",
+            fontFamily: "'Noto Serif JP', serif",
+            fontWeight: 600,
+            fontSize: 18,
+            letterSpacing: "0.18em",
+          }}
+        >
+          内容を<ruby>確認<rt style={rtStyle}>かくにん</rt></ruby>して、<ruby>誓<rt style={rtStyle}>ちか</rt></ruby>いを立てる
+        </h1>
+        <p style={{ margin: 0, fontSize: 11, color: "#8b6f47", letterSpacing: "0.1em", fontFamily: "'Noto Serif JP', serif" }}>
+          Step 4：契約を成立させる
+        </p>
+      </header>
+
+      <div style={{ padding: "0 16px 18px" }}>
+        <UnsignedContractCard data={sampleData} signer={signer} sealed={sealed} sealAnimate={sealed && initialMode !== "sealed"} />
+      </div>
+
+      <div
+        style={{
+          margin: "0 20px",
+          padding: "20px 18px 22px",
+          background: "rgba(255,255,255,0.55)",
+          border: "1px solid #d4c8b0",
+          borderRadius: 4,
+          display: "flex",
+          flexDirection: "column",
+          gap: 18,
+        }}
+      >
+        <SignatureInput value={signer} onChange={setSigner} />
+        <VowButton enabled={enabled} sealing={sealing} onClick={handleVow} />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+            padding: "10px 12px",
+            background: "rgba(139,26,26,0.05)",
+            border: "1px solid rgba(139,26,26,0.18)",
+            borderRadius: 4,
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              textAlign: "center",
+              fontSize: 12,
+              color: "#8b1a1a",
+              letterSpacing: "0.06em",
+              fontFamily: "'Noto Serif JP', serif",
+              fontWeight: 600,
+              lineHeight: 1.6,
+            }}
+          >
+            ⚠ 契約成立後、<ruby>期日<rt style={rtStyle}>きじつ</rt></ruby>と<ruby>難易度<rt style={rtStyle}>なんいど</rt></ruby>は変更できません
+          </p>
+          <p
+            style={{
+              margin: 0,
+              textAlign: "center",
+              fontSize: 11,
+              color: "#8b6f47",
+              letterSpacing: "0.04em",
+              fontFamily: "'Noto Serif JP', serif",
+              lineHeight: 1.6,
+            }}
+          >
+            <ruby>目標<rt style={rtStyle}>もくひょう</rt></ruby>と<ruby>試練<rt style={rtStyle}>しれん</rt></ruby>の文言のみ後から編集可能です
+          </p>
+        </div>
+        <button
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#8b6f47",
+            fontSize: 13,
+            fontFamily: "'Noto Serif JP', serif",
+            cursor: "pointer",
+            letterSpacing: "0.06em",
+            padding: 0,
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            margin: "0 auto",
+            textDecoration: "underline",
+            textUnderlineOffset: 3,
+          }}
+        >
+          <ArrowIcon4 dir="left" size={11} color="#8b6f47" />
+          戻って修正する
+        </button>
+      </div>
+
+      <div style={{ height: 28 }} />
+    </div>
+  );
+}
+
+if (typeof document !== "undefined" && !document.getElementById("vp-stamp-style")) {
+  const s = document.createElement("style");
+  s.id = "vp-stamp-style";
+  s.textContent = `
+    @keyframes vp-stamp {
+      0% { transform: scale(2.5) rotate(-30deg); opacity: 0; }
+      40% { transform: scale(1.3) rotate(-12deg); opacity: 1; }
+      70% { transform: scale(0.92) rotate(-6deg); }
+      100% { transform: scale(1) rotate(-8deg); opacity: 1; }
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+Object.assign(window, { Step4Screen });

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -1,0 +1,1309 @@
+# Vow Pact - API 設計書
+
+このドキュメントは、目標達成アプリ「Vow Pact（誓約契約）」の REST API 設計をまとめたものです。
+
+## 目次
+
+- [共通方針](#共通方針)
+- [認証エンドポイント](#認証エンドポイント)（7つ）
+- [契約エンドポイント](#契約エンドポイント)（7つ）
+- [チェックインエンドポイント](#チェックインエンドポイント)（2つ）
+- [AI エンドポイント](#ai-エンドポイント)（5つ）
+- [ランキングエンドポイント](#ランキングエンドポイント)（2つ）
+- [設計判断の記録](#設計判断の記録)
+
+**全 23 エンドポイント**
+
+---
+
+## 共通方針
+
+### URL 規則
+
+すべてのエンドポイントに `/api/v1/` プレフィックスを付ける。
+
+- 認証関連: `/api/v1/auth/*`
+- リソース関連: `/api/v1/{resource}/*`
+- AI 関連: `/api/v1/ai/*`
+
+将来的に v2 を作る場合の拡張性を確保。
+
+### レスポンスのデータ構造
+
+データを直接返すシンプル形式。`data` キーでラップしない。
+
+### エラーレスポンスの形式
+
+詳細形式（`errors` 配列）を採用。
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "email",
+      "message": "は既に使用されています"
+    }
+  ]
+}
+```
+
+#### エラーコード一覧
+
+| コード | 用途 | 対応するステータスコード |
+|---|---|---|
+| `validation_error` | 入力値のバリデーションエラー | 422 |
+| `authentication_failed` | 認証失敗（パスワード違い等） | 401 |
+| `unauthorized` | 未ログイン | 401 |
+| `forbidden` | 権限なし | 403 |
+| `not_found` | リソースが存在しない | 404 |
+| `rate_limit_exceeded` | レート制限超過 | 429 |
+| `ai_service_error` | AI サービスエラー | 503 |
+| `internal_server_error` | サーバー内部エラー | 500 |
+
+### ステータスコードの使い分け
+
+#### 成功系
+
+| コード | 用途 |
+|---|---|
+| 200 OK | 通常の成功（GET、PATCH 等でデータを返すとき） |
+| 201 Created | 新規作成成功（POST） |
+| 202 Accepted | 非同期処理を受理（AI ジョブ投入） |
+| 204 No Content | 成功だがレスポンスボディ不要 |
+
+#### エラー系
+
+| コード | 用途 |
+|---|---|
+| 400 Bad Request | リクエストフォーマットが不正 |
+| 401 Unauthorized | 認証エラー |
+| 403 Forbidden | 認証はOKだが権限がない |
+| 404 Not Found | リソースが存在しない |
+| 422 Unprocessable Entity | バリデーションエラー |
+| 429 Too Many Requests | レート制限超過 |
+| 500 Internal Server Error | サーバー内部エラー |
+| 503 Service Unavailable | サービス一時的に利用不可（AI 失敗等） |
+
+### 認証方式
+
+セッションベース認証（Cookie）を採用。
+
+- Rails 8 標準の認証ジェネレータを利用
+- Cookie 属性: `HttpOnly`, `Secure`, `SameSite=Lax`
+- フロントエンド（React）は `credentials: 'include'` で Cookie を送信
+
+### User オブジェクトの形式
+
+```json
+{
+  "id": 1,
+  "email": "yuto@example.com",
+  "nickname": "Yuto",
+  "avatar_url": null,
+  "is_public": true,
+  "streak_count": 7,
+  "longest_streak": 14,
+  "created_at": "2026-05-02T10:30:00Z",
+  "updated_at": "2026-05-02T10:30:00Z"
+}
+```
+
+`password_digest` などの機密情報は含まない。
+
+#### 公開用の最小 User オブジェクト（ランキングなど）
+
+```json
+{
+  "id": 1,
+  "nickname": "Yuto",
+  "avatar_url": null
+}
+```
+
+email や is_public は他人には見せない。
+
+### Pact オブジェクトの形式
+
+#### 一覧表示用（軽量、ホーム画面向け）
+
+```json
+{
+  "id": 1,
+  "goal": "TOEIC 800点を達成する",
+  "constraint_text": "達成までSNSを1日30分以内に制限する",
+  "difficulty": 4,
+  "difficulty_reason": "...",
+  "deadline": "2026-08-02",
+  "status": "active",
+  "title": "沈黙の試練を背負いし者",
+  "signed_at": "2026-05-02T10:30:00Z",
+  "completed_at": null,
+  "days_remaining": 92,
+  "today_check_in": null,
+  "current_streak": 5,
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+#### 詳細表示用（追加情報付き、詳細画面向け）
+
+一覧表示用 + 以下を追加：
+- `completion_progress`: 達成進捗の詳細
+- `crest`: 紋章情報（completed の場合）
+
+#### 殿堂表示用（過去の契約向け）
+
+一覧表示用 + 以下：
+- `crest`: 紋章情報（completed の場合）
+- 不要な情報の除外: `today_check_in`, `current_streak`, `days_remaining`
+
+---
+
+## 認証エンドポイント
+
+### エンドポイント一覧
+
+| メソッド | パス | 役割 | 認証必須 |
+|---|---|---|---|
+| POST | `/api/v1/auth/signup` | 新規登録 | 不要 |
+| POST | `/api/v1/auth/login` | ログイン | 不要 |
+| DELETE | `/api/v1/auth/logout` | ログアウト | 必要 |
+| GET | `/api/v1/auth/me` | 自分の情報取得 | 必要 |
+| PATCH | `/api/v1/auth/me` | プロフィール更新 | 必要 |
+| PATCH | `/api/v1/auth/email` | メールアドレス変更 | 必要 |
+| PATCH | `/api/v1/auth/password` | パスワード変更 | 必要 |
+
+---
+
+### POST /api/v1/auth/signup（新規登録）
+
+新規ユーザーを作成し、自動的にログイン状態にする。
+
+#### リクエスト
+
+```json
+{
+  "user": {
+    "email": "yuto@example.com",
+    "password": "secure_password_123",
+    "password_confirmation": "secure_password_123",
+    "nickname": "Yuto"
+  }
+}
+```
+
+#### バリデーション
+
+- `email`: 必須、メール形式、UNIQUE
+- `password`: 必須、6文字以上
+- `password_confirmation`: 必須、`password` と一致
+- `nickname`: 必須、1-30文字
+
+#### レスポンス
+
+**成功時 (201 Created)**: User オブジェクト + Set-Cookie ヘッダー
+
+**バリデーションエラー時 (422)**: errors 配列
+
+---
+
+### POST /api/v1/auth/login（ログイン）
+
+#### リクエスト
+
+```json
+{
+  "email": "yuto@example.com",
+  "password": "secure_password_123"
+}
+```
+
+#### レスポンス
+
+**成功時 (200 OK)**: User オブジェクト + Set-Cookie ヘッダー
+
+**認証失敗時 (401 Unauthorized)**
+
+```json
+{
+  "errors": [
+    {
+      "code": "authentication_failed",
+      "field": null,
+      "message": "メールアドレスまたはパスワードが正しくありません"
+    }
+  ]
+}
+```
+
+セキュリティ上、「メールアドレスが間違っている」と「パスワードが間違っている」を区別しないメッセージを返す。
+
+---
+
+### DELETE /api/v1/auth/logout（ログアウト）
+
+#### リクエスト
+
+ボディなし。
+
+#### レスポンス
+
+**成功時 (204 No Content)**: ボディなし、Cookie 削除。
+
+---
+
+### GET /api/v1/auth/me（自分の情報取得）
+
+#### レスポンス
+
+**成功時 (200 OK)**: User オブジェクト
+**未ログイン時 (401)**: `unauthorized` エラー
+
+---
+
+### PATCH /api/v1/auth/me（プロフィール更新）
+
+ニックネーム、アバター画像URL、公開設定など、プロフィール情報のみ更新可能。
+
+#### リクエスト
+
+```json
+{
+  "user": {
+    "nickname": "Yuto Updated",
+    "avatar_url": "https://example.com/avatar.jpg",
+    "is_public": false
+  }
+}
+```
+
+#### バリデーション
+
+- `nickname`: 1-30文字（任意）
+- `avatar_url`: URL形式（任意、NULL 許容）
+- `is_public`: boolean（任意）
+
+`email` や `password` は Strong Parameters で受け付けない。
+
+#### レスポンス
+
+**成功時 (200 OK)**: 更新後の User オブジェクト
+
+---
+
+### PATCH /api/v1/auth/email（メールアドレス変更）
+
+本人確認のため現在のパスワードが必須。
+
+#### リクエスト
+
+```json
+{
+  "current_password": "secure_password_123",
+  "email": "newemail@example.com"
+}
+```
+
+#### レスポンス
+
+**成功時 (200 OK)**: 更新後の User オブジェクト
+
+**現在のパスワード不一致時 (401)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "authentication_failed",
+      "field": "current_password",
+      "message": "現在のパスワードが正しくありません"
+    }
+  ]
+}
+```
+
+---
+
+### PATCH /api/v1/auth/password（パスワード変更）
+
+#### リクエスト
+
+```json
+{
+  "current_password": "old_password_123",
+  "password": "new_password_456",
+  "password_confirmation": "new_password_456"
+}
+```
+
+#### レスポンス
+
+**成功時 (204 No Content)**: ボディなし
+
+**現在のパスワード不一致時 (401)**: `authentication_failed` エラー
+
+---
+
+## 契約エンドポイント
+
+### エンドポイント一覧
+
+| メソッド | パス | 役割 | 認証必須 |
+|---|---|---|---|
+| GET | `/api/v1/pacts` | active 契約一覧 | 必要 |
+| POST | `/api/v1/pacts` | 新規契約作成 | 必要 |
+| GET | `/api/v1/pacts/:id` | 契約詳細取得 | 必要 |
+| PATCH | `/api/v1/pacts/:id` | 契約編集（goal, constraint_text） | 必要 |
+| POST | `/api/v1/pacts/:id/abandon` | 契約破棄 | 必要 |
+| POST | `/api/v1/pacts/:id/complete` | 達成判定 | 必要 |
+| GET | `/api/v1/pacts/archived` | 殿堂用一覧 | 必要 |
+
+---
+
+### GET /api/v1/pacts（契約一覧取得）
+
+ホーム画面で表示する active な契約を取得する。
+
+#### レスポンス
+
+**成功時 (200 OK)**: 一覧表示用 Pact オブジェクトの配列
+
+```json
+[
+  {
+    "id": 1,
+    "goal": "TOEIC 800点を達成する",
+    "constraint_text": "達成までSNSを1日30分以内に制限する",
+    "difficulty": 4,
+    "difficulty_reason": "日常的な習慣を変える必要があるため",
+    "deadline": "2026-08-02",
+    "status": "active",
+    "title": "沈黙の試練を背負いし者",
+    "signed_at": "2026-05-02T10:30:00Z",
+    "completed_at": null,
+    "days_remaining": 92,
+    "today_check_in": {
+      "id": 100,
+      "checked_on": "2026-05-02",
+      "status": "kept",
+      "note": null
+    },
+    "current_streak": 5,
+    "created_at": "2026-05-02T10:30:00Z",
+    "updated_at": "2026-05-02T10:30:00Z"
+  }
+]
+```
+
+---
+
+### POST /api/v1/pacts（新規契約作成）
+
+#### リクエスト
+
+```json
+{
+  "pact": {
+    "goal": "TOEIC 800点を達成する",
+    "constraint_text": "達成までSNSを1日30分以内に制限する",
+    "difficulty": 4,
+    "difficulty_reason": "日常的な習慣を変える必要があるため",
+    "deadline": "2026-08-02",
+    "title": "沈黙の試練を背負いし者"
+  }
+}
+```
+
+#### バリデーション
+
+- `goal`: 必須、1-500文字
+- `constraint_text`: 必須、1-500文字
+- `difficulty`: 必須、1-5の整数
+- `difficulty_reason`: 任意
+- `deadline`: 必須、未来の日付
+- `title`: 任意
+
+ビジネスルール：active 状態の契約は3つまで。
+
+#### レスポンス
+
+**成功時 (201 Created)**: 一覧表示用 Pact オブジェクト
+
+`signed_at` はサーバー側で自動セット。
+
+**3つ上限超過時 (422)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "base",
+      "message": "active状態の契約は3つまでです"
+    }
+  ]
+}
+```
+
+---
+
+### GET /api/v1/pacts/:id（契約詳細取得）
+
+#### レスポンス
+
+**成功時 (200 OK)**: 詳細表示用 Pact オブジェクト
+
+```json
+{
+  "id": 1,
+  "goal": "TOEIC 800点を達成する",
+  ...
+  "completion_progress": {
+    "total_days": 92,
+    "kept_days": 5,
+    "broken_days": 0,
+    "skipped_days": 0,
+    "missing_days": 87,
+    "compliance_rate": 1.0
+  },
+  "crest": null
+}
+```
+
+`completed` な契約の場合、`crest` には紋章情報が含まれる。
+
+**存在しない / 他人の契約の場合 (404)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "not_found",
+      "field": null,
+      "message": "契約が見つかりません"
+    }
+  ]
+}
+```
+
+セキュリティ上、「他人の契約」と「存在しない契約」を区別しないメッセージにする。
+
+---
+
+### PATCH /api/v1/pacts/:id（契約編集）
+
+仕様により、編集可能なのは `goal` と `constraint_text` のみ。
+
+#### リクエスト
+
+```json
+{
+  "pact": {
+    "goal": "TOEIC 850点を達成する",
+    "constraint_text": "達成までSNSを1日20分以内に制限する"
+  }
+}
+```
+
+#### バリデーション
+
+- `goal`: 1-500文字（送られてきた場合）
+- `constraint_text`: 1-500文字（送られてきた場合）
+- **status が active のときのみ編集可能**
+
+#### レスポンス
+
+**成功時 (200 OK)**: 一覧表示用 Pact オブジェクト
+
+**非active な契約を編集しようとした時 (422)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "base",
+      "message": "完了または破棄された契約は編集できません"
+    }
+  ]
+}
+```
+
+---
+
+### POST /api/v1/pacts/:id/abandon（契約破棄）
+
+#### リクエスト
+
+ボディなし。
+
+#### バリデーション
+
+- 自分の契約か
+- `active` 状態か
+
+#### レスポンス
+
+**成功時 (200 OK)**: 一覧表示用 Pact オブジェクト（status が `abandoned` に変更）
+
+**非active な契約を破棄しようとした時 (422)**: バリデーションエラー
+
+---
+
+### POST /api/v1/pacts/:id/complete（達成判定）
+
+達成判定を実行する。チェックイン作成時の自動判定 + ユーザー手動の両方で利用。
+
+#### 達成条件（寛容モード）
+
+- 期日が今日以前
+- 期日までの全日に対して、チェックインが何らかの形で記録されている（kept / broken / skipped 問わず）
+
+#### 達成時の連鎖処理
+
+1つのトランザクションで実行：
+
+1. Pact.status を `completed` に変更
+2. Pact.completed_at に現在時刻をセット
+3. Crest を生成（紋章データの作成、レアリティ計算）
+
+#### リクエスト
+
+ボディなし。
+
+#### レスポンス
+
+**成功時 (200 OK)**: 詳細表示用 Pact オブジェクト + 紋章情報
+
+```json
+{
+  "id": 1,
+  "status": "completed",
+  "completed_at": "2026-08-02T15:00:00Z",
+  "crest": {
+    "id": 50,
+    "crest_data": {...},
+    "rarity": "epic",
+    "generated_at": "2026-08-02T15:00:00Z"
+  },
+  ...
+}
+```
+
+**達成条件を満たしていない時 (422)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "base",
+      "message": "達成条件を満たしていません",
+      "details": {
+        "missing_check_in_days": 5,
+        "total_required_days": 92,
+        "recorded_days": 87
+      }
+    }
+  ]
+}
+```
+
+**期日前に達成しようとした時 (422)**: バリデーションエラー
+
+---
+
+### GET /api/v1/pacts/archived(殿堂用一覧)
+
+`completed` と `failed` の契約一覧を取得する。
+`abandoned` は含まれない。
+
+#### クエリパラメータ（任意）
+
+| パラメータ | 値 | デフォルト | 説明 |
+|---|---|---|---|
+| `status` | `completed` / `failed` / `all` | `all` | フィルタ |
+| `sort` | `completed_at` / `rarity` / `difficulty` | `completed_at` | ソート順 |
+
+#### 仕様
+
+- 全件返す（最大100件）
+- ソート順デフォルト：`completed_at DESC`（新しい順）
+
+#### レスポンス
+
+**成功時 (200 OK)**: 殿堂表示用 Pact オブジェクトの配列
+
+```json
+[
+  {
+    "id": 50,
+    "goal": "TOEIC 800点を達成する",
+    "constraint_text": "達成までSNSを1日30分以内に制限する",
+    "difficulty": 4,
+    "deadline": "2026-08-02",
+    "status": "completed",
+    "title": "沈黙の試練を背負いし者",
+    "signed_at": "2026-05-02T10:30:00Z",
+    "completed_at": "2026-08-02T15:00:00Z",
+    "crest": {
+      "id": 10,
+      "crest_data": {...},
+      "rarity": "epic",
+      "generated_at": "2026-08-02T15:00:00Z"
+    },
+    "created_at": "2026-05-02T10:30:00Z",
+    "updated_at": "2026-08-02T15:00:00Z"
+  }
+]
+```
+
+`failed` の場合は `crest` は `null`。
+
+---
+
+## チェックインエンドポイント
+
+### エンドポイント一覧
+
+| メソッド | パス | 役割 | 認証必須 |
+|---|---|---|---|
+| POST | `/api/v1/pacts/:pact_id/check_ins` | 記録 / 更新 | 必要 |
+| GET | `/api/v1/pacts/:pact_id/check_ins` | 履歴取得 | 必要 |
+
+ネスト構造：チェックインは必ず特定の Pact に紐づくため、`/pacts/:pact_id/check_ins` の形式。
+
+---
+
+### POST /api/v1/pacts/:pact_id/check_ins（記録 / 更新）
+
+「守れた / 守れなかった / スキップ」の記録を作成または更新する。
+ユニーク制約 `(pact_id, checked_on)` により、サーバー側で自動的に「作成 or 更新」を判定。
+
+達成判定も自動実行：チェックイン後に達成条件を満たしていれば、Pact.status を `completed` に変更し、紋章を生成。
+
+#### リクエスト
+
+```json
+{
+  "check_in": {
+    "status": "kept",
+    "note": "今日も継続できた。気分よし。"
+  }
+}
+```
+
+`checked_on` はサーバー側で `Date.current` を自動セット。
+
+#### バリデーション
+
+- `status`: 必須、enum 値（`kept` / `broken` / `skipped`）
+- `note`: 任意、500文字以内
+- 該当 Pact が自分のものか
+- 該当 Pact が `active` 状態か
+
+#### レスポンス
+
+**成功時 (200 OK) - 達成しなかった場合**
+
+```json
+{
+  "check_in": {
+    "id": 100,
+    "pact_id": 1,
+    "checked_on": "2026-05-02",
+    "status": "kept",
+    "note": "今日も継続できた。気分よし。",
+    "created_at": "2026-05-02T22:00:00Z",
+    "updated_at": "2026-05-02T22:00:00Z"
+  },
+  "pact": {
+    "id": 1,
+    "current_streak": 6,
+    "completion_progress": {
+      "total_days": 92,
+      "kept_days": 6,
+      "broken_days": 0,
+      "skipped_days": 0,
+      "missing_days": 86,
+      "compliance_rate": 1.0
+    }
+  },
+  "user": {
+    "streak_count": 6,
+    "longest_streak": 14
+  },
+  "achievement": null
+}
+```
+
+**成功時 (200 OK) - 達成した場合**
+
+`achievement` フィールドに達成情報が含まれる：
+
+```json
+{
+  "check_in": {...},
+  "pact": {
+    "id": 1,
+    "status": "completed",
+    "completed_at": "2026-08-02T22:00:00Z",
+    "current_streak": 92
+  },
+  "user": {
+    "streak_count": 92,
+    "longest_streak": 92
+  },
+  "achievement": {
+    "achieved": true,
+    "crest": {
+      "id": 50,
+      "crest_data": {...},
+      "rarity": "epic",
+      "generated_at": "2026-08-02T22:00:00Z"
+    },
+    "title": "沈黙の試練を背負いし者"
+  }
+}
+```
+
+フロントはこのレスポンスを受け取ったら、達成演出画面に遷移できる。
+
+**バリデーションエラー時 (422)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "status",
+      "message": "は kept、broken、skipped のいずれかにしてください"
+    }
+  ]
+}
+```
+
+**非active な契約にチェックインしようとした時 (422)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "base",
+      "message": "完了または破棄された契約にはチェックインできません"
+    }
+  ]
+}
+```
+
+---
+
+### GET /api/v1/pacts/:pact_id/check_ins（履歴取得）
+
+契約の詳細画面でカレンダー表示する用のチェックイン履歴を取得。
+
+#### レスポンス
+
+**成功時 (200 OK)**: チェックインの配列（`checked_on DESC`）
+
+```json
+[
+  {
+    "id": 100,
+    "pact_id": 1,
+    "checked_on": "2026-05-02",
+    "status": "kept",
+    "note": "今日も継続できた。気分よし。",
+    "created_at": "2026-05-02T22:00:00Z",
+    "updated_at": "2026-05-02T22:00:00Z"
+  },
+  {
+    "id": 99,
+    "pact_id": 1,
+    "checked_on": "2026-05-01",
+    "status": "kept",
+    "note": null,
+    "created_at": "2026-05-01T21:30:00Z",
+    "updated_at": "2026-05-01T21:30:00Z"
+  }
+]
+```
+
+全期間返す（契約開始から今日まで）。
+
+---
+
+## AI エンドポイント
+
+非同期処理を採用。OpenAI API への呼び出しは Solid Queue でバックグラウンドジョブとして実行。
+
+### エンドポイント一覧
+
+| メソッド | パス | 役割 | 認証必須 |
+|---|---|---|---|
+| POST | `/api/v1/ai/goals` | 目標案ジョブ投入 | 必要 |
+| POST | `/api/v1/ai/constraints` | 制約案ジョブ投入 | 必要 |
+| POST | `/api/v1/ai/difficulty` | 難易度判定ジョブ投入 | 必要 |
+| POST | `/api/v1/ai/title` | 称号生成ジョブ投入 | 必要 |
+| GET | `/api/v1/ai/jobs/:job_id` | ジョブ結果取得 | 必要 |
+
+### 共通仕様
+
+- レート制限：1ユーザーあたり1分間に10回まで
+- ジョブ ID 形式：`ai_job_{generation_id}`（generation_id は AiGeneration テーブルの ID）
+- 他人のジョブにはアクセス不可（404）
+
+---
+
+### POST /api/v1/ai/goals（目標案ジョブ投入）
+
+「天啓を受ける」ボタンに対応。ユーザーが入力したキーワードから3つの目標案を生成。
+
+#### リクエスト
+
+```json
+{
+  "user_input": "英語を頑張る"
+}
+```
+
+#### バリデーション
+
+- `user_input`: 必須、1-200文字
+
+#### レスポンス
+
+**成功時 (202 Accepted)**
+
+```json
+{
+  "job_id": "ai_job_123",
+  "status": "pending",
+  "estimated_seconds": 5
+}
+```
+
+**レート制限超過時 (429)**:
+
+```json
+{
+  "errors": [
+    {
+      "code": "rate_limit_exceeded",
+      "field": null,
+      "message": "AIの利用制限を超えました。少し時間をおいてからお試しください。"
+    }
+  ]
+}
+```
+
+---
+
+### POST /api/v1/ai/constraints（制約案ジョブ投入）
+
+「試練を授かる」ボタンに対応。選んだ目標から3つの試練案を生成。
+
+#### リクエスト
+
+```json
+{
+  "goal": "TOEIC 800点を3ヶ月で達成する"
+}
+```
+
+#### バリデーション
+
+- `goal`: 必須、1-500文字
+
+#### レスポンス
+
+**成功時 (202 Accepted)**: 同上のジョブ投入レスポンス
+
+---
+
+### POST /api/v1/ai/difficulty（難易度判定ジョブ投入）
+
+ユーザーが自由入力した制約に対して、難易度を判定する。
+
+#### リクエスト
+
+```json
+{
+  "goal": "TOEIC 800点を3ヶ月で達成する",
+  "constraint_text": "達成までSNSを完全に断つ",
+  "deadline": "2026-08-02"
+}
+```
+
+#### バリデーション
+
+- `goal`: 必須、1-500文字
+- `constraint_text`: 必須、1-500文字
+- `deadline`: 必須、未来の日付
+
+#### レスポンス
+
+**成功時 (202 Accepted)**: 同上のジョブ投入レスポンス
+
+---
+
+### POST /api/v1/ai/title（称号生成ジョブ投入）
+
+契約締結時に生成される称号。
+
+#### リクエスト
+
+```json
+{
+  "goal": "TOEIC 800点を3ヶ月で達成する",
+  "constraint_text": "達成までSNSを1日30分以内に制限する",
+  "difficulty": 4
+}
+```
+
+#### レスポンス
+
+**成功時 (202 Accepted)**: 同上のジョブ投入レスポンス
+
+---
+
+### GET /api/v1/ai/jobs/:job_id（ジョブ結果取得）
+
+ジョブの状態と結果を取得する。フロントエンドはポーリングで使用。
+
+#### リクエスト
+
+```http
+GET /api/v1/ai/jobs/ai_job_123
+Cookie: _vow_pact_session=...
+```
+
+#### レスポンス
+
+**処理中の場合 (200 OK)**
+
+```json
+{
+  "job_id": "ai_job_123",
+  "status": "processing",
+  "started_at": "2026-05-02T22:00:00Z"
+}
+```
+
+**完了した場合 (200 OK)**
+
+ジョブの種類によって `result` の中身が変わる。
+
+**目標生成 / 制約生成の場合**:
+
+```json
+{
+  "job_id": "ai_job_123",
+  "status": "completed",
+  "completed_at": "2026-05-02T22:00:05Z",
+  "result": {
+    "generation_id": 123,
+    "options": [
+      "TOEIC 800点を3ヶ月で達成する",
+      "毎日30分英会話アプリで学習する習慣を90日続ける",
+      "英語の本を3冊読破する（30日以内）"
+    ]
+  }
+}
+```
+
+**難易度判定の場合**:
+
+```json
+{
+  "job_id": "ai_job_125",
+  "status": "completed",
+  "completed_at": "2026-05-02T22:00:05Z",
+  "result": {
+    "generation_id": 125,
+    "difficulty": 4,
+    "reason": "SNSを完全に断つことは現代人にとって極めて難しく..."
+  }
+}
+```
+
+**称号生成の場合**:
+
+```json
+{
+  "job_id": "ai_job_126",
+  "status": "completed",
+  "completed_at": "2026-05-02T22:00:05Z",
+  "result": {
+    "generation_id": 126,
+    "title": "沈黙の試練を背負いし者"
+  }
+}
+```
+
+**失敗した場合 (200 OK)**
+
+```json
+{
+  "job_id": "ai_job_123",
+  "status": "failed",
+  "failed_at": "2026-05-02T22:00:10Z",
+  "error": {
+    "code": "ai_service_error",
+    "message": "AIが応答できませんでした。もう一度お試しください。"
+  }
+}
+```
+
+ステータスが `failed` でも、エンドポイント自体は 200 OK で返す（ジョブの状態取得は成功している）。
+
+**他人のジョブを取りに行ったら (404)**: `not_found` エラー
+
+---
+
+## ランキングエンドポイント
+
+### エンドポイント一覧
+
+| メソッド | パス | 役割 | 認証必須 |
+|---|---|---|---|
+| GET | `/api/v1/rankings/monthly` | 今月の達成数ランキング | 必要 |
+| GET | `/api/v1/rankings/streak` | 連続日数ランキング | 必要 |
+
+### 共通仕様
+
+- 上位10位まで返す
+- `is_public = true` のユーザーのみランキングに表示
+- 自分の順位（`my_rank`）は、`is_public` の値に関係なく自分には表示
+- 自分が10位以内なら `rank` 入り、圏外なら `rank: null`
+
+---
+
+### GET /api/v1/rankings/monthly（今月の達成数ランキング）
+
+今月の達成数（completed_at が今月の Pact の数）でランキング。
+
+#### レスポンス
+
+**成功時 (200 OK)**
+
+```json
+{
+  "month": "2026-05",
+  "rankings": [
+    {
+      "rank": 1,
+      "user": {
+        "id": 5,
+        "nickname": "Alice",
+        "avatar_url": "https://example.com/alice.jpg"
+      },
+      "achievement_count": 12
+    },
+    {
+      "rank": 2,
+      "user": {
+        "id": 7,
+        "nickname": "Bob",
+        "avatar_url": null
+      },
+      "achievement_count": 8
+    }
+  ],
+  "my_rank": {
+    "rank": 3,
+    "achievement_count": 5
+  }
+}
+```
+
+**自分が圏外の場合**:
+
+```json
+{
+  "month": "2026-05",
+  "rankings": [...],
+  "my_rank": {
+    "rank": null,
+    "achievement_count": 2
+  }
+}
+```
+
+---
+
+### GET /api/v1/rankings/streak（連続日数ランキング）
+
+連続チェックイン日数（User.streak_count）でランキング。
+
+#### レスポンス
+
+**成功時 (200 OK)**
+
+```json
+{
+  "rankings": [
+    {
+      "rank": 1,
+      "user": {
+        "id": 9,
+        "nickname": "Carol",
+        "avatar_url": "https://example.com/carol.jpg"
+      },
+      "streak_count": 156
+    },
+    {
+      "rank": 2,
+      "user": {
+        "id": 5,
+        "nickname": "Alice",
+        "avatar_url": "https://example.com/alice.jpg"
+      },
+      "streak_count": 89
+    }
+  ],
+  "my_rank": {
+    "rank": 3,
+    "streak_count": 45
+  }
+}
+```
+
+`monthly` ランキングと違い、`month` フィールドはない。
+
+---
+
+## 設計判断の記録
+
+### 共通方針
+
+#### 判断1: URL に `/api/v1/` プレフィックスを付ける
+
+将来の API バージョン管理のため。実務でほぼ標準。
+
+#### 判断2: レスポンスのデータ構造はシンプル形式
+
+`data` キーでラップせず、データを直接返す。
+
+#### 判断3: エラーレスポンスは詳細形式（errors 配列）
+
+複数エラー対応、フィールド指定が可能。実務標準。
+
+#### 判断4: セッションベース認証を採用
+
+Rails 8 標準ジェネレータが対応、同一ドメインで動くアプリ向け。JWT は採用しない。
+
+### 認証関連
+
+#### 判断5: プロフィール更新と認証情報変更を分離
+
+セキュリティ要件が違うため。メール・パスワード変更は現在のパスワード必須。
+
+#### 判断6: ログイン失敗時のメッセージは曖昧に
+
+セキュリティ上、メールアドレスの存在を漏らさないため。
+
+### 契約関連
+
+#### 判断7: 状態変更は専用エンドポイントを使う
+
+`POST /pacts/:id/abandon`、`POST /pacts/:id/complete` を専用エンドポイントとして用意。Rails の `member action` の慣例に沿う。
+
+#### 判断8: 一覧と詳細でレスポンス形式を変える
+
+ケースごとに必要な情報を出すことで、レスポンスサイズを最適化。
+
+#### 判断9: 殿堂用一覧は別エンドポイント
+
+`GET /pacts/archived` を別エンドポイントとして用意。明示的でフロントの実装が分かりやすい。
+
+#### 判断10: 達成判定は両方実装
+
+チェックイン作成時の自動判定 + 手動エンドポイント。バグの保険、運用上の柔軟性。
+
+#### 判断11: 達成条件は寛容モード
+
+`broken` の日があっても、チェックイン記録があれば達成扱い。ユーザーフレンドリー。
+
+#### 判断12: 破棄時の理由は保存しない
+
+シンプルさ優先。将来必要になったらカラム追加で対応。
+
+#### 判断13: 殿堂は全件返す（最大100件）
+
+ページング対応はせず、最大100件まで全件返す。MVP のシンプルさ優先。
+
+#### 判断14: 複数制約は MVP 範囲外
+
+1契約 = 1制約のまま。複数制約を持ちたいユーザーは複数契約（最大3つ active）で表現。
+
+### チェックイン関連
+
+#### 判断15: 作成と更新を1つのエンドポイントに統合
+
+ユニーク制約 `(pact_id, checked_on)` があるため、サーバー側で「作成 or 更新」を自動判定。フロントは常に POST するだけ。
+
+#### 判断16: ステータスコードは常に 200 OK
+
+作成も更新もシンプルさ優先。201 と 200 の使い分けはしない。
+
+#### 判断17: checked_on はサーバー側で自動設定
+
+ユーザーは「今日」のチェックインしかできない。チート防止、シンプル化。
+
+#### 判断18: 履歴は全期間返す
+
+最大365件なので、データ量はそれほど大きくない。フロントで月切り替えできる。
+
+### AI 関連
+
+#### 判断19: 非同期処理を採用（Solid Queue）
+
+OpenAI API への呼び出しを Solid Queue でバックグラウンドジョブとして実行。学習価値高い、Rails 8 標準機能の活用。
+
+#### 判断20: ジョブ結果取得は共通エンドポイント
+
+`GET /api/v1/ai/jobs/:job_id` で全種類のジョブ結果を取得。エンドポイント数を増やさない。
+
+#### 判断21: レート制限を実装
+
+1ユーザーあたり1分間に10回まで。AI 利用コスト保護のため。
+
+#### 判断22: 失敗もステータスコード 200 で返す
+
+ジョブの状態取得自体は成功している。`status: 'failed'` フィールドで判別。
+
+### ランキング関連
+
+#### 判断23: ランキングは「今月達成数」と「連続日数」のみ
+
+先行者有利を排除するため、累計レアリティはランキングから外す。個人記録としては保持。
+
+#### 判断24: 上位10位まで返す
+
+実務でよくある「Top 10」表示。データ量も少なくて済む。
+
+#### 判断25: is_public = false のユーザーは非表示
+
+プライバシー配慮。ただし自分の順位は自分には見える。
+
+#### 判断26: 圏外の自分は rank: null で返す
+
+10位以内でない場合、計算コストをかけずに `rank: null` を返す。`achievement_count` や `streak_count` は計算して返す。
+
+---
+
+## 参考資料
+
+- [Rails 8 ガイド](https://guides.rubyonrails.org/)
+- [REST API Design Best Practices](https://restfulapi.net/)
+- [HTTP ステータスコード - MDN](https://developer.mozilla.org/ja/docs/Web/HTTP/Status)
+- [Solid Queue](https://github.com/rails/solid_queue)
+- データモデル設計: `docs/data_model.md`
+
+---
+
+**最終更新**: 2026年5月2日（全23エンドポイント設計完了）

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -1,0 +1,688 @@
+# Vow Pact - データモデル設計
+
+このドキュメントは、目標達成アプリ「Vow Pact（誓約契約）」のデータベーステーブル設計をまとめたものです。
+
+## 目次
+
+- [概要](#概要)
+- [テーブル一覧](#テーブル一覧)
+- [リレーション全体図](#リレーション全体図)
+- [テーブル詳細](#テーブル詳細)
+  - [users](#users)
+  - [pacts](#pacts)
+  - [check_ins](#check_ins)
+  - [crests](#crests)
+  - [ai_generations](#ai_generations)
+- [設計判断の記録](#設計判断の記録)
+
+---
+
+## 概要
+
+### 技術スタック
+
+- **DBエンジン**: PostgreSQL 18（Neon Free Plan）
+- **ORM**: Active Record（Rails 8）
+- **マイグレーション管理**: Rails 標準
+- **テスト**: RSpec + factory_bot
+
+### 設計方針
+
+- **正規化を基本**とするが、表示頻度の高い情報はキャッシュとして保持
+- **DB レベルのバリデーション** + **Rails レベルのバリデーション**を併用
+- **enum** で状態管理を明確化
+- **インデックス**は頻出クエリパターンに合わせて設計
+- **JSONb** はパーツ組み合わせや構造可変なデータに使用
+
+---
+
+## テーブル一覧
+
+| テーブル名 | 役割 | 概算データ量（1ユーザー1年） |
+|---|---|---|
+| `users` | ユーザー情報、認証、プロフィール | 1件 |
+| `pacts` | 契約（アプリの中心） | 数十件 |
+| `check_ins` | 日々のチェックイン履歴 | 数百〜千件 |
+| `crests` | 達成時に生成される紋章 | 数件〜十数件 |
+| `ai_generations` | AI 生成履歴（ログ用） | 数百件 |
+
+---
+
+## リレーション全体図
+
+```
+┌─────────────┐
+│   users     │
+│             │
+│ id (PK)     │
+└──────┬──────┘
+       │ 1
+       │
+       │ N (最大3つの active)
+       ▼
+┌─────────────┐  1     1  ┌──────────────┐
+│   pacts     │◀──────────│   crests     │
+│             │           │              │
+│ id (PK)     │           │ id (PK)      │
+│ user_id (FK)│           │ pact_id (FK) │
+└──────┬──────┘           └──────────────┘
+       │ 1
+       │
+       │ N (1日1契約1件)
+       ▼
+┌─────────────┐
+│ check_ins   │
+│             │
+│ id (PK)     │
+│ pact_id (FK)│
+└─────────────┘
+
+┌──────────────────┐
+│ ai_generations   │  ← User と Pact に関連（独立的なログ）
+│                  │
+│ id (PK)          │
+│ user_id (FK)     │
+│ pact_id (FK,NULL)│
+└──────────────────┘
+```
+
+### Rails モデルでの表現
+
+```ruby
+class User < ApplicationRecord
+  has_many :pacts, dependent: :destroy
+  has_many :check_ins, through: :pacts
+  has_many :ai_generations, dependent: :destroy
+end
+
+class Pact < ApplicationRecord
+  belongs_to :user
+  has_many :check_ins, dependent: :destroy
+  has_one :crest, dependent: :destroy
+  has_many :ai_generations, dependent: :nullify
+end
+
+class CheckIn < ApplicationRecord
+  belongs_to :pact
+end
+
+class Crest < ApplicationRecord
+  belongs_to :pact
+end
+
+class AiGeneration < ApplicationRecord
+  belongs_to :user
+  belongs_to :pact, optional: true
+end
+```
+
+---
+
+## テーブル詳細
+
+### users
+
+ユーザー情報、認証、プロフィールを管理。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | bigint | PRIMARY KEY | レコードID |
+| email | string | NOT NULL, UNIQUE | ログイン用メールアドレス |
+| password_digest | string | NOT NULL | ハッシュ化されたパスワード |
+| nickname | string | NOT NULL | 契約者名（表示用） |
+| avatar_url | string | NULLABLE | アバター画像URL |
+| is_public | boolean | NOT NULL, default: true | プロフィール公開設定 |
+| streak_count | integer | NOT NULL, default: 0 | 現在の連続記録（キャッシュ） |
+| longest_streak | integer | NOT NULL, default: 0 | 過去最長の連続記録（キャッシュ） |
+| created_at | datetime | NOT NULL | |
+| updated_at | datetime | NOT NULL | |
+
+#### インデックス
+
+- `email` (UNIQUE INDEX、ログイン高速化)
+
+#### バリデーション（Rails レベル）
+
+- `email`: 必須、形式チェック、UNIQUE
+- `nickname`: 必須、文字数制限（1-30文字）
+- `password`: 必須（has_secure_passwordで自動）、最小長（6文字以上）
+- `avatar_url`: 形式チェック（URLとして有効か、NULLは許容）
+
+#### 設計上の注意
+
+- **streak_count はキャッシュ**: CheckIn から計算可能だが、表示頻度が高いためキャッシュ
+- **キャッシュ更新**: CheckIn の after_create / after_destroy で自動更新する（ロジック必須）
+- **avatar_url の方針**: MVPではURL保存のみ。ファイルアップロード機能は将来的にActive Storageで実装
+
+#### マイグレーション例
+
+```ruby
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+      t.string :nickname, null: false
+      t.string :avatar_url
+      t.boolean :is_public, null: false, default: true
+      t.integer :streak_count, null: false, default: 0
+      t.integer :longest_streak, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end
+```
+
+---
+
+### pacts
+
+契約。アプリの中心となるテーブル。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | bigint | PRIMARY KEY | レコードID |
+| user_id | bigint | NOT NULL, FK→users.id | 契約者 |
+| goal | text | NOT NULL | 目標 |
+| constraint_text | text | NOT NULL | 試練（制約） |
+| difficulty | integer | NOT NULL | 試練の格 (1-5) |
+| difficulty_reason | text | NULLABLE | 難易度判定理由 (AI) |
+| deadline | date | NOT NULL | 期日 |
+| status | integer | NOT NULL, default: 0 | ステータス (enum) |
+| title | string | NULLABLE | 称号 |
+| signed_at | datetime | NOT NULL | 契約締結日時 |
+| completed_at | datetime | NULLABLE | 達成日時 |
+| created_at | datetime | NOT NULL | |
+| updated_at | datetime | NOT NULL | |
+
+#### enum 定義
+
+```ruby
+enum :status, {
+  active: 0,      # 進行中
+  completed: 1,   # 達成
+  failed: 2,      # 期日切れで未達成
+  abandoned: 3    # ユーザーが破棄
+}
+```
+
+#### インデックス
+
+- `user_id` (B-tree、ユーザーの契約一覧取得)
+- `status` (B-tree、ステータス別フィルター)
+- `(user_id, status)` 複合インデックス（最頻クエリ用）
+- `deadline` (B-tree、期日切れチェックジョブ用)
+
+#### バリデーション
+
+- `goal`: 必須、1-500文字
+- `constraint_text`: 必須、1-500文字
+- `difficulty`: 必須、1-5の範囲
+- `deadline`: 必須、未来の日付
+- `status`: enum値のみ
+- **active 状態の契約はユーザーごとに最大3つまで**（カスタムバリデーション）
+
+#### カスタムバリデーション例
+
+```ruby
+class Pact < ApplicationRecord
+  validate :active_pacts_limit, if: -> { active? }
+
+  private
+
+  def active_pacts_limit
+    return unless user.pacts.where(status: :active)
+                          .where.not(id: id)
+                          .count >= 3
+    errors.add(:base, "active状態の契約は3つまでです")
+  end
+end
+```
+
+#### 編集権限
+
+仕様により、契約締結後の編集制限あり：
+
+- **編集可能**: `goal`, `constraint_text`
+- **編集不可**: `deadline`, `difficulty`, `signed_at`
+- **削除**: 物理削除ではなく、`status: abandoned` への論理削除
+
+#### マイグレーション例
+
+```ruby
+class CreatePacts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pacts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :goal, null: false
+      t.text :constraint_text, null: false
+      t.integer :difficulty, null: false
+      t.text :difficulty_reason
+      t.date :deadline, null: false
+      t.integer :status, null: false, default: 0
+      t.string :title
+      t.datetime :signed_at, null: false
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    add_index :pacts, :status
+    add_index :pacts, [:user_id, :status]
+    add_index :pacts, :deadline
+  end
+end
+```
+
+---
+
+### check_ins
+
+日々のチェックイン履歴。1日1契約1チェックインを保証。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | bigint | PRIMARY KEY | レコードID |
+| pact_id | bigint | NOT NULL, FK→pacts.id | 契約ID |
+| checked_on | date | NOT NULL | チェックイン日 |
+| status | integer | NOT NULL | 結果 (enum) |
+| note | text | NULLABLE | ユーザーのメモ |
+| created_at | datetime | NOT NULL | |
+| updated_at | datetime | NOT NULL | |
+
+#### enum 定義
+
+```ruby
+enum :status, {
+  kept: 0,      # 守れた
+  broken: 1,    # 守れなかった
+  skipped: 2    # スキップ
+}
+```
+
+#### インデックス
+
+- `pact_id` (B-tree、契約のチェックイン履歴取得)
+- `(pact_id, checked_on)` **UNIQUE INDEX**（1日1契約1チェックインを強制）
+- `checked_on` (B-tree、ユーザー全体の連続日数計算用)
+
+#### バリデーション
+
+- `pact_id`: 必須
+- `checked_on`: 必須、未来の日付不可、契約のsigned_at以降
+- `status`: enum値のみ
+- **1日1契約1チェックイン**（DB レベルで保証 + Rails レベルでも検証）
+
+#### 設計上の注意
+
+- **訂正は UPDATE で実装**: 1日1件しか作れないので、再度チェックインすると既存レコードが更新される
+- **連続記録の更新**: after_create/after_update/after_destroy で User.streak_count を再計算
+
+#### 訂正の実装パターン
+
+```ruby
+def check_in(pact, status, note = nil)
+  check_in = pact.check_ins.find_or_initialize_by(checked_on: Date.current)
+  check_in.update!(status: status, note: note)
+end
+```
+
+#### マイグレーション例
+
+```ruby
+class CreateCheckIns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :check_ins do |t|
+      t.references :pact, null: false, foreign_key: true
+      t.date :checked_on, null: false
+      t.integer :status, null: false
+      t.text :note
+
+      t.timestamps
+    end
+
+    add_index :check_ins, [:pact_id, :checked_on], unique: true
+    add_index :check_ins, :checked_on
+  end
+end
+```
+
+---
+
+### crests
+
+達成時に生成される紋章。1契約に対して1紋章。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | bigint | PRIMARY KEY | レコードID |
+| pact_id | bigint | NOT NULL, FK→pacts.id, UNIQUE | 契約ID（1契約1紋章） |
+| crest_data | jsonb | NOT NULL | 紋章の見た目データ |
+| rarity | integer | NOT NULL | レアリティ (enum) |
+| generated_at | datetime | NOT NULL | 生成日時 |
+| created_at | datetime | NOT NULL | |
+| updated_at | datetime | NOT NULL | |
+
+#### enum 定義
+
+```ruby
+enum :rarity, {
+  common: 0,      # コモン
+  rare: 1,        # レア
+  epic: 2,        # エピック
+  legendary: 3    # レジェンダリー
+}
+```
+
+#### crest_data の JSON 構造
+
+```json
+{
+  "base_shape": "shield_round",
+  "central_motif": "sword",
+  "decoration": "wings",
+  "color_palette": "crimson_gold",
+  "shimmer_level": 3
+}
+```
+
+- `base_shape`: 5種類（盾の形）
+- `central_motif`: 10種類（剣、月、炎、目、書物など）
+- `decoration`: 5種類（翼、鎖、植物、星、雷）
+- `color_palette`: 10種類
+- `shimmer_level`: レアリティに応じた装飾レベル
+
+#### インデックス
+
+- `pact_id` (UNIQUE INDEX、1契約1紋章を強制 + 高速検索)
+- `rarity` (B-tree、レアリティ別表示・集計用)
+
+#### バリデーション
+
+- `pact_id`: 必須、UNIQUE
+- `crest_data`: 必須、JSONスキーマ検証（必須キーが揃っているか）
+- `rarity`: enum値のみ
+- **紋章は対応する Pact が completed 状態のときのみ作成可**（カスタムバリデーション）
+
+#### レアリティ計算ロジック
+
+```ruby
+def calculate_rarity(pact)
+  difficulty = pact.difficulty                              # 1-5
+  compliance_rate = pact.check_ins.kept.count.to_f /
+                    [pact.check_ins.count, 1].max           # 0.0-1.0
+  period_score = (pact.deadline - pact.signed_at.to_date) / 30.0  # 月数
+
+  total_score = difficulty * compliance_rate * period_score
+
+  case total_score
+  when 0..1.0   then :common
+  when 1.0..2.5 then :rare
+  when 2.5..4.0 then :epic
+  else               :legendary
+  end
+end
+```
+
+#### 設計上の注意
+
+- **計算データは保存しない**: difficulty, compliance_rate, period_days などは Pact / CheckIn から計算可能なので保存不要（YAGNI 原則）
+- **rarity は永久に保護**: レアリティ計算ロジックが変わっても、過去に確定した rarity は変わらない
+
+#### マイグレーション例
+
+```ruby
+class CreateCrests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :crests do |t|
+      t.references :pact, null: false, foreign_key: true
+      t.jsonb :crest_data, null: false
+      t.integer :rarity, null: false
+      t.datetime :generated_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :crests, :pact_id, unique: true
+    add_index :crests, :rarity
+  end
+end
+```
+
+---
+
+### ai_generations
+
+AI 生成履歴のログテーブル。デバッグ・コスト分析・改善のため。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | bigint | PRIMARY KEY | レコードID |
+| user_id | bigint | NOT NULL, FK→users.id | リクエスト者 |
+| pact_id | bigint | NULLABLE, FK→pacts.id | 関連契約（あれば） |
+| generation_type | integer | NOT NULL | 生成タイプ (enum) |
+| input_data | jsonb | NOT NULL | 入力データ |
+| output_data | jsonb | NOT NULL | 出力データ |
+| model | string | NOT NULL | 使用モデル名 |
+| tokens_used | integer | NULLABLE | 消費トークン数 |
+| latency_ms | integer | NULLABLE | 応答時間 (ms) |
+| status | integer | NOT NULL | 成功/失敗 (enum) |
+| error_message | text | NULLABLE | エラーメッセージ |
+| created_at | datetime | NOT NULL | |
+| updated_at | datetime | NOT NULL | |
+
+#### enum 定義
+
+```ruby
+enum :generation_type, {
+  goal_suggestion: 0,         # 目標案
+  constraint_suggestion: 1,   # 制約案
+  difficulty_judgment: 2,     # 難易度判定
+  title_generation: 3         # 称号生成
+}
+
+enum :status, {
+  success: 0,
+  failed: 1,
+  filtered: 2  # コンテンツフィルタで弾かれた
+}
+```
+
+#### input_data / output_data の構造例
+
+**目標生成（goal_suggestion）**
+
+```json
+{
+  "input_data": {
+    "user_input": "英語を頑張る",
+    "system_prompt": "あなたは古き賢者として、契約者に天啓を授ける役割です。...",
+    "model": "gpt-4o-mini",
+    "temperature": 0.7
+  },
+  "output_data": {
+    "generated_options": [
+      "TOEIC 800点を3ヶ月で達成する",
+      "英会話アプリを毎日30分続ける",
+      "英語の本を5冊読破する"
+    ],
+    "raw_response": "天啓により、汝の進むべき道は3つあり。..."
+  }
+}
+```
+
+#### インデックス
+
+- `user_id` (B-tree、ユーザーごとの履歴取得)
+- `created_at` (B-tree、時系列分析用)
+- `generation_type` (B-tree、タイプ別集計用)
+- `(user_id, created_at)` 複合インデックス（ユーザー履歴の時系列取得）
+
+#### バリデーション
+
+- `user_id`: 必須
+- `generation_type`: enum値のみ
+- `input_data`, `output_data`: 必須、JSON形式
+- `status`: enum値のみ
+- `model`: 必須
+
+#### データ保持ポリシー
+
+- MVP段階では削除なし
+- 将来的に「90日以上前のログは削除」のバッチを追加予定
+- プライバシー対応として、ユーザー削除時は AiGeneration の user_id を NULL に（または削除）
+
+#### マイグレーション例
+
+```ruby
+class CreateAiGenerations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_generations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :pact, foreign_key: true, null: true
+      t.integer :generation_type, null: false
+      t.jsonb :input_data, null: false
+      t.jsonb :output_data, null: false
+      t.string :model, null: false
+      t.integer :tokens_used
+      t.integer :latency_ms
+      t.integer :status, null: false
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :ai_generations, :generation_type
+    add_index :ai_generations, [:user_id, :created_at]
+  end
+end
+```
+
+---
+
+## 設計判断の記録
+
+設計を進める中で行った重要な判断と、その理由を記録します。
+
+### 判断1: streak_count を User にキャッシュ
+
+**選択**: User テーブルに streak_count を持つ（CheckIn から都度計算ではなく）
+
+**理由**:
+- ホーム画面、ランキング、殿堂など複数箇所で表示される
+- CheckIn からの集計は重い（日付グループ化、連続性判定）
+- チェックインの更新頻度は低い（1日1回程度）
+
+**注意点**:
+- キャッシュずれ対策として、CheckIn の after_create/after_destroy で更新ロジック必須
+- TDD でキャッシュ更新ロジックを保護する
+
+### 判断2: Crest を Pact から分離
+
+**選択**: Crest を別テーブルとして独立
+
+**理由**:
+- 達成時のみ生成される（NULL を扱う必要がなくなる）
+- 紋章の属性（レアリティ、SVGデータ）を独立して管理できる
+- 責務が分離される（契約と紋章で別概念）
+
+### 判断3: crest_data を JSONB で保存
+
+**選択**: 紋章のパーツ情報を JSONB の単一カラムに
+
+**理由**:
+- 紋章のパーツは将来追加される可能性が高い（柔軟性重視）
+- パーツでの検索・集計は不要（rarity だけインデックスがあれば十分）
+- カラム追加のマイグレーションを避けられる
+
+### 判断4: 1契約に対して1日1チェックイン（UNIQUE 制約）
+
+**選択**: `(pact_id, checked_on)` に UNIQUE INDEX
+
+**理由**:
+- 仕様で「1日1回チェックイン」と決めている
+- バグでの2重登録を DB レベルで防ぐ
+- 連続記録の計算が単純になる
+- 訂正は UPDATE で実装可能（INSERT を増やす必要はない）
+
+### 判断5: Pact の編集制限
+
+**選択**: goal, constraint_text のみ編集可、deadline / difficulty は編集不可
+
+**理由**:
+- 仕様議論でゲーム性とランキング公平性のため
+- タイポ修正のニーズには応えつつ、無限延長などの抜け道を防ぐ
+- 期日変更したい場合は「破棄して再契約」で対応
+
+### 判断6: AiGeneration を別テーブルで履歴保存
+
+**選択**: AI 生成履歴を AiGeneration テーブルに保存
+
+**理由**:
+- バグ調査時のリクエスト/レスポンス再現
+- API コストの分析（tokens_used）
+- プロンプト改善のためのデータ収集
+- 失敗パターンの分析（status, error_message）
+
+### 判断7: レアリティ計算データは保存しない
+
+**選択**: difficulty_at_completion, compliance_rate などの計算元データは Crest に保存しない
+
+**理由**:
+- 必要な情報は Pact / CheckIn から計算可能（正規化原則）
+- 表示する UI が現状ない（YAGNI 原則）
+- rarity カラムだけで「結果」は永久に保証される
+
+### 判断8: ランキングは公平性重視
+
+**選択**: 「今月の達成数」と「連続チェックイン日数」のみ採用、累計レアリティは個人記録としてのみ
+
+**理由**:
+- 「早く始めた人が有利」を防ぐ
+- 新規ユーザーも楽しめる
+- 月次リセットで全員が同じ土俵に立てる
+
+---
+
+## 今後の拡張案（参考）
+
+MVP では実装しないが、将来的に追加するかもしれない要素を記録しておく。
+
+### 拡張1: 通知機能
+
+- `notifications` テーブル：期日が近いリマインダー、達成お祝いなど
+- メール / プッシュ通知の連携
+
+### 拡張2: ソーシャル機能
+
+- `follows` テーブル：ユーザー同士のフォロー関係
+- `likes` テーブル：紋章への「いいね」
+
+### 拡張3: バッジ・実績システム
+
+- `achievements` テーブル：「初めての達成」「10連続成功」などの実績解除
+
+### 拡張4: 内部カテゴリタグ
+
+- AI による自動タグ付け（学習、健康、創作 など）
+- カテゴリ別ランキング
+
+### 拡張5: プッシュ通知設定
+
+- `notification_preferences` テーブル：通知のオン/オフ設定
+
+---
+
+## 参考資料
+
+- [Rails 8 ガイド](https://guides.rubyonrails.org/)
+- [PostgreSQL JSONB](https://www.postgresql.org/docs/current/datatype-json.html)
+- [factory_bot](https://github.com/thoughtbot/factory_bot)
+- 過去の議論ログ: `docs/design_prompts.md`（Claude Design用プロンプト集）
+
+---
+
+**最終更新**: 2026年5月2日

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -1,0 +1,1779 @@
+# Vow Pact セットアップガイド（Docker 版）
+
+このガイドは、Vow Pact プロジェクトを **Docker 環境** で開発するためのセットアップ手順書です。
+設計フェーズで決めた技術スタックを Docker で動くプロジェクトとして立ち上げます。
+
+## ゴール
+
+このガイドを完了すると、以下の状態になります：
+
+- Docker Compose で Rails 8.1 + React + TypeScript + PostgreSQL 18 が起動する
+- ローカルマシンには Ruby 3.4 のみ追加インストール（PostgreSQL はコンテナ内）
+- GitHub リポジトリが作成され、初回コミット済み
+- Neon との本番 DB 接続準備完了
+- Render へのデプロイ準備完了
+- GitHub Actions の CI 設定済み
+
+つまり「Docker でコードを書き始められる状態」がゴールです。
+
+## 想定所要時間
+
+3〜5時間（休憩込み、Docker 学習込み）
+
+## 進め方
+
+各フェーズを順番に実行してください。各フェーズの最後に **✅ チェックポイント** があるので、そこで動作確認をしてから次に進みます。
+
+エラーが出た場合は、最後の「12. トラブルシューティング」を参照してください。
+
+## このガイドの方針
+
+- **ローカル開発は Docker で完結**（PostgreSQL はコンテナ内）
+- **ローカルにも Ruby 3.4 をインストール**（IDE 補完と `rails new` 用）
+- **本番デプロイは Render の標準フロー**（Docker は使わない、Render のビルドプロセス）
+
+---
+
+## 目次
+
+1. [前提条件](#1-前提条件)
+2. [Ruby 3.4 のインストール（mise）](#2-ruby-34-のインストールmise)
+3. [Rails プロジェクトの新規作成](#3-rails-プロジェクトの新規作成)
+4. [Docker 環境の構築](#4-docker-環境の構築)
+5. [データベース接続設定](#5-データベース接続設定)
+6. [Gem の追加とセットアップ](#6-gem-の追加とセットアップ)
+7. [フロントエンド環境の構築](#7-フロントエンド環境の構築)
+8. [テスト・Lint 環境の整備](#8-テストlint-環境の整備)
+9. [GitHub リポジトリの作成](#9-github-リポジトリの作成)
+10. [Render デプロイ準備](#10-render-デプロイ準備)
+11. [CI/CD（GitHub Actions）の設定](#11-cicdgithub-actionsの設定)
+12. [動作確認](#12-動作確認)
+13. [トラブルシューティング](#13-トラブルシューティング)
+
+---
+
+## 1. 前提条件
+
+### ローカル環境の確認
+
+以下のツールがインストールされているか確認します。
+
+```bash
+# Docker Desktop の確認
+docker --version
+# 期待値: Docker version 24.x.x 以上
+
+docker compose version
+# 期待値: Docker Compose version v2.x.x 以上
+
+# Node.js のバージョン確認（Vite が要求するバージョン、開発機にも入れておく）
+node --version
+# 期待値: v20.x 以上
+
+# Git の確認
+git --version
+# 期待値: git version 2.x
+
+# GitHub CLI の確認
+gh --version
+# 期待値: gh version 2.x.x
+```
+
+**注意**: Ruby は次のフェーズでインストールします。
+**注意**: PostgreSQL はローカルにインストール不要（Docker コンテナ内で動かすため）。
+
+### Docker Desktop の起動確認
+
+Mac のメニューバーにクジラのアイコンが表示されているか確認。表示されていない場合は Docker Desktop アプリを起動してください。
+
+```bash
+# Docker が動いているか確認
+docker ps
+# エラーが出なければ OK
+```
+
+### 必要なアカウント
+
+以下のアカウントを事前に作成してください：
+
+- [GitHub](https://github.com/) - ソースコード管理
+- [Neon](https://neon.tech/) - 本番データベースホスティング
+- [Render](https://render.com/) - アプリケーションホスティング
+- [OpenAI](https://platform.openai.com/) - AI API
+
+### ✅ チェックポイント1
+
+- [ ] Docker Desktop が起動している
+- [ ] `docker ps` がエラーなく実行できる
+- [ ] Node.js 20+ が動く
+- [ ] Git、GitHub CLI が使える
+- [ ] 必要なアカウントを作成済み
+
+---
+
+## 2. Ruby 3.4 のインストール（mise）
+
+ローカルマシンに Ruby 3.4 を入れます。`rails new` の実行と IDE の補完用です。
+
+### mise のインストール
+
+mise は複数言語のバージョン管理ツールで、最近の主流です。
+
+```bash
+# Homebrew で mise をインストール
+brew install mise
+
+# シェル設定（zsh の場合、~/.zshrc に追加）
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+
+# 設定を反映
+source ~/.zshrc
+
+# 確認
+mise --version
+```
+
+### Ruby 3.4 のインストール
+
+```bash
+# Ruby 3.4 の最新版をインストール
+mise install ruby@3.4
+
+# グローバル設定（マシン全体のデフォルト）
+mise use --global ruby@3.4
+
+# 確認
+ruby --version
+# 期待値: ruby 3.4.x
+```
+
+### Rails 8.1 のインストール
+
+```bash
+# Rails 8.1 をインストール
+gem install rails -v 8.1.3
+
+# 確認
+rails --version
+# 期待値: Rails 8.1.3
+```
+
+### ✅ チェックポイント2
+
+- [ ] `mise --version` が動く
+- [ ] `ruby --version` が 3.4.x を表示
+- [ ] `rails --version` が 8.1.3 を表示
+
+---
+
+## 3. Rails プロジェクトの新規作成
+
+### プロジェクトディレクトリの準備
+
+開発用ディレクトリ（例：`~/Projects`）に移動します。
+
+```bash
+cd ~/Projects
+```
+
+### rails new コマンド
+
+以下のコマンドで Vow Pact プロジェクトを新規作成します。
+
+```bash
+rails new vow_pact \
+  --javascript=vite \
+  --css=tailwind \
+  --database=postgresql \
+  --skip-test \
+  --skip-jbuilder
+```
+
+**各オプションの説明**：
+
+- `--javascript=vite`: フロントエンドのビルドに Vite を使用
+- `--css=tailwind`: Tailwind CSS を最初からセットアップ
+- `--database=postgresql`: DB を PostgreSQL に設定
+- `--skip-test`: 標準の Minitest をスキップ（後で RSpec を入れる）
+- `--skip-jbuilder`: jbuilder をスキップ（alba を使う）
+
+実行が完了すると、`~/Projects/vow_pact/` ディレクトリが作成されます。
+
+### プロジェクトディレクトリへ移動
+
+```bash
+cd vow_pact
+```
+
+### ✅ チェックポイント3
+
+- [ ] `~/Projects/vow_pact/` ディレクトリが作成された
+- [ ] 中に Gemfile、app/、config/ などのファイル・ディレクトリがある
+
+```bash
+# 確認
+ls -la
+```
+
+---
+
+## 4. Docker 環境の構築
+
+ここから Docker の出番です。
+
+### 4.1 Dockerfile.dev の作成
+
+開発用の Dockerfile を作成します。プロジェクトルートに `Dockerfile.dev` を作成：
+
+```dockerfile
+# Dockerfile.dev
+# 開発用 Dockerfile
+
+FROM ruby:3.4-slim
+
+# 必要なパッケージのインストール
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    nodejs \
+    npm \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js を新しいバージョンに更新（n を使う）
+RUN npm install -g n && n stable && hash -r
+
+# 作業ディレクトリ
+WORKDIR /app
+
+# Gemfile を先にコピー（Docker キャッシュを活用）
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# package.json も先にコピー
+COPY package.json package-lock.json* ./
+RUN npm install || true
+
+# アプリケーションのソースをコピー
+COPY . .
+
+# ポート公開
+EXPOSE 3000 5173
+
+# 起動コマンド（docker-compose.yml で上書きされる）
+CMD ["bin/dev"]
+```
+
+**この Dockerfile の解説**：
+
+- `ruby:3.4-slim`: 軽量な Ruby 3.4 公式イメージ
+- `apt-get install`: PostgreSQL クライアント、Node.js、Git などをインストール
+- `n stable`: より新しい Node.js に更新（apt のは古い）
+- `WORKDIR /app`: コンテナ内の作業ディレクトリ
+- `Gemfile を先にコピー`: Docker のレイヤーキャッシュを活用、ソース変更時に bundle install を再実行しない
+- `EXPOSE 3000 5173`: Rails サーバーと Vite の両方のポート
+
+### 4.2 docker-compose.yml の作成
+
+プロジェクトルートに `docker-compose.yml` を作成：
+
+```yaml
+# docker-compose.yml
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"  # Rails サーバー
+      - "5173:5173"  # Vite dev サーバー
+    volumes:
+      - .:/app:cached  # ホストとコンテナでソースを共有（cached モード）
+      - bundle_cache:/usr/local/bundle  # gem のキャッシュを保持
+      - node_modules:/app/node_modules  # node_modules を分離
+    environment:
+      DATABASE_URL: postgresql://vow_pact:password@db:5432/vow_pact_development
+      RAILS_ENV: development
+      BINDING: 0.0.0.0  # コンテナ外からアクセス可能に
+    depends_on:
+      db:
+        condition: service_healthy
+    tty: true
+    stdin_open: true
+
+  db:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: vow_pact
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: vow_pact_development
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"  # ホストからも接続可能（GUI ツール用）
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vow_pact"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:    # DB データを永続化
+  bundle_cache:     # gem のキャッシュを永続化
+  node_modules:     # node_modules を永続化
+```
+
+**この docker-compose.yml の解説**：
+
+- `services.web`: Rails アプリのコンテナ
+  - `build.dockerfile`: Dockerfile.dev を使う
+  - `ports`: ホストの 3000 と 5173 をコンテナの同ポートにマップ
+  - `volumes`: ソースを共有（コードを書き換えればコンテナ内に反映）
+  - `cached`: Mac での I/O パフォーマンス改善
+  - `bundle_cache`: gem のインストール先を分離（コンテナ削除しても残る）
+  - `depends_on`: db が healthy になってから起動
+- `services.db`: PostgreSQL 18 コンテナ
+  - `volumes`: DB データを永続化
+  - `ports`: ホストからも接続可能（TablePlus などで覗ける）
+  - `healthcheck`: DB が起動しきったか定期チェック
+- `volumes`: 名前付きボリューム（コンテナ削除しても残る）
+
+### 4.3 .dockerignore の作成
+
+Docker イメージに含めたくないファイルを指定。プロジェクトルートに `.dockerignore` を作成：
+
+```
+# .dockerignore
+
+.git
+.gitignore
+.dockerignore
+Dockerfile*
+docker-compose*.yml
+README.md
+
+# Rails
+log/*
+tmp/*
+storage/*
+node_modules
+.bundle
+vendor/bundle
+public/assets
+public/packs
+public/vite
+
+# 環境変数
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store
+Thumbs.db
+
+# エディタ
+.vscode/
+.idea/
+*.swp
+
+# テスト
+coverage/
+spec/examples.txt
+```
+
+### 4.4 BINDING 環境変数の対応
+
+Rails サーバーがコンテナ外からアクセス可能になるよう、`Procfile.dev` を確認・編集します。
+
+`Procfile.dev`：
+
+```
+web: bin/rails server -p 3000 -b 0.0.0.0
+vite: bin/vite dev --host 0.0.0.0
+```
+
+`-b 0.0.0.0` がポイント。これがないと、コンテナ内の `localhost` だけがリスンされ、ホストから繋がりません。
+
+### 4.5 Vite の設定（コンテナ用）
+
+`vite.config.js` を編集。HMR（ホットリロード）が Docker でも効くようにします。
+
+```javascript
+// vite.config.js
+
+import { defineConfig } from 'vite'
+import RubyPlugin from 'vite-plugin-ruby'
+
+export default defineConfig({
+  plugins: [
+    RubyPlugin(),
+  ],
+  server: {
+    host: '0.0.0.0',  // コンテナ外からアクセス可能に
+    port: 5173,
+    hmr: {
+      host: 'localhost',
+    },
+  },
+})
+```
+
+### 4.6 コンテナのビルドと起動
+
+初回はイメージのビルドが必要です。
+
+```bash
+# イメージのビルド（初回のみ、5〜10分かかる）
+docker compose build
+
+# コンテナの起動
+docker compose up
+```
+
+ログが流れて、最後に Rails サーバーが起動するメッセージが見えれば成功です。
+
+```
+web-1  | * Listening on http://0.0.0.0:3000
+```
+
+### 4.7 動作確認
+
+ブラウザで http://localhost:3000 を開きます。
+ただし、まだ DB の作成をしていないので、エラー画面が出るはずです。
+これは正常です（次のフェーズで対処）。
+
+`Ctrl + C` でコンテナを停止します。
+
+### よく使う Docker コマンド
+
+これから何度も使うコマンドを覚えておきましょう。
+
+```bash
+# コンテナ起動（フォアグラウンド）
+docker compose up
+
+# バックグラウンドで起動
+docker compose up -d
+
+# ログを見る
+docker compose logs -f web
+
+# コンテナ内でコマンド実行
+docker compose exec web bash             # シェルに入る
+docker compose exec web bin/rails console  # Rails コンソール
+docker compose exec web bundle exec rspec  # RSpec 実行
+
+# コンテナを止める
+docker compose down
+
+# コンテナを止めて、ボリュームも削除（DBデータも消える）
+docker compose down -v
+
+# イメージを再ビルド
+docker compose build --no-cache
+```
+
+### エイリアスの設定（オプション、便利）
+
+`docker compose exec web` は長いので、`~/.zshrc` にエイリアスを追加すると楽です。
+
+```bash
+# ~/.zshrc に追加
+alias dce="docker compose exec"
+alias dcw="docker compose exec web"
+alias dcrails="docker compose exec web bin/rails"
+alias dcrspec="docker compose exec web bundle exec rspec"
+alias dcrubocop="docker compose exec web bundle exec rubocop"
+alias dcbundle="docker compose exec web bundle"
+
+# 設定を反映
+source ~/.zshrc
+```
+
+これで `dcw bash` や `dcrails console` のように短く書けます。
+
+### ✅ チェックポイント4
+
+- [ ] `Dockerfile.dev` が作成された
+- [ ] `docker-compose.yml` が作成された
+- [ ] `.dockerignore` が作成された
+- [ ] `docker compose build` が完了した
+- [ ] `docker compose up` で起動できる
+- [ ] http://localhost:3000 にアクセスできる（DBエラーは正常）
+
+---
+
+## 5. データベース接続設定
+
+### 5.1 config/database.yml の修正
+
+開発環境では Docker の PostgreSQL、本番では Neon を使う設定に変更します。
+
+```yaml
+# config/database.yml
+
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development:
+  <<: *default
+  url: <%= ENV.fetch("DATABASE_URL") %>
+
+test:
+  <<: *default
+  url: <%= ENV.fetch("DATABASE_URL", "postgresql://vow_pact:password@db:5432/vow_pact_test") %>
+
+production:
+  <<: *default
+  url: <%= ENV.fetch("DATABASE_URL") %>
+```
+
+開発環境では `docker-compose.yml` で設定した `DATABASE_URL` を使います。
+
+### 5.2 DB の作成
+
+コンテナを起動した状態で、別ターミナルから DB を作成します。
+
+```bash
+# コンテナを起動（バックグラウンドで）
+docker compose up -d
+
+# DB の作成
+docker compose exec web bin/rails db:create
+# または、エイリアスを設定済みなら：
+# dcrails db:create
+
+# テスト DB の作成（後で必要）
+docker compose exec web bin/rails db:create RAILS_ENV=test
+```
+
+成功すると以下のメッセージが表示されます：
+
+```
+Created database 'vow_pact_development'
+Created database 'vow_pact_test'
+```
+
+### 5.3 動作確認
+
+ブラウザで http://localhost:3000 を再読み込み。
+Rails の初期画面が表示されれば成功です。
+
+### 5.4 .env ファイルの準備（本番用）
+
+本番環境（Render）と OpenAI API 用の環境変数の準備をします。
+
+```bash
+# .env.example（git管理する）
+touch .env.example
+
+# .env（git管理しない）
+touch .env
+```
+
+`.env.example` に以下を記載：
+
+```bash
+# .env.example
+
+# Database (本番用、Neon)
+DATABASE_URL=postgresql://USER:PASSWORD@HOST/vow_pact_production?sslmode=require
+
+# OpenAI API
+OPENAI_API_KEY=sk-proj-xxxxx
+
+# Rails
+RAILS_MASTER_KEY=（config/master.key の内容）
+
+# Frontend
+FRONTEND_URL=http://localhost:5173
+```
+
+`.env` には実際の値を記載（後で Neon の接続情報、OpenAI の API キーが揃ってから）。
+
+### 5.5 .gitignore の確認
+
+`.env` が git 管理外になっているか確認。なければ追加：
+
+```bash
+# .gitignore に以下が含まれていることを確認
+.env
+.env.local
+```
+
+### ✅ チェックポイント5
+
+- [ ] `config/database.yml` が更新された
+- [ ] `bin/rails db:create` が成功した
+- [ ] http://localhost:3000 で Rails の初期画面が見える
+- [ ] `.env.example` と `.env` が作成された
+- [ ] `.env` が `.gitignore` に含まれている
+
+---
+
+## 6. Gem の追加とセットアップ
+
+### 6.1 必要な gem を Gemfile に追加
+
+`Gemfile` を編集して、以下の gem を追加：
+
+```ruby
+# Gemfile
+
+# 既存の gem に加えて、以下を追加
+
+# Authentication（Rails 8 標準ジェネレータで使用）
+gem 'bcrypt', '~> 3.1.7'
+
+# Serializer
+gem 'alba'
+
+# OpenAI API クライアント
+gem 'ruby-openai'
+
+# CORS 対応
+gem 'rack-cors'
+
+# テスト用
+group :development, :test do
+  gem 'rspec-rails'
+  gem 'factory_bot_rails'
+  gem 'faker'
+  gem 'dotenv-rails'
+end
+
+# 開発用
+group :development do
+  gem 'rubocop-rails-omakase', require: false
+end
+```
+
+### 6.2 bundle install（コンテナ内で）
+
+```bash
+docker compose exec web bundle install
+```
+
+実行後、コンテナを再起動して新しい gem が読み込まれるようにします。
+
+```bash
+docker compose restart web
+```
+
+### 6.3 認証ジェネレータの実行
+
+```bash
+docker compose exec web bin/rails generate authentication
+```
+
+以下が生成されます：
+
+- `app/models/user.rb`
+- `app/models/session.rb`
+- `app/controllers/sessions_controller.rb`
+- `app/controllers/passwords_controller.rb`
+- `db/migrate/xxxx_create_users.rb`
+- `db/migrate/xxxx_create_sessions.rb`
+- 関連するビューやメーラー
+
+### 6.4 認証ジェネレータの調整（API mode）
+
+API mode では HTML ビューが不要なので削除します。
+
+```bash
+# コンテナ外（ホスト）で実行
+rm -rf app/views/sessions
+rm -rf app/views/passwords
+rm -rf app/views/passwords_mailer
+```
+
+メール認証用の mailer 関連は残します（パスワードリセットで使う）。
+
+### 6.5 マイグレーションの実行
+
+```bash
+docker compose exec web bin/rails db:migrate
+```
+
+### 6.6 RSpec のセットアップ
+
+```bash
+docker compose exec web bin/rails generate rspec:install
+```
+
+以下のファイルが生成されます：
+
+- `.rspec`
+- `spec/spec_helper.rb`
+- `spec/rails_helper.rb`
+
+### 6.7 RSpec の設定
+
+`spec/rails_helper.rb` を編集して、factory_bot ヘルパーを使えるようにします。
+
+```ruby
+# spec/rails_helper.rb の RSpec.configure ブロック内に追加
+
+config.include FactoryBot::Syntax::Methods
+```
+
+### 6.8 ApplicationController の設定（API mode）
+
+`app/controllers/application_controller.rb` を編集：
+
+```ruby
+# app/controllers/application_controller.rb
+
+class ApplicationController < ActionController::API
+  include ActionController::Cookies
+
+  before_action :authenticate_user!
+
+  private
+
+  def authenticate_user!
+    return if current_user.present?
+
+    render json: {
+      errors: [{ code: 'unauthorized', field: nil, message: 'ログインが必要です' }]
+    }, status: :unauthorized
+  end
+
+  def current_user
+    @current_user ||= authenticate_user_from_session
+  end
+
+  def authenticate_user_from_session
+    session_token = cookies.signed[:session_token]
+    return nil unless session_token
+
+    session = Session.find_by(token: session_token)
+    session&.user
+  end
+end
+```
+
+### 6.9 CORS の設定
+
+`config/initializers/cors.rb` を作成：
+
+```ruby
+# config/initializers/cors.rb
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch('FRONTEND_URL', 'http://localhost:5173')
+
+    resource '*',
+      headers: :any,
+      methods: %i[get post put patch delete options head],
+      credentials: true
+  end
+end
+```
+
+### 6.10 OpenAI クライアントの設定
+
+`config/initializers/openai.rb` を作成：
+
+```ruby
+# config/initializers/openai.rb
+
+OpenAI.configure do |config|
+  config.access_token = ENV.fetch('OPENAI_API_KEY', '')
+  config.log_errors = Rails.env.development?
+end
+```
+
+`OPENAI_API_KEY` が無い場合でも起動できるように、空文字列をデフォルトにしています（実際の AI 機能を使うときには必要）。
+
+### ✅ チェックポイント6
+
+- [ ] `bundle install` が成功
+- [ ] 認証ジェネレータが実行され、users/sessions テーブルが作成された
+- [ ] RSpec がセットアップされた
+- [ ] CORS と OpenAI クライアントの設定が完了
+- [ ] `bin/rails console` で `User` クラスが見える
+
+```bash
+# 確認
+docker compose exec web bin/rails console
+# > User
+# # => User(id: integer, ...)
+# > exit
+```
+
+---
+
+## 7. フロントエンド環境の構築
+
+### 7.1 React + TypeScript パッケージのインストール
+
+```bash
+docker compose exec web npm install \
+  react react-dom react-router-dom
+
+docker compose exec web npm install --save-dev \
+  typescript \
+  @types/react \
+  @types/react-dom \
+  @vitejs/plugin-react \
+  @types/node
+```
+
+### 7.2 TanStack Query のインストール
+
+```bash
+docker compose exec web npm install @tanstack/react-query
+```
+
+### 7.3 Tailwind CSS の設定
+
+`tailwind.config.js` を編集：
+
+```javascript
+// tailwind.config.js
+
+module.exports = {
+  content: [
+    './app/views/**/*.{erb,haml,html,slim}',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Vow Pact のカラーパレット
+        parchment: '#f4e8d0',
+        ink: '#2c1810',
+        seal: '#8b1a1a',
+        gold: '#c9a961',
+        'light-parchment': '#fbf6e9',
+        'dark-ink': '#1a0e08',
+        'seal-hover': '#6f1414',
+        'gold-glow': '#e6c887',
+      },
+      fontFamily: {
+        sans: ['"Noto Sans JP"', 'sans-serif'],
+        serif: ['"Noto Serif JP"', 'serif'],
+      },
+    },
+  },
+  plugins: [],
+}
+```
+
+### 7.4 Vite の TypeScript 化
+
+`vite.config.js` を `vite.config.ts` にリネーム：
+
+```bash
+mv vite.config.js vite.config.ts
+```
+
+`vite.config.ts` の内容を編集：
+
+```typescript
+// vite.config.ts
+
+import { defineConfig } from 'vite'
+import RubyPlugin from 'vite-plugin-ruby'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    RubyPlugin(),
+    react(),
+  ],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    hmr: {
+      host: 'localhost',
+    },
+  },
+})
+```
+
+### 7.5 TypeScript 設定（tsconfig.json）
+
+プロジェクトルートに `tsconfig.json` を作成：
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./app/javascript/*"]
+    }
+  },
+  "include": ["app/javascript/**/*"],
+  "exclude": ["node_modules"]
+}
+```
+
+### 7.6 エントリーポイントの作成
+
+```bash
+# 既存の application.js を削除
+rm app/javascript/entrypoints/application.js
+```
+
+`app/javascript/entrypoints/application.tsx` を作成：
+
+```typescript
+// app/javascript/entrypoints/application.tsx
+
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import App from '../App'
+import '../styles/application.css'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000, // 5分
+    },
+  },
+})
+
+const rootElement = document.getElementById('root')
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </React.StrictMode>
+  )
+}
+```
+
+### 7.7 App.tsx の作成
+
+`app/javascript/App.tsx` を作成（最初は最小限）：
+
+```typescript
+// app/javascript/App.tsx
+
+import React from 'react'
+
+const App: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-parchment text-ink p-8">
+      <h1 className="text-4xl font-serif">Vow Pact</h1>
+      <p className="mt-4">セットアップ完了。実装フェーズに進めます。</p>
+    </div>
+  )
+}
+
+export default App
+```
+
+### 7.8 styles/application.css の確認
+
+`app/javascript/styles/application.css`：
+
+```css
+/* app/javascript/styles/application.css */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Google Fonts: Noto Sans JP / Noto Serif JP */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;700&display=swap');
+```
+
+### 7.9 ルートビューの作成
+
+`config/routes.rb`：
+
+```ruby
+# config/routes.rb
+
+Rails.application.routes.draw do
+  # API 関連
+  namespace :api do
+    namespace :v1 do
+      # ここに API ルートを追加していく
+    end
+  end
+
+  # フロントエンドの SPA を返すルート（API 以外のすべてのパス）
+  get '*path', to: 'home#index', constraints: ->(req) { !req.xhr? && req.format.html? }
+  root 'home#index'
+end
+```
+
+`app/controllers/home_controller.rb` を作成：
+
+```ruby
+# app/controllers/home_controller.rb
+
+class HomeController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+
+  def index
+    render html: <<~HTML.html_safe
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Vow Pact</title>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          #{vite_javascript_tag 'application'}
+          #{vite_stylesheet_tag 'application'}
+        </head>
+        <body>
+          <div id="root"></div>
+        </body>
+      </html>
+    HTML
+  end
+
+  private
+
+  def vite_javascript_tag(entry)
+    ViteRuby.instance.manifest.path_for(entry, type: :javascript)
+  end
+
+  def vite_stylesheet_tag(entry)
+    ViteRuby.instance.manifest.path_for(entry, type: :stylesheet)
+  end
+end
+```
+
+### 7.10 動作確認
+
+```bash
+# 一度コンテナを再起動
+docker compose restart web
+```
+
+ブラウザで http://localhost:3000 を開きます。
+「Vow Pact / セットアップ完了。実装フェーズに進めます。」が表示され、背景がパーチメント色（薄ベージュ）になっていれば成功です。
+
+### ✅ チェックポイント7
+
+- [ ] React + TypeScript のパッケージがインストールされた
+- [ ] Vite + React の設定が完了
+- [ ] http://localhost:3000 で「Vow Pact」のページが表示される
+- [ ] 背景がパーチメント色（#f4e8d0）になっている
+- [ ] Tailwind CSS のクラスが適用されている
+
+---
+
+## 8. テスト・Lint 環境の整備
+
+### 8.1 RuboCop の設定
+
+`.rubocop.yml` を作成：
+
+```yaml
+# .rubocop.yml
+
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.4
+  NewCops: enable
+  Exclude:
+    - 'db/schema.rb'
+    - 'db/migrate/**/*'
+    - 'bin/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    - 'node_modules/**/*'
+
+Style/Documentation:
+  Enabled: false
+```
+
+### 8.2 RuboCop の実行
+
+```bash
+docker compose exec web bundle exec rubocop -a
+```
+
+### 8.3 ESLint + Prettier のインストール
+
+```bash
+docker compose exec web npm install --save-dev \
+  eslint \
+  prettier \
+  eslint-plugin-react \
+  eslint-plugin-react-hooks \
+  @typescript-eslint/parser \
+  @typescript-eslint/eslint-plugin \
+  eslint-config-prettier
+```
+
+### 8.4 ESLint と Prettier の設定
+
+`.eslintrc.json` を作成：
+
+```json
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2020": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "plugins": ["react", "@typescript-eslint", "react-hooks"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
+}
+```
+
+`.prettierrc` を作成：
+
+```json
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}
+```
+
+### 8.5 package.json にスクリプト追加
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest",
+    "lint": "eslint app/javascript --ext .ts,.tsx",
+    "lint:fix": "eslint app/javascript --ext .ts,.tsx --fix",
+    "format": "prettier --write 'app/javascript/**/*.{ts,tsx}'"
+  }
+}
+```
+
+### 8.6 Vitest のセットアップ
+
+```bash
+docker compose exec web npm install --save-dev \
+  vitest jsdom @testing-library/react @testing-library/jest-dom
+```
+
+`vitest.config.ts` を作成：
+
+```typescript
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./app/javascript/test/setup.ts'],
+  },
+})
+```
+
+`app/javascript/test/setup.ts` を作成：
+
+```typescript
+import '@testing-library/jest-dom'
+```
+
+### ✅ チェックポイント8
+
+- [ ] `bundle exec rubocop` が通る
+- [ ] `npm run lint` が通る
+- [ ] `bundle exec rspec` が動く（テストファイルなしでも OK）
+
+---
+
+## 9. GitHub リポジトリの作成
+
+### 9.1 .gitignore の確認
+
+`.gitignore` に以下が含まれていることを確認（`rails new` で大半は含まれているはず）：
+
+```
+# 環境変数
+.env
+.env.local
+
+# OS
+.DS_Store
+Thumbs.db
+
+# エディタ
+.vscode/
+.idea/
+*.swp
+
+# ログ・tmp
+log/*
+!log/.keep
+tmp/*
+!tmp/.keep
+
+# Vite
+public/vite/
+public/vite-dev/
+public/vite-test/
+
+# Node
+node_modules/
+
+# Rails
+config/master.key
+
+# Docker
+.dockerignore（これは含めない）
+```
+
+### 9.2 GitHub リポジトリの作成
+
+```bash
+# プライベートリポジトリとして作成
+gh repo create vow_pact --private --source=. --remote=origin
+```
+
+### 9.3 設計書ファイルの配置
+
+設計書（data_model.md、api_design.md、design_prompts.md、setup_guide.md）を `docs/` に配置。
+CLAUDE.md はプロジェクトルートに配置。
+
+```bash
+mkdir docs
+# 各ファイルを docs/ にコピー（事前に用意したものを使う）
+# CLAUDE.md はルートに配置
+```
+
+### 9.4 PR テンプレート
+
+`.github/pull_request_template.md` を作成：
+
+```markdown
+## 概要
+<!-- この PR で何をしたか -->
+
+## 変更内容
+- [ ] xxx を実装
+- [ ] yyy を修正
+
+## 関連 Issue
+Closes #
+
+## 動作確認
+<!-- スクリーンショットや確認手順 -->
+
+## 注意点
+<!-- レビュアーに気をつけて見てほしいポイント -->
+```
+
+### 9.5 初回コミットと push
+
+```bash
+# すべてのファイルをステージング
+git add .
+
+# 初回コミット
+git commit -m "feat: Vow Pact プロジェクトの初期セットアップ
+
+- Rails 8.1 + Vite + React + TypeScript の構成
+- Docker 開発環境（Dockerfile.dev、docker-compose.yml）
+- 認証ジェネレータの実行
+- Tailwind CSS と独自カラーパレットの設定
+- alba、ruby-openai、rack-cors の追加
+- RSpec、Vitest、ESLint、Prettier のセットアップ
+- 設計書とプロジェクトガイドを配置"
+
+# main ブランチに push
+git push -u origin main
+```
+
+### ✅ チェックポイント9
+
+- [ ] GitHub にプライベートリポジトリ `vow_pact` が作成された
+- [ ] main ブランチに初回コミットが push されている
+- [ ] 設計書（docs/）が配置された
+- [ ] CLAUDE.md がルートにある
+
+---
+
+## 10. Render デプロイ準備
+
+Render には Docker を使わない標準フロー（Native Runtime）でデプロイします。
+Docker は開発環境だけで使い、本番は Render の標準プロセスを使います。
+
+### 10.1 Procfile の作成
+
+Render が起動コマンドを認識するためのファイルを作成。
+
+`Procfile`（開発用 `Procfile.dev` とは別）：
+
+```
+web: bundle exec rails server -p $PORT -e $RAILS_ENV
+release: bundle exec rails db:migrate
+```
+
+### 10.2 build.sh の作成
+
+`bin/render-build.sh` を作成：
+
+```bash
+#!/usr/bin/env bash
+# bin/render-build.sh
+
+set -o errexit
+
+bundle install
+npm install
+npm run build
+
+bundle exec rails assets:precompile
+bundle exec rails db:migrate
+```
+
+実行権限を付与：
+
+```bash
+chmod a+x bin/render-build.sh
+```
+
+### 10.3 Neon でプロジェクトを作成
+
+1. [Neon コンソール](https://console.neon.tech/) にログイン
+2. 「New Project」をクリック
+3. 以下の設定で作成：
+   - **Name**: `vow-pact`
+   - **PostgreSQL Version**: 18
+   - **Region**: `AWS - Asia Pacific (Tokyo)` または最寄りのリージョン
+   - **Create a database named**: `vow_pact_production`
+4. 接続情報をコピーして `.env` に保存
+
+### 10.4 Render での Web Service 作成
+
+1. [Render ダッシュボード](https://dashboard.render.com/) にログイン
+2. 「New +」→「Web Service」をクリック
+3. GitHub の `vow_pact` リポジトリを選択
+4. 以下の設定で作成：
+
+| 項目 | 値 |
+|---|---|
+| Name | vow-pact |
+| Region | Singapore（一番近い） |
+| Branch | main |
+| Runtime | Ruby |
+| Build Command | `./bin/render-build.sh` |
+| Start Command | `bundle exec rails server` |
+| Plan | Free |
+
+### 10.5 環境変数の設定
+
+Render の「Environment」タブで以下を設定：
+
+| Key | Value |
+|---|---|
+| DATABASE_URL | （Neon の接続情報、`?sslmode=require` 必須） |
+| OPENAI_API_KEY | （OpenAI から取得） |
+| RAILS_MASTER_KEY | （`config/master.key` の内容） |
+| RAILS_ENV | production |
+| RACK_ENV | production |
+| FRONTEND_URL | （Render の URL） |
+
+### 10.6 マスターキーの確認
+
+```bash
+cat config/master.key
+```
+
+### 10.7 デプロイ実行
+
+設定完了後、Render が自動的にビルド・デプロイを開始します。
+
+### ✅ チェックポイント10
+
+- [ ] Neon にプロジェクトが作成された
+- [ ] Render に Web Service が作成された
+- [ ] 環境変数が設定された
+- [ ] デプロイが成功した
+
+---
+
+## 11. CI/CD（GitHub Actions）の設定
+
+### 11.1 ワークフローファイルの作成
+
+`.github/workflows/ci.yml` を作成：
+
+```yaml
+# .github/workflows/ci.yml
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: vow_pact
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: vow_pact_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Set up DB
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://vow_pact:password@localhost:5432/vow_pact_test
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:migrate
+
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://vow_pact:password@localhost:5432/vow_pact_test
+        run: bundle exec rspec
+
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+```
+
+GitHub Actions は Docker を使わず、ホストマシンで PostgreSQL を起動します。
+これにより CI が高速になります。
+
+### 11.2 動作確認
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "chore: GitHub Actions の CI 設定を追加"
+git push origin main
+```
+
+GitHub の Actions タブで CI が成功するか確認。
+
+### ✅ チェックポイント11
+
+- [ ] `.github/workflows/ci.yml` が作成された
+- [ ] main への push で CI が実行される
+- [ ] RSpec、RuboCop、ESLint のジョブが成功する
+
+---
+
+## 12. 動作確認
+
+### ローカル環境（Docker）
+
+```bash
+# コンテナ起動
+docker compose up
+
+# ブラウザで http://localhost:3000
+# 「Vow Pact」のページが見える
+```
+
+### テスト
+
+```bash
+# RSpec
+docker compose exec web bundle exec rspec
+
+# Vitest
+docker compose exec web npm run test
+
+# Lint
+docker compose exec web bundle exec rubocop
+docker compose exec web npm run lint
+```
+
+### Git ワークフロー
+
+```bash
+# 試しにブランチを切って、PR を作る
+git checkout -b feat/test-branch
+git add .
+git commit -m "test: PR テスト"
+git push origin feat/test-branch
+
+gh pr create --title "test: PR テスト" --body "CI動作確認用"
+gh pr checks <PR番号>
+
+# テスト完了したら閉じる
+gh pr close <PR番号> --delete-branch
+git checkout main
+```
+
+### ✅ 最終チェックポイント
+
+- [ ] Docker でローカルサーバーが起動する
+- [ ] RSpec、Vitest、RuboCop、ESLint がすべて通る
+- [ ] Render の URL でアプリが見える
+- [ ] PR を作ると CI が動く
+- [ ] CLAUDE.md と設計書が GitHub にある
+
+🎉 **おめでとうございます！セットアップ完了です。**
+
+これで実装フェーズに進む準備が整いました。
+
+---
+
+## 13. トラブルシューティング
+
+### Q. Docker コンテナが起動しない
+
+**症状**: `docker compose up` でエラー
+
+**対処**:
+```bash
+# ログを確認
+docker compose logs web
+docker compose logs db
+
+# 再ビルド
+docker compose down -v
+docker compose build --no-cache
+docker compose up
+```
+
+### Q. ファイル変更がコンテナに反映されない
+
+**症状**: コードを書き換えても画面が変わらない
+
+**対処**:
+- Mac の Docker は `cached` モードでも一部反映が遅いことがある
+- ブラウザの Hard Reload（Cmd + Shift + R）
+- Vite の HMR が効いているか、ブラウザのコンソールを確認
+
+### Q. bundle install / npm install で「Permission denied」
+
+**症状**: コンテナ内でパーミッションエラー
+
+**対処**:
+```bash
+# コンテナ内のユーザーを確認
+docker compose exec web whoami
+
+# ホスト側でファイル権限を確認
+ls -la
+
+# 権限が root になっている場合
+sudo chown -R $USER:$USER .
+```
+
+### Q. ホストの3000ポートが既に使われている
+
+**症状**: `Bind for 0.0.0.0:3000 failed: port is already allocated`
+
+**対処**:
+```bash
+# 3000 ポートを使っているプロセスを確認
+lsof -i :3000
+
+# 該当プロセスを kill
+kill -9 <PID>
+
+# または docker-compose.yml でポートを変更
+# ports:
+#   - "3001:3000"
+```
+
+### Q. PostgreSQL に接続できない
+
+**症状**: `could not connect to server`
+
+**対処**:
+```bash
+# DB コンテナの状態確認
+docker compose ps
+
+# DB コンテナのログ確認
+docker compose logs db
+
+# DB コンテナに直接入って確認
+docker compose exec db psql -U vow_pact -d vow_pact_development
+```
+
+### Q. Vite の HMR が効かない
+
+**症状**: ファイル変更がブラウザに反映されない
+
+**対処**:
+- `vite.config.ts` の `server.host: '0.0.0.0'` 設定を確認
+- `vite.config.ts` の `server.hmr.host: 'localhost'` 設定を確認
+- ブラウザのコンソールで HMR の WebSocket 接続を確認
+
+### Q. M1/M2/M3/M4 Mac でビルドが遅い
+
+**症状**: `docker compose build` が時間かかる、起動も遅い
+
+**対処**:
+- Docker Desktop の設定で「Use Rosetta for x86/amd64 emulation on Apple Silicon」を有効化
+- または ARM64 イメージを明示的に使用：
+  ```yaml
+  # docker-compose.yml
+  services:
+    db:
+      image: postgres:18
+      platform: linux/arm64  # 追加
+  ```
+
+### Q. RSpec で「LoadError: cannot load such file」
+
+**症状**: `cannot load such file -- factory_bot`
+
+**対処**:
+```bash
+# Gemfile に factory_bot_rails があるか確認
+docker compose exec web bundle install
+docker compose restart web
+```
+
+### Q. CORS エラー
+
+**症状**: ブラウザのコンソールに `CORS policy` エラー
+
+**対処**:
+- `config/initializers/cors.rb` の `origins` を確認
+- 開発時は `http://localhost:3000` と `http://localhost:5173` の両方を許可するか、ワイルドカードを設定
+
+### Q. Render のデプロイが失敗する
+
+**症状**: ビルドエラーで止まる
+
+**対処**:
+- Render のログを確認（よくある原因：環境変数の設定漏れ）
+- DATABASE_URL に `?sslmode=require` が含まれているか確認
+- `bin/render-build.sh` に実行権限が付いているか確認
+- ローカルで `RAILS_ENV=production bundle exec rails assets:precompile` が成功するか試す
+
+### それでも解決しない場合
+
+1. エラーメッセージで Google 検索
+2. 設計書（CLAUDE.md, data_model.md, api_design.md）を再確認
+3. このガイドを最初から見直す
+4. `docker compose down -v && docker compose up --build` で再構築
+5. 最終手段：ディレクトリを削除して最初からやり直す
+
+---
+
+## 次のステップ
+
+セットアップ完了後は、いよいよ実装フェーズです。
+
+1. データモデルのマイグレーション（5テーブル）
+2. シリアライザーの作成（alba ベース）
+3. API エンドポイントの実装（23エンドポイント）
+4. フロントエンドの実装（13画面）
+
+Claude Code に CLAUDE.md と設計書を渡して、エンドポイント単位で順番に実装していくのがおすすめです。
+
+---
+
+**最終更新**: 2026年5月2日（Docker 開発版）


### PR DESCRIPTION
## 概要

別Claudeセッション（Web版）で作成した設計フェーズの成果物を取り込む。今後の実装で参照するため。

## 追加ファイル

### プロジェクトルート
- `CLAUDE.md` — プロジェクト全体ガイド（750行から224行に圧縮済み）

### docs/
- `docs/data_model.md` — 5テーブル設計（users / pacts / check_ins / crests / ai_generations）
- `docs/api_design.md` — 23エンドポイントの仕様
- `docs/setup_guide.md` — Docker版セットアップ手順（古い参考、現実装と一部齟齬あり）
- `docs/VowPact_mock/` — HTMLモックアップ13画面 + design-canvas.jsx

## 補足

### .gitignore に追加
- `.DS_Store`（macOS Finderが自動生成するメタファイル）

### setup_guide.md の扱い

setup_guide.md の内容は実装が始まる前に書かれたため、postgres:18のマウント変更や app/frontend パス、libyaml-dev不足など、実作業で得た知見と齟齬があります。詳細は Obsidianの学習ログ（08〜09）に記録済み。

## 関連Issue

Project Boardの以下のIssueで参照される想定:
- #10〜#14 のモデル実装
- #17〜#20 のAPI実装
- #21 の13画面実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented authentication, home, contract creation, ranking, settings, and detail screens for Vow Pact application
  * Added interactive design canvas for screen previewing and prototyping

* **Documentation**
  * Added comprehensive API specification and database design documentation
  * Created setup guide for development and production environments
  * Added development operations guidelines

* **Chores**
  * Updated .gitignore to exclude macOS metadata files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->