### PR TITLE
環境変数の例を .env.example に整理（FRONTEND_URL 追加、Neon URL は含めない方針）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,6 @@ POSTGRES_DB=vow_pact_development
 # 形式: postgresql://USER:PASSWORD@HOST:PORT/DBNAME
 DATABASE_URL=postgresql://vow_pact:PASSWORD@db:5432/vow_pact_development
 
-# 本番環境（Neon）形式の例
-# DATABASE_URL=postgresql://USER:PASSWORD@ep-xxxxxxxx-pooler.region.neon.tech/dbname?sslmode=require
-
 # フロントエンドURL
 FRONTEND_URL=http://localhost:3000
 

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,17 @@
 # PostgreSQL
-  POSTGRES_USER=vow_pact
-  POSTGRES_PASSWORD=
-  POSTGRES_DB=vow_pact_development
+POSTGRES_USER=vow_pact
+POSTGRES_PASSWORD=
+POSTGRES_DB=vow_pact_development
 
-  # Rails -> DB 接続URL
-  # 形式: postgresql://USER:PASSWORD@HOST:PORT/DBNAME
-  DATABASE_URL=postgresql://vow_pact:PASSWORD@db:5432/vow_pact_development
+# Rails -> DB 接続URL
+# 形式: postgresql://USER:PASSWORD@HOST:PORT/DBNAME
+DATABASE_URL=postgresql://vow_pact:PASSWORD@db:5432/vow_pact_development
 
-  # OpenAI API
-  OPENAI_API_KEY=
+# 本番環境（Neon）形式の例
+# DATABASE_URL=postgresql://USER:PASSWORD@ep-xxxxxxxx-pooler.region.neon.tech/dbname?sslmode=require
+
+# フロントエンドURL
+FRONTEND_URL=http://localhost:3000
+
+# OpenAI API
+OPENAI_API_KEY=


### PR DESCRIPTION
## 概要

Issue #6 の対応。`.env.example` を整理して、本番環境変数の役割を明確化。

## 設計判断

### Neon URL は `.env.example` にも書かない（AI セキュリティ対応）

検討の経緯:
- 当初は本番（Neon）URL の形式例を コメント として書く予定だった
- AI ツール（Claude Code 等）が `.env` / `.env.example` を読む可能性がある
- ホスト名（`ep-xxxx-pooler.region.neon.tech`）は本番情報なので、`.env.example` でも記載しない方針に変更

### 本番接続情報の管理場所

| 機密 | 場所 |
|---|---|
| ローカル開発の DB 認証情報 | `.env`（Git 除外） |
| 本番 DB URL（Neon） | **Render の管理画面で直接設定**（`.env` には書かない） |
| RAILS_MASTER_KEY | Render の管理画面 |
| OpenAI API キー（本番） | Render の管理画面 |

→ Mabatalk と同じ Rails 純正に近いパターン。

## 変更内容

`.env.example`:

- インデント修正（先頭スペースを除去、ignore パターンと同じ問題を回避）
- `FRONTEND_URL` 追加（CORS 設定・リダイレクト URL 用、開発デフォルト値）
- 既存の `POSTGRES_*` / `DATABASE_URL` / `OPENAI_API_KEY` は維持

## 動作確認

- [x] docker compose exec web bundle exec rspec が「0 examples, 0 failures」
- [x] docker compose exec web bundle exec rubocop が「no offenses detected」
- [x] git status で `.env`（実値）が出てこない（Git 除外確認）

## 関連

- AI セキュリティ観点での議論を経て、本番情報を `.env.example` から除外
- 本番設定は Issue #22（Render デプロイ）で Render 管理画面に直接入力する方針

Closes #6