### PR TITLE
認証 API 実装（7 endpoints）+ CSRF 対策 + bin/rspec ラッパー (closes #17)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# CodeRabbit AI コードレビュー設定
+# https://docs.coderabbit.ai/configuration
+
+language: "ja-JP"
+tone_instructions: "丁寧で建設的な日本語でレビューしてください。コードの良い点も指摘し、改善提案は理由とともに具体的に書いてください。"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false

--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    module Auth
+      class PasswordsController < Api::V1::BaseController
+        def update
+          unless Current.user.authenticate(params[:current_password])
+            render json: {
+              errors: [ { code: "invalid_password", message: "現在のパスワードが正しくありません" } ]
+            }, status: :unauthorized
+            return
+          end
+
+          Current.user.update!(
+            password: params[:password],
+            password_confirmation: params[:password_confirmation]
+          )
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    module Auth
+      class RegistrationsController < Api::V1::BaseController
+        allow_unauthenticated_access only: [ :create ]
+        skip_forgery_protection only: [ :create ]
+
+        def create
+          user = User.create!(user_params)
+          start_new_session_for(user)
+          render json: UserSerializer.new(user).serializable_hash, status: :created
+        end
+
+        private
+
+        def user_params
+          params.permit(:email, :nickname, :password, :password_confirmation)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V1
+    module Auth
+      class SessionsController < Api::V1::BaseController
+        allow_unauthenticated_access only: [ :create ]
+        skip_forgery_protection only: [ :create ]
+
+        def create
+          user = User.find_by(email: params[:email]&.downcase)
+
+          if user&.authenticate(params[:password])
+            start_new_session_for(user)
+            render json: UserSerializer.new(user).serializable_hash, status: :ok
+          else
+            render json: {
+              errors: [ { code: "invalid_credentials", message: "メールアドレスまたはパスワードが正しくありません" } ]
+            }, status: :unauthorized
+          end
+        end
+
+        def destroy
+          terminate_session
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/users_controller.rb
+++ b/app/controllers/api/v1/auth/users_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module V1
+    module Auth
+      class UsersController < Api::V1::BaseController
+        def show
+          render json: UserSerializer.new(Current.user).serializable_hash, status: :ok
+        end
+
+        def update
+          Current.user.update!(profile_params)
+          render json: UserSerializer.new(Current.user).serializable_hash, status: :ok
+        end
+
+        def update_email
+          unless Current.user.authenticate(params[:current_password])
+            render json: {
+              errors: [ { code: "invalid_password", message: "現在のパスワードが正しくありません" } ]
+            }, status: :unauthorized
+            return
+          end
+
+          Current.user.update!(email: params[:email])
+          render json: UserSerializer.new(Current.user).serializable_hash, status: :ok
+        end
+
+        private
+
+        def profile_params
+          params.permit(:nickname, :avatar_url, :is_public)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class BaseController < ApplicationController
+      rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+      rescue_from ActiveRecord::RecordInvalid, with: :render_validation_errors
+
+      private
+
+      def render_not_found(exception)
+        render json: { errors: [ { code: "not_found", message: exception.message } ] },
+                status: :not_found
+      end
+
+      def render_validation_errors(exception)
+        errors = exception.record.errors.map do |error|
+          { code: "validation_error", field: error.attribute, message: error.full_message }
+        end
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
+  include ActionController::RequestForgeryProtection
   include Authentication
+
+  protect_from_forgery with: :exception
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,5 +3,8 @@ class ApplicationController < ActionController::API
   include ActionController::RequestForgeryProtection
   include Authentication
 
-  protect_from_forgery with: :exception
+  # ActionController::API は allow_forgery_protection を持たないため
+  # config.action_controller.allow_forgery_protection = false（test.rb）が効かない。
+  # test 環境では protect_from_forgery 自体を呼ばないことで request spec を簡潔に保つ。
+  protect_from_forgery with: :exception unless Rails.env.test?
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -35,7 +35,13 @@ module Authentication
     def start_new_session_for(user)
       user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
         Current.session = session
-        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+        cookies.signed[:session_id] = {
+          value: session.id,
+          httponly: true,
+          same_site: :lax,
+          secure: Rails.env.production?,
+          expires: 2.weeks.from_now
+        }
       end
     end
 

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -16,6 +16,11 @@ export class ApiError extends Error {
   }
 }
 
