### PR TITLE
Production database を Neon 単一DB構成に変更（Solid系は同居）

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -87,18 +87,13 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: vow_pact_production
-    username: vow_pact
-    password: <%= ENV["VOW_PACT_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
-    database: vow_pact_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: vow_pact_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: vow_pact_production_cable
     migrations_paths: db/cable_migrate


### PR DESCRIPTION
## 概要

Issue #5 の対応。production の database.yml を Neon 単一DB構成に変更。Solid Queue/Cache/Cable は同一DBに同居させる方針。

## 設計判断

### 採用案：Solid 系を同一 Neon DB に同居（案 B）

3 つの選択肢を検討：

| 案 | 内容 | 評価 |
|---|---|---|
| 案A: 全部 inline / async | Solid 系を実質使わない | ❌ AI 非同期が機能しない |
| **案B: 同一 Neon DB に Solid 系同居** | 4 connections だが 1 DB 共有 | ✅ 採用 |
| 案C: Rails 8 デフォルト維持（4 別DB） | 完全分離 | ❌ Neon 無料枠浪費 |

採用理由:
- Issue #20（AI API）の非同期処理（202 Accepted + ポーリング）を維持できる
- Neon 無料枠（0.5GB）を効率的に使える
- Rails 8 のモダン構成（Solid系）を活用できる
- 後で必要なら 4 別DB に分割可能

## 変更内容

`config/database.yml` の production セクション:

- `database: vow_pact_production` → `url: <%= ENV["DATABASE_URL"] %>`
- `username` / `password` 行を削除（URL に含まれる）
- cache / queue / cable の各セクションから個別 `database:` 行を削除（primary URL を継承）
- `migrations_paths` は維持（Solid 系のテーブル分離のため必要）

## 影響範囲

- ✅ development / test: 変更なし（Docker DB 継続）
- ✅ production: Neon 1 DB に Solid 系のテーブル同居
- ✅ ローカルテスト: rspec / rubocop ともに green

## 動作確認

- [x] docker compose exec web bundle exec rspec が「0 examples, 0 failures」で通る
- [x] docker compose exec web bundle exec rubocop が「no offenses detected」

Closes #5