### PR TITLE
users テーブル + User モデル + spec を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "puma", ">= 5.0"
 gem "tailwindcss-rails"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     alba (3.10.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
@@ -417,6 +418,7 @@ PLATFORMS
 
 DEPENDENCIES
   alba
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,43 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  # アソシエーション（Pact / CheckIn / AiGeneration は v1.1 で実装）
+  # has_many :pacts, dependent: :destroy
+  # has_many :check_ins, through: :pacts
+  # has_many :ai_generations, dependent: :destroy
+
+  # バリデーション
+  validates :email,
+            presence: true,
+            uniqueness: { case_sensitive: false },
+            format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :nickname,
+            presence: true,
+            length: { in: 1..30 }
+  validates :password,
+            length: { minimum: 6 },
+            allow_nil: true
+  validates :avatar_url,
+            format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]) },
+            allow_blank: true
+  validates :is_public,
+            inclusion: { in: [ true, false ] }
+  validates :streak_count,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :longest_streak,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  # validation 前に正規化（前後空白除去 + 小文字化）
+  before_validation :normalize_email
+  before_validation :strip_nickname
+
+  private
+
+  def normalize_email
+    self.email = email.strip.downcase if email.present?
+  end
+
+  def strip_nickname
+    self.nickname = nickname.strip if nickname.present?
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,6 +57,9 @@ development:
 test:
   <<: *default
   database: vow_pact_test
+  host: db
+  username: vow_pact
+  password: password
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20260503104819_create_users.rb
+++ b/db/migrate/20260503104819_create_users.rb
@@ -1,0 +1,17 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+      t.string :nickname, null: false
+      t.string :avatar_url
+      t.boolean :is_public, null: false, default: true
+      t.integer :streak_count, null: false, default: 0
+      t.integer :longest_streak, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20260503115041_change_users_email_index_to_case_insensitive.rb
+++ b/db/migrate/20260503115041_change_users_email_index_to_case_insensitive.rb
@@ -1,0 +1,11 @@
+class ChangeUsersEmailIndexToCaseInsensitive < ActiveRecord::Migration[8.1]
+  def up
+    remove_index :users, :email
+    add_index :users, "LOWER(email)", unique: true, name: "index_users_on_lower_email"
+  end
+
+  def down
+    remove_index :users, name: "index_users_on_lower_email"
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_05_03_115041) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "avatar_url"
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.boolean "is_public", default: true, null: false
+    t.integer "longest_streak", default: 0, null: false
+    t.string "nickname", null: false
+    t.string "password_digest", null: false
+    t.integer "streak_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password123" }
+    nickname { Faker::Name.first_name }
+    avatar_url { nil }
+    is_public { true }
+    streak_count { 0 }
+    longest_streak { 0 }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "factory" do
+    it "valid な user を生成できる" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+  end
+
+  describe "validations" do
+    describe "email" do
+      it "必須" do
+        user = build(:user, email: nil)
+        expect(user).not_to be_valid
+        expect(user.errors[:email]).to include("can't be blank")
+      end
+
+      it "メール形式チェック" do
+        user = build(:user, email: "not-an-email")
+        expect(user).not_to be_valid
+        expect(user.errors[:email]).to include("is invalid")
+      end
+
+      it "重複は不可（大文字小文字無視）" do
+        create(:user, email: "test@example.com")
+        duplicate = build(:user, email: "TEST@example.com")
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:email]).to include("has already been taken")
+      end
+
+      it "DB レベルの UNIQUE 制約も大文字小文字無視（バリデーションをすり抜けても止まる）" do
+        create(:user, email: "test@example.com")
+        # validate: false で Rails のバリデーションをスキップ → DB 制約だけが残る
+        bypass = build(:user, email: "TEST@Example.com")
+        expect {
+          bypass.save(validate: false)
+        }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+
+    describe "nickname" do
+      it "必須" do
+        user = build(:user, nickname: nil)
+        expect(user).not_to be_valid
+        expect(user.errors[:nickname]).to include("can't be blank")
+      end
+
+      it "1〜30文字" do
+        expect(build(:user, nickname: "a")).to be_valid
+        expect(build(:user, nickname: "a" * 30)).to be_valid
+        expect(build(:user, nickname: "a" * 31)).not_to be_valid
+      end
+    end
+
+    describe "password" do
+      it "必須（新規作成時）" do
+        user = User.new(email: "x@example.com", nickname: "X", password: nil)
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("can't be blank")
+      end
+
+      it "6文字以上" do
+        user = build(:user, password: "12345")
+        expect(user).not_to be_valid
+        expect(user.errors[:password]).to include("is too short (minimum is 6 characters)")
+      end
+    end
+
+    describe "avatar_url" do
+      it "URL 形式（任意）" do
+        expect(build(:user, avatar_url: "https://example.com/a.jpg")).to be_valid
+        expect(build(:user, avatar_url: nil)).to be_valid
+        expect(build(:user, avatar_url: "")).to be_valid
+        expect(build(:user, avatar_url: "not-a-url")).not_to be_valid
+      end
+    end
+
+    describe "streak_count / longest_streak" do
+      it "0 以上の整数" do
+        expect(build(:user, streak_count: -1)).not_to be_valid
+        expect(build(:user, streak_count: 0)).to be_valid
+        expect(build(:user, longest_streak: -1)).not_to be_valid
+        expect(build(:user, longest_streak: 0)).to be_valid
+      end
+    end
+  end
+
+  describe "正規化（before_validation）" do
+    it "email を保存前に小文字化する" do
+      user = create(:user, email: "Mixed@Example.COM")
+      expect(user.reload.email).to eq("mixed@example.com")
+    end
+
+    it "email の前後空白を除去する" do
+      user = create(:user, email: "  test@example.com  ")
+      expect(user.reload.email).to eq("test@example.com")
+    end
+
+    it "nickname の前後空白を除去する" do
+      user = create(:user, nickname: "  山田  ")
+      expect(user.reload.nickname).to eq("山田")
+    end
+
+    it "validation 前に正規化されているので、空白入り email でも uniqueness で弾かれる" do
+      create(:user, email: "test@example.com")
+      duplicate = build(:user, email: "  TEST@example.com  ")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:email]).to include("has already been taken")
+    end
+  end
+
+  describe "has_secure_password" do
+    let(:user) { create(:user, password: "mypassword") }
+
+    it "正しいパスワードで authenticate できる" do
+      expect(user.authenticate("mypassword")).to eq(user)
+    end
+
+    it "間違ったパスワードでは authenticate できない" do
+      expect(user.authenticate("wrong")).to be(false)
+    end
+
+    it "password_digest が保存され、平文 password は保存されない" do
+      expect(user.password_digest).to be_present
+      expect(user.password_digest).not_to eq("mypassword")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #10 の対応。users テーブル、User モデル（has_secure_password + バリデーション + 正規化）、ファクトリ、spec を実装。

