### PR TITLE
pacts テーブル + Pact モデル + spec を追加

### DIFF
--- a/app/models/pact.rb
+++ b/app/models/pact.rb
@@ -1,0 +1,57 @@
+class Pact < ApplicationRecord
+  # MVP に含めない関連（v1.1 で実装）
+  # has_many :check_ins, dependent: :destroy
+  # has_one :crest, dependent: :destroy
+  # has_many :ai_generations, dependent: :nullify
+
+  belongs_to :user
+
+  # 進行中の契約は最大 3 つまで（ユーザーごと）
+  MAX_ACTIVE_PACTS = 3
+
+  enum :status, { active: 0, completed: 1, failed: 2, abandoned: 3 }
+
+  # バリデーション
+  validates :goal,
+            presence: true,
+            length: { in: 1..500 }
+  validates :constraint_text,
+            presence: true,
+            length: { in: 1..500 }
+  validates :difficulty,
+            presence: true,
+            inclusion: { in: 1..5 }
+  validates :deadline,
+            presence: true
+  validates :signed_at,
+            presence: true
+  validate :deadline_must_be_in_the_future, on: :create
+  validate :active_pacts_limit, if: -> { active? }
+
+  # 正規化
+  before_validation :strip_text_fields
+
+  private
+
+  def deadline_must_be_in_the_future
+    return if deadline.blank?
+    return if deadline > Date.current
+
+    errors.add(:deadline, "must be in the future")
+  end
+
+  def active_pacts_limit
+    return unless user
+
+    active_count = user.pacts.where(status: :active).where.not(id: id).count
+    return if active_count < MAX_ACTIVE_PACTS
+
+    errors.add(:base, "active な契約は#{MAX_ACTIVE_PACTS}つまでです")
+  end
+
+  def strip_text_fields
+    self.goal = goal.strip if goal.present?
+    self.constraint_text = constraint_text.strip if constraint_text.present?
+    self.title = title.strip if title.present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   has_secure_password
 
-  # アソシエーション（Pact / CheckIn / AiGeneration は v1.1 で実装）
-  # has_many :pacts, dependent: :destroy
+  # アソシエーション
+  has_many :pacts, dependent: :destroy
+  # CheckIn / AiGeneration は v1.1 で実装
   # has_many :check_ins, through: :pacts
   # has_many :ai_generations, dependent: :destroy
 

--- a/db/migrate/20260503120439_create_pacts.rb
+++ b/db/migrate/20260503120439_create_pacts.rb
@@ -1,0 +1,22 @@
+class CreatePacts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :pacts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :goal, null: false
+      t.text :constraint_text, null: false
+      t.integer :difficulty, null: false
+      t.text :difficulty_reason
+      t.date :deadline, null: false
+      t.integer :status, null: false, default: 0
+      t.string :title
+      t.datetime :signed_at, null: false
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    add_index :pacts, :status
+    add_index :pacts, [ :user_id, :status ]
+    add_index :pacts, :deadline
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_115041) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_03_120439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "pacts", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.text "constraint_text", null: false
+    t.datetime "created_at", null: false
+    t.date "deadline", null: false
+    t.integer "difficulty", null: false
+    t.text "difficulty_reason"
+    t.text "goal", null: false
+    t.datetime "signed_at", null: false
+    t.integer "status", default: 0, null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["deadline"], name: "index_pacts_on_deadline"
+    t.index ["status"], name: "index_pacts_on_status"
+    t.index ["user_id", "status"], name: "index_pacts_on_user_id_and_status"
+    t.index ["user_id"], name: "index_pacts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "avatar_url"
@@ -26,4 +45,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_115041) do
     t.datetime "updated_at", null: false
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
   end
+
+  add_foreign_key "pacts", "users"
 end

--- a/spec/factories/pacts.rb
+++ b/spec/factories/pacts.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :pact do
+    association :user
+    goal { Faker::Lorem.sentence(word_count: 5) }
+    constraint_text { Faker::Lorem.sentence(word_count: 5) }
+    difficulty { 3 }
+    deadline { 30.days.from_now.to_date }
+    status { :active }
+    signed_at { Time.current }
+    completed_at { nil }
+    title { nil }
+  end
+end

