### PR TITLE
契約 API（POST/GET 一覧）を TDD で実装 (refs #18)

### DIFF
--- a/app/controllers/api/v1/pacts_controller.rb
+++ b/app/controllers/api/v1/pacts_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    class PactsController < Api::V1::BaseController
+      def index
+        pacts = Current.user.pacts.order(created_at: :desc)
+        render json: PactSerializer.new(pacts).serializable_hash, status: :ok
+      end
+
+      def create
+        pact = Current.user.pacts.create!(pact_params)
+        render json: PactSerializer.new(pact).serializable_hash, status: :created
+      end
+
+      private
+
+      def pact_params
+        params.permit(:goal, :constraint_text, :difficulty, :deadline, :signed_at)
+      end
+    end
+  end
+end

--- a/app/serializers/pact_serializer.rb
+++ b/app/serializers/pact_serializer.rb
@@ -1,0 +1,17 @@
+class PactSerializer
+  include Alba::Resource
+
+  attributes :id,
+             :user_id,
+             :goal,
+             :constraint_text,
+             :difficulty,
+             :difficulty_reason,
+             :deadline,
+             :status,
+             :title,
+             :signed_at,
+             :completed_at,
+             :created_at,
+             :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
         patch  "email",    to: "users#update_email"
         patch  "password", to: "passwords#update"
       end
+
+      resources :pacts, only: [ :index, :create ]
     end
   end
 

--- a/spec/requests/api/v1/pacts_spec.rb
+++ b/spec/requests/api/v1/pacts_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Pacts", type: :request do
+  let!(:user) do
+    create(:user,
+           email: "test@example.com",
+           password: "password123",
+           password_confirmation: "password123")
+  end
+
+  let(:login_params) { { email: "test@example.com", password: "password123" } }
+
+  describe "POST /api/v1/pacts" do
+    let(:valid_params) do
+      {
+        goal: "毎日30分読書する",
+        constraint_text: "スマホを別室に置く",
+        difficulty: 3,
+        deadline: 30.days.from_now.to_date.to_s,
+        signed_at: Time.current.iso8601
+      }
+    end
+
+    context "ログイン中で有効なパラメータの場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "201 Created を返し、契約を作成する" do
+        expect {
+          post "/api/v1/pacts", params: valid_params, as: :json
+        }.to change(Pact, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["goal"]).to eq("毎日30分読書する")
+        expect(response.parsed_body["status"]).to eq("active")
+        expect(response.parsed_body["user_id"]).to eq(user.id)
+      end
+    end
+
+    context "active な契約が既に 3 つある場合" do
+      before do
+        post "/api/v1/auth/login", params: login_params, as: :json
+        3.times { create(:pact, user: user, status: :active) }
+      end
+
+      it "422 を返し、4 つ目を作成しない" do
+        expect {
+          post "/api/v1/pacts", params: valid_params, as: :json
+        }.not_to change(Pact, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"].any? { |e| e["field"] == "base" }).to be true
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        post "/api/v1/pacts", params: valid_params, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/pacts" do
+    context "ログイン中の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      let!(:my_pact_active) { create(:pact, user: user, status: :active, goal: "自分の active") }
+      let!(:my_pact_completed) { create(:pact, user: user, status: :completed, goal: "自分の完了", completed_at: 1.day.ago) }
+      let!(:other_user_pact) do
+        other_user = create(:user)
+        create(:pact, user: other_user, status: :active, goal: "他人の契約")
+      end
+
+      it "200 OK を返し、自分の契約のみを返す" do
+        get "/api/v1/pacts", as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to be_an(Array)
+        expect(response.parsed_body.size).to eq(2)
+
+        goals = response.parsed_body.map { |p| p["goal"] }
+        expect(goals).to include("自分の active", "自分の完了")
+        expect(goals).not_to include("他人の契約")
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        get "/api/v1/pacts", as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #18 の MVP スコープに沿って、契約 API の POST（作成）/ GET（一覧）の 2 endpoint を TDD で実装。  
詳細・編集・削除・達成判定は v1.1 で追加予定（Issue #18 のコメントでスコープ調整済み）。

## 主な変更

### コントローラー / シリアライザー

- `Api::V1::PactsController < Api::V1::BaseController`
  - `create`：`Current.user.pacts.create!` で user_id を自動紐付け、active 4 つ目は Pact モデルのバリデーションで 422
  - `index`：`Current.user.pacts.order(created_at: :desc)` で自分の契約のみ返却、他ユーザーは構造的に見えない
  - Strong Parameters で `goal / constraint_text / difficulty / deadline / signed_at` のみ許可
- `PactSerializer`（alba）：Pact の全 13 属性を JSON 化

### routes

```ruby
resources :pacts, only: [:index, :create]
```

→ `/api/v1/pacts` に対する `GET`（一覧）/ `POST`（作成）のみ。

### request spec（5 ケース、TDD で Red → Green）

| # | エンドポイント | ケース | 期待 |
| --- | --- | --- | --- |
| 1 | POST /pacts | 正常系 | 201 + Pact 作成 |
| 2 | POST /pacts | active 4 つ目 | 422 + base エラー |
| 3 | POST /pacts | 未ログイン | 401 |
| 4 | GET /pacts | 正常系 | 200 + 自分の契約のみ |
| 5 | GET /pacts | 未ログイン | 401 |

## 動作確認

- [x] `./bin/rspec` 全件 PASS（**71 examples, 0 failures**）
- [x] `bundle exec rubocop`（51 files, no offenses）
- [x] `npm run lint`（0 件）

## セキュリティ確認

- [x] `Current.user.pacts` で他ユーザーの契約に構造的アクセス不可
- [x] Strong Parameters で `user_id`, `status`, `completed_at` 等の不正書き換えを防止
- [x] active 上限 3 つを Pact モデルでバリデーション
- [x] 未ログイン時に Authentication concern が 401 を返す

## 関連 Issue

- Refs #18（MVP スコープ：POST + GET のみ。詳細・編集・削除等は v1.1 で）
- 後続: #19（CheckIn / Ranking、v1.1）、#21（フロントエンド）

## やり残し（v1.1）

- GET /api/v1/pacts/:id（詳細）
- PATCH /api/v1/pacts/:id（goal / constraint_text のみ編集可）
- DELETE /api/v1/pacts/:id（abandoned に論理削除）
- POST /api/v1/pacts/:id/complete（達成判定）
- GET /api/v1/pacts/:id/check_ins
- PactCompleter サービス