+function getCsrfToken(): string {
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')
+  return meta?.content ?? ""
+}
+
 export async function api<T>(path: string, options: ApiOptions = {}): Promise<T> {
   const { method = "GET", body } = options
 
@@ -25,6 +30,7 @@ export async function api<T>(path: string, options: ApiOptions = {}): Promise<T>
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
+      "X-CSRF-Token": getCsrfToken(),
     },
     body: body ? JSON.stringify(body) : undefined,
   })

--- a/app/frontend/types/css.d.ts
+++ b/app/frontend/types/css.d.ts
@@ -1,0 +1,2 @@
+// CSS の副作用 import（Vite 経由でビルドされる）を TypeScript が認識できるように
+declare module "*.css"

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,13 @@
+class UserSerializer
+  include Alba::Resource
+
+  attributes :id,
+             :email,
+             :nickname,
+             :avatar_url,
+             :is_public,
+             :streak_count,
+             :longest_streak,
+             :created_at,
+             :updated_at
+end

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,18 @@
+#!/bin/bash
+# RSpec 実行ラッパー
+#
+# docker-compose.yml は RAILS_ENV=development / DATABASE_URL（development DB）を固定している。
+# rspec を素のまま実行すると development 環境・DB で動作してしまうため、
+# このラッパーで test 環境・test DB を明示的に指定して実行する。
+#
+# 使い方:
+#   ./bin/rspec                              # 全テスト
+#   ./bin/rspec spec/models/user_spec.rb     # 特定ファイル
+#   ./bin/rspec spec/models/user_spec.rb:42  # 特定行
+
+set -e
+
+docker compose exec \
+  -e RAILS_ENV=test \
+  -e DATABASE_URL=postgresql://vow_pact:password@db:5432/vow_pact_test \
+  web bundle exec rspec "$@"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # request spec のデフォルトホスト（www.example.com）を許可するため HostAuthorization を緩和
+  # Rails 8 の HostAuthorization は DNS rebinding 攻撃対策だが、テスト環境では不要
+  config.hosts.clear
+  config.hosts << "www.example.com"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,18 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # API ルート（Issue #17 以降で実装）
+  # API ルート
   namespace :api do
     namespace :v1 do
-      # 認証（Issue #17）
-      # post   "auth/signup", to: "auth/registrations#create"
-      # post   "auth/login",  to: "auth/sessions#create"
-      # delete "auth/logout", to: "auth/sessions#destroy"
-      # get    "auth/me",     to: "auth/sessions#show"
+      namespace :auth do
+        post   "signup",   to: "registrations#create"
+        post   "login",    to: "sessions#create"
+        delete "logout",   to: "sessions#destroy"
+        get    "me",       to: "users#show"
+        patch  "me",       to: "users#update"
+        patch  "email",    to: "users#update_email"
+        patch  "password", to: "passwords#update"
+      end
     end
   end
 