--- a/spec/models/pact_spec.rb
+++ b/spec/models/pact_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+RSpec.describe Pact, type: :model do
+  describe "factory" do
+    it "valid な pact を生成できる" do
+      pact = build(:pact)
+      expect(pact).to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "user に belongs_to" do
+      user = create(:user)
+      pact = create(:pact, user: user)
+      expect(pact.user).to eq(user)
+    end
+
+    it "User から has_many :pacts でアクセスできる" do
+      user = create(:user)
+      pact = create(:pact, user: user)
+      expect(user.pacts).to include(pact)
+    end
+
+    it "User 削除で紐づく pact も destroy される" do
+      user = create(:user)
+      create(:pact, user: user)
+      expect { user.destroy }.to change { Pact.count }.by(-1)
+    end
+  end
+
+  describe "enum status" do
+    it "active / completed / failed / abandoned を持つ" do
+      expect(Pact.statuses.keys).to contain_exactly("active", "completed", "failed", "abandoned")
+    end
+
+    it "デフォルトは active" do
+      pact = create(:pact)
+      expect(pact.status).to eq("active")
+    end
+  end
+
+  describe "validations" do
+    describe "goal" do
+      it "必須" do
+        pact = build(:pact, goal: nil)
+        expect(pact).not_to be_valid
+        expect(pact.errors[:goal]).to include("can't be blank")
+      end
+
+      it "1〜500文字" do
+        expect(build(:pact, goal: "a")).to be_valid
+        expect(build(:pact, goal: "a" * 500)).to be_valid
+        expect(build(:pact, goal: "a" * 501)).not_to be_valid
+      end
+
+      it "前後空白を除去" do
+        pact = create(:pact, goal: "  目標を立てる  ")
+        expect(pact.reload.goal).to eq("目標を立てる")
+      end
+    end
+
+    describe "constraint_text" do
+      it "必須" do
+        pact = build(:pact, constraint_text: nil)
+        expect(pact).not_to be_valid
+        expect(pact.errors[:constraint_text]).to include("can't be blank")
+      end
+
+      it "1〜500文字" do
+        expect(build(:pact, constraint_text: "a" * 500)).to be_valid
+        expect(build(:pact, constraint_text: "a" * 501)).not_to be_valid
+      end
+    end
+
+    describe "difficulty" do
+      it "必須" do
+        pact = build(:pact, difficulty: nil)
+        expect(pact).not_to be_valid
+        expect(pact.errors[:difficulty]).to include("can't be blank")
+      end
+
+      it "1〜5の整数" do
+        expect(build(:pact, difficulty: 1)).to be_valid
+        expect(build(:pact, difficulty: 5)).to be_valid
+        expect(build(:pact, difficulty: 0)).not_to be_valid
+        expect(build(:pact, difficulty: 6)).not_to be_valid
+      end
+    end
+
+    describe "deadline" do
+      it "必須" do
+        pact = build(:pact, deadline: nil)
+        expect(pact).not_to be_valid
+        expect(pact.errors[:deadline]).to include("can't be blank")
+      end
+
+      it "未来の日付（新規作成時のみ検証）" do
+        expect(build(:pact, deadline: 1.day.from_now.to_date)).to be_valid
+        # 過去日は弾く
+        past_pact = build(:pact, deadline: 1.day.ago.to_date)
+        expect(past_pact).not_to be_valid
+        expect(past_pact.errors[:deadline]).to include("must be in the future")
+        # 既存 pact は更新時に過去日でも valid（期日切れは状態として許容）
+        existing = create(:pact, deadline: 1.day.from_now.to_date)
+        existing.update(goal: "新しい目標")
+        existing.deadline = 1.day.ago.to_date
+        expect(existing.valid?).to be true
+      end
+    end
+
+    describe "active 契約の上限（最大3つ）" do
+      let(:user) { create(:user) }
+
+      it "3つまでは active 契約を作れる" do
+        3.times { create(:pact, user: user, status: :active) }
+        expect(user.pacts.where(status: :active).count).to eq(3)
+      end
+
+      it "4つ目の active 契約は弾かれる" do
+        3.times { create(:pact, user: user, status: :active) }
+        fourth = build(:pact, user: user, status: :active)
+        expect(fourth).not_to be_valid
+        expect(fourth.errors[:base]).to include("active な契約は3つまでです")
+      end
+
+      it "completed / abandoned はカウントしない（4つ目作成可能）" do
+        2.times { create(:pact, user: user, status: :active) }
+        create(:pact, user: user, status: :completed, completed_at: Time.current)
+        create(:pact, user: user, status: :abandoned)
+
+        new_active = build(:pact, user: user, status: :active)
+        expect(new_active).to be_valid
+      end
+
+      it "他ユーザーの active 契約はカウントしない" do
+        other_user = create(:user)
+        3.times { create(:pact, user: other_user, status: :active) }
+
+        my_pact = build(:pact, user: user, status: :active)
+        expect(my_pact).to be_valid
+      end
+
+      it "自分自身の更新では再カウントしない" do
+        3.times { create(:pact, user: user, status: :active) }
+        existing = user.pacts.first
+        existing.goal = "新しい目標"
+        expect(existing).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #11 の対応（v1.0 MVP 簡易版）。pacts テーブル、Pact モデル、spec を実装。User モデルに `has_many :pacts` を追加。