bcrypt 有効化、test DB 設定、DB 側の大文字小文字無視一意性までセットで対応。

## 変更内容

### 1. bcrypt の有効化（Gemfile）
- 既存のコメントアウトされた `gem "bcrypt", "~> 3.1.7"` をアンコメント
- `has_secure_password` を使うために必須

### 2. test DB の設定修正（config/database.yml）
- 既存の test セクションでは host/username/password が未定義 → socket 接続失敗
- `host: db / username: vow_pact / password: password` を明示
- これで test DB（vow_pact_test）が確実に Docker DB を指す

### 3. users テーブル（マイグレーション 1）
- カラム: email, password_digest, nickname, avatar_url, is_public, streak_count, longest_streak
- 通常の email UNIQUE インデックスで初期作成

### 4. email インデックスの case-insensitive 化（マイグレーション 2）
- `add_index :users, "LOWER(email)", unique: true, name: "index_users_on_lower_email"`
- 並行リクエストや直接 DB 操作でも大文字小文字違いの重複を物理的に阻止
- 実務目線で重要（Codex レビュー指摘事項）

### 5. User モデル
- `has_secure_password`
- バリデーション: email 形式・重複不可・必須、nickname 1-30 文字、password 6 文字以上、avatar_url URL 形式、is_public boolean、streak_count/longest_streak 0 以上
- `before_validation :normalize_email` — 前後空白除去 + 小文字化（バリデーション前に正規化）
- `before_validation :strip_nickname` — 前後空白除去
- アソシエーション（pacts / check_ins / ai_generations）はコメントアウト、関連モデル実装時にアンコメント

### 6. ファクトリ + spec
- `spec/factories/users.rb` — Faker 連携、ユニーク email
- `spec/models/user_spec.rb` — 18 テスト（factory / バリデーション / 正規化 / DB 制約 / has_secure_password）

## 設計判断のハイライト

### Codex レビュー指摘を反映
1. **DB 側 case-insensitive 一意性**: `LOWER(email)` 関数インデックスで race condition を防止
2. **`before_save` → `before_validation`**: バリデーション前に正規化することで、検証ロジックと正規化のタイミングを揃える
3. **入力時のスペース除去**: ユーザー要望でメール・ニックネームの前後空白を自動除去

### `is_public` の `inclusion` 採用理由
- Ruby の `false.blank? == true` 仕様により、boolean に `presence: true` は不適切
- `inclusion: { in: [ true, false ] }` で nil だけを弾く

## 動作確認

- [x] docker compose exec web bin/rails db:migrate 成功（2 マイグレーション）
- [x] docker compose exec web bin/rails db:test:prepare で test DB 同期
- [x] docker compose exec web bundle exec rspec → 18 examples, 0 failures
- [x] docker compose exec web bundle exec rubocop → 27 files, no offenses
- [x] DB の users インデックスが `index_users_on_lower_email` (lower((email)::text)) UNIQUE になっている

## 残課題（v1.1 で対応）

- has_many :pacts / check_ins / ai_generations のアソシエーション（関連モデル実装時にアンコメント）
- streak_count キャッシュ更新ロジック（CheckIn の after_create/after_destroy で再計算）

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User authentication system with secure password handling
  * User profiles with customizable nicknames and avatars
  * Public/private account visibility settings
  * Streak tracking functionality to monitor user activity

* **Tests**
  * Comprehensive test coverage for user functionality

* **Chores**
  * Added password encryption security dependency
  * Updated database configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->