--- a/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/spec/requests/api/v1/auth/passwords_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Passwords", type: :request do
+  let!(:user) do
+    create(:user,
+           email: "test@example.com",
+           password: "password123",
+           password_confirmation: "password123")
+  end
+
+  let(:login_params) do
+    { email: "test@example.com", password: "password123" }
+  end
+
+  describe "PATCH /api/v1/auth/password" do
+    context "ログイン中で現パスワードと新パスワードが有効な場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "204 No Content を返し、新パスワードでログインできる" do
+        patch "/api/v1/auth/password", params: {
+          current_password: "password123",
+          password: "newpassword456",
+          password_confirmation: "newpassword456"
+        }, as: :json
+
+        expect(response).to have_http_status(:no_content)
+
+        # ログアウトして新パスワードでログイン
+        delete "/api/v1/auth/logout", as: :json
+        post "/api/v1/auth/login",
+             params: { email: "test@example.com", password: "newpassword456" },
+             as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "現パスワードが間違っている場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/auth/password", params: {
+          current_password: "wrong",
+          password: "newpassword456",
+          password_confirmation: "newpassword456"
+        }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("invalid_password")
+      end
+    end
+
+    context "新パスワードが短すぎる場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "422 を返す" do
+        patch "/api/v1/auth/password", params: {
+          current_password: "password123",
+          password: "abc",
+          password_confirmation: "abc"
+        }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "password" }).to be true
+      end
+    end
+
+    context "新パスワードと確認が一致しない場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "422 を返す" do
+        patch "/api/v1/auth/password", params: {
+          current_password: "password123",
+          password: "newpassword456",
+          password_confirmation: "different789"
+        }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "password_confirmation" }).to be true
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/auth/password", params: {
+          current_password: "password123",
+          password: "newpassword456",
+          password_confirmation: "newpassword456"
+        }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /api/v1/auth/signup" do
+    context "有効なパラメータの場合" do
+      let(:valid_params) do
+        {
+          email: "newuser@example.com",
+          nickname: "新規ユーザー",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      end
+
+      it "201 Created を返し、ユーザーを作成する" do
+        expect {
+          post "/api/v1/auth/signup", params: valid_params, as: :json
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["email"]).to eq("newuser@example.com")
+        expect(response.parsed_body["nickname"]).to eq("新規ユーザー")
+        expect(response.parsed_body).not_to have_key("password_digest")
+      end
+    end
+
+    context "email が空の場合" do
+      let(:invalid_params) do
+        {
+          email: "",
+          nickname: "新規ユーザー",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      end
+
+      it "422 Unprocessable Content を返し、ユーザーを作成しない" do
+        expect {
+          post "/api/v1/auth/signup", params: invalid_params, as: :json
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to be_an(Array)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "email" }).to be true
+      end
+    end
+
+    context "email が重複する場合" do
+      before { create(:user, email: "newuser@example.com") }
+
+      let(:duplicate_params) do
+        {
+          email: "newuser@example.com",
+          nickname: "別のユーザー",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      end
+
+      it "422 を返し、ユーザーを作成しない" do
+        expect {
+          post "/api/v1/auth/signup", params: duplicate_params, as: :json
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "email" }).to be true
+      end
+    end
+
+    context "password が短い場合（6 文字未満）" do
+      let(:short_password_params) do
+        {
+          email: "shortpw@example.com",
+          nickname: "新規ユーザー",
+          password: "abc",
+          password_confirmation: "abc"
+        }
+      end
+
+      it "422 を返し、ユーザーを作成しない" do
+        expect {
+          post "/api/v1/auth/signup", params: short_password_params, as: :json
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "password" }).to be true
+      end
+    end
+
+    context "password と password_confirmation が一致しない場合" do
+      let(:mismatch_params) do
+        {
+          email: "mismatch@example.com",
+          nickname: "新規ユーザー",
+          password: "password123",
+          password_confirmation: "different456"
+        }
+      end
+
+      it "422 を返し、ユーザーを作成しない" do
+        expect {
+          post "/api/v1/auth/signup", params: mismatch_params, as: :json
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "password_confirmation" }).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /api/v1/auth/login" do
+    let!(:user) do
+      create(:user,
+             email: "test@example.com",
+             password: "password123",
+             password_confirmation: "password123")
+    end
+
+    context "有効な認証情報の場合" do
+      let(:valid_params) do
+        {
+          email: "test@example.com",
+          password: "password123"
+        }
+      end
+
+      it "200 OK を返し、ユーザー情報を返す" do
+        post "/api/v1/auth/login", params: valid_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["email"]).to eq("test@example.com")
+        expect(response.parsed_body).not_to have_key("password_digest")
+      end
+    end
+
+    context "email が存在しない場合" do
+      let(:invalid_email_params) do
+        {
+          email: "nonexistent@example.com",
+          password: "password123"
+        }
+      end
+
+      it "401 Unauthorized を返す" do
+        post "/api/v1/auth/login", params: invalid_email_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("invalid_credentials")
+      end
+    end
+
+    context "password が間違っている場合" do
+      let(:wrong_password_params) do
+        {
+          email: "test@example.com",
+          password: "wrongpassword"
+        }
+      end
+
+      it "401 Unauthorized を返す" do
+        post "/api/v1/auth/login", params: wrong_password_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("invalid_credentials")
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/auth/logout" do
+    let!(:user) do
+      create(:user,
+             email: "test@example.com",
+             password: "password123",
+             password_confirmation: "password123")
+    end
+
+    context "ログイン中の場合" do
+      before do
+        post "/api/v1/auth/login",
+             params: { email: "test@example.com", password: "password123" },
+             as: :json
+      end
+
+      it "204 No Content を返す" do
+        delete "/api/v1/auth/logout", as: :json
+
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        delete "/api/v1/auth/logout", as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/users_spec.rb
+++ b/spec/requests/api/v1/auth/users_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Users", type: :request do
+  let!(:user) do
+    create(:user,
+           email: "test@example.com",
+           nickname: "テスト",
+           password: "password123",
+           password_confirmation: "password123")
+  end
+
+  let(:login_params) do
+    { email: "test@example.com", password: "password123" }
+  end
+
+  describe "GET /api/v1/auth/me" do
+    context "ログイン中の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返し、ログイン中ユーザーの情報を返す" do
+        get "/api/v1/auth/me", as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["email"]).to eq("test@example.com")
+        expect(response.parsed_body["nickname"]).to eq("テスト")
+        expect(response.parsed_body).not_to have_key("password_digest")
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        get "/api/v1/auth/me", as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/auth/me" do
+    context "ログイン中で有効な値の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返し、nickname / avatar_url / is_public を更新する" do
+        patch "/api/v1/auth/me", params: {
+          nickname: "新しい名前",
+          avatar_url: "https://example.com/avatar.png",
+          is_public: false
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["nickname"]).to eq("新しい名前")
+        expect(response.parsed_body["avatar_url"]).to eq("https://example.com/avatar.png")
+        expect(response.parsed_body["is_public"]).to eq(false)
+      end
+    end
+
+    context "ログイン中で nickname が空の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "422 を返し、ユーザーを更新しない" do
+        patch "/api/v1/auth/me", params: { nickname: "" }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "nickname" }).to be true
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/auth/me", params: { nickname: "x" }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/auth/email" do
+    context "ログイン中で現パスワードと新メールが有効な場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返し、メールアドレスを更新する" do
+        patch "/api/v1/auth/email", params: {
+          current_password: "password123",
+          email: "newemail@example.com"
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["email"]).to eq("newemail@example.com")
+      end
+    end
+
+    context "現パスワードが間違っている場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/auth/email", params: {
+          current_password: "wrong",
+          email: "newemail@example.com"
+        }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("invalid_password")
+      end
+    end
+
+    context "新メールが無効な形式の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "422 を返す" do
+        patch "/api/v1/auth/email", params: {
+          current_password: "password123",
+          email: "invalid"
+        }, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "email" }).to be true
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/auth/email", params: {
+          current_password: "password123",
+          email: "newemail@example.com"
+        }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