## 変更内容

### 1. pacts テーブル（マイグレーション）
- カラム: user_id, goal, constraint_text, difficulty, difficulty_reason, deadline, status, title, signed_at, completed_at
- インデックス: user_id, status, [user_id, status], deadline
- foreign_key 制約 (user_id → users.id)

### 2. Pact モデル
- `belongs_to :user`
- `enum :status, { active: 0, completed: 1, failed: 2, abandoned: 3 }`
- バリデーション:
  - goal / constraint_text: 必須・1-500文字
  - difficulty: 必須・1-5
  - deadline: 必須・新規作成時は未来日付
  - active 契約はユーザーごと最大3つ（カスタムバリデーション）
- `before_validation :strip_text_fields`（goal / constraint_text / title の前後空白除去）
- `MAX_ACTIVE_PACTS = 3` 定数で上限を明示

### 3. User モデルの更新
- `has_many :pacts, dependent: :destroy` を有効化（コメントアウトから復活）
- CheckIn / AiGeneration の関連は引き続きコメントアウト（v1.1 で実装）

### 4. ファクトリ + spec
- `spec/factories/pacts.rb` — Faker でランダムな目標・制約
- `spec/models/pact_spec.rb` — 20 テスト
  - factory / アソシエーション / enum / バリデーション
  - active 上限（3つOK、4つ目NG、他状態カウントしない、他ユーザー無関係、自分の更新はOK）
  - 期日のバリデーション（新規作成時のみ未来必須）

## 設計判断

### MVP スコープ（v1.0）
- 必須バリデーション + active 最大3つ
- アソシエーション（User のみ）

### v1.1 で対応予定
- 編集制限ロジック（goal/constraint_text のみ可）
- 論理削除（abandoned への遷移）
- difficulty_reason の AI 連携（カラムは作成済み、使うのは Issue #20 で）
- has_many :check_ins / has_one :crest（関連モデル実装時にアンコメント）

### エラーメッセージ
- 現状はプレーン文字列（英語混在）
- Issue #32（i18n 化）で `config/locales/ja.yml` に集約予定

## 動作確認

- [x] docker compose exec web bin/rails db:migrate 成功
- [x] docker compose exec web bin/rails db:test:prepare で test DB 同期
- [x] rspec → 38 examples (User 18 + Pact 20), 0 failures
- [x] rubocop → 30 files, no offenses

Closes #11