vow_pact の認証 API を **TDD（Red → Green → Refactor）厳守** で 7 endpoint 実装。
あわせて Codex 第三者レビューで指摘された 3 点（CSRF / BaseController / Cookie 期限）と、テスト実行環境の根本的な問題（rspec が development 環境で動いていた）も解消した。

## 主な変更

### 共通土台

- **`Api::V1::BaseController`** を新設し API 共通の `rescue_from` を集約
  - `RecordNotFound` → 404 / `RecordInvalid` → 422 を CLAUDE.md エラー形式 `{ errors: [{ code, field, message }] }` で返す
- **CSRF 対策**：`ApplicationController` に `RequestForgeryProtection` を include + `protect_from_forgery with: :exception`
  - `ActionController::API` には `allow_forgery_protection` メソッドが存在しないため、test 環境では `unless Rails.env.test?` でガード
- **Cookie 期限見直し**：`cookies.signed.permanent`（20 年）→ `expires: 2.weeks.from_now` + `secure: Rails.env.production?`
- **`UserSerializer`**（alba）：password_digest を含めず 9 属性のみ公開
- **routes.rb**：`namespace :api > :v1 > :auth` で 7 endpoint を登録

### 7 endpoint（TDD で 24 ケース）

| HTTP | パス | コントローラー | ケース数 |
| --- | --- | --- | --- |
| POST | /api/v1/auth/signup | RegistrationsController#create | 5 |
| POST | /api/v1/auth/login | SessionsController#create | 3 |
| DELETE | /api/v1/auth/logout | SessionsController#destroy | 2 |
| GET | /api/v1/auth/me | UsersController#show | 2 |
| PATCH | /api/v1/auth/me | UsersController#update | 3 |
| PATCH | /api/v1/auth/email | UsersController#update_email | 4 |
| PATCH | /api/v1/auth/password | PasswordsController#update | 5 |

すべて Red → Green → Refactor を踏み、異常系（バリデーション失敗・現パスワード違い・未ログイン）も網羅。

### フロント連携

- `app/frontend/lib/api.ts` に CSRF トークン送信を追加（`<meta name="csrf-token">` → `X-CSRF-Token` ヘッダー）
- `app/frontend/types/css.d.ts` で `declare module "*.css"` を追加し、TypeScript の typecheck を通す

### テスト環境の根本修正

これまで rspec が **development 環境・development DB で動作していた重大な問題**を発見し修正：

- **原因**：`docker-compose.yml` で `RAILS_ENV: development` を固定 → `rails_helper.rb` の `ENV['RAILS_ENV'] ||= 'test'` が無効化されていた
- **症状**：これまでの 42 examples は development DB を触り、transactional_fixtures の rollback で見かけ上 PASS していた（テストが test 環境設定を一度も読まずにいた）
- **解決**：`bin/rspec` ラッパーを追加し、実行時に `-e RAILS_ENV=test -e DATABASE_URL=...test` で環境を上書き
- **副次対応**：`config/environments/test.rb` で `config.hosts << "www.example.com"` を追加（Rails 8 HostAuthorization 対策）

→ Codex レビューで指摘された通り、`rails_helper.rb` で `ENV['RAILS_ENV'] = 'test'` と強制上書きする案は、DATABASE_URL の問題を隠してしまうため不採用。実行コマンドで明示するアプローチを採用。

## 動作確認

- [x] `./bin/rspec` 全件 PASS（**66 examples, 0 failures**）
- [x] `bundle exec rubocop`（48 files, no offenses）
- [x] `npm run lint`（ESLint 0 件）
- [x] `npm run typecheck`（TypeScript エラー 0 件）
- [x] `npm run format` 整形済み（Prettier）

## セキュリティ確認

- [x] `password_digest` を API レスポンスに含めない（UserSerializer + spec で検証）
- [x] login 失敗時に「メール存在 / パスワード違い」を区別しない（情報漏洩防止）
- [x] email / password 変更時に現パスワード必須
- [x] CSRF 対策（production / development で `protect_from_forgery` 有効）
- [x] Cookie: `httponly` / `same_site: :lax` / `secure: Rails.env.production?` / `expires: 2.weeks.from_now`
- [x] Strong Parameters で `.permit` を明示（`.permit!` 禁止に準拠）

## 関連 Issue

- closes #17
- Codex 指摘 3 点すべて反映済み（CSRF / BaseController / Cookie 期限）
- 後続: #18（Pact API、同パターンで実装可能）

## やり残し（範囲外）

- React からの実 fetch 動作確認 → Issue #21（フロントエンド画面実装）でログイン UI を作る時に確認
- パスワード変更後の他デバイスセッション無効化 → v1.x バックログ候補
- `docs/architecture.md`（ハイブリッド構成記録）→ Issue #36（v1.x: バックログ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added user authentication system with signup, login, and logout endpoints
- Added user profile management capabilities including profile updates and email changes
- Added password change endpoint with current password verification

**Tests**
- Added comprehensive request spec coverage for authentication and user management endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->