### PR TITLE
契約 API に show / update / destroy を追加 (closes #18)

### DIFF
--- a/app/controllers/api/v1/pacts_controller.rb
+++ b/app/controllers/api/v1/pacts_controller.rb
@@ -6,15 +6,39 @@ module Api
         render json: PactSerializer.new(pacts).serializable_hash, status: :ok
       end
 
+      def show
+        pact = Current.user.pacts.find(params[:id])
+        render json: PactSerializer.new(pact).serializable_hash, status: :ok
+      end
+
       def create
         pact = Current.user.pacts.create!(pact_params)
         render json: PactSerializer.new(pact).serializable_hash, status: :created
+      end
+
+      def update
+        pact = Current.user.pacts.find(params[:id])
+        pact.update!(edit_params)
+        render json: PactSerializer.new(pact).serializable_hash, status: :ok
+      end
+
+      # 論理削除：DB からは消さず status を abandoned に変更する
+      def destroy
+        pact = Current.user.pacts.find(params[:id])
+        pact.update!(status: :abandoned)
+        head :no_content
       end
 
       private
 
       def pact_params
         params.permit(:goal, :constraint_text, :difficulty, :deadline, :signed_at)
+      end
+
+      # 編集可能な属性は goal / constraint_text のみ
+      # deadline / difficulty / signed_at は契約時に確定し、後から変更不可
+      def edit_params
+        params.permit(:goal, :constraint_text)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
         patch  "password", to: "passwords#update"
       end
 
-      resources :pacts, only: [ :index, :create ]
+      resources :pacts, only: [ :index, :create, :show, :update, :destroy ]
     end
   end
 

--- a/spec/requests/api/v1/pacts_spec.rb
+++ b/spec/requests/api/v1/pacts_spec.rb
@@ -93,4 +93,156 @@ RSpec.describe "Api::V1::Pacts", type: :request do
       end
     end
   end
+
+  describe "GET /api/v1/pacts/:id" do
+    let!(:my_pact) { create(:pact, user: user, goal: "自分の契約") }
+    let!(:other_user) { create(:user, email: "other@example.com") }
+    let!(:other_pact) { create(:pact, user: other_user, goal: "他人の契約") }
+
+    context "ログイン中で自分の契約を取得する場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返し、契約詳細を返す" do
+        get "/api/v1/pacts/#{my_pact.id}", as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["id"]).to eq(my_pact.id)
+        expect(response.parsed_body["goal"]).to eq("自分の契約")
+      end
+    end
+
+    context "ログイン中で他人の契約を取得しようとする場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "404 Not Found を返す（構造的に他人の契約には到達不可）" do
+        get "/api/v1/pacts/#{other_pact.id}", as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "存在しない id の場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "404 Not Found を返す" do
+        get "/api/v1/pacts/999999", as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        get "/api/v1/pacts/#{my_pact.id}", as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/pacts/:id" do
+    let!(:my_pact) do
+      create(:pact,
+             user: user,
+             goal: "元の目標",
+             constraint_text: "元の制約",
+             difficulty: 3,
+             deadline: 30.days.from_now.to_date)
+    end
+    let!(:other_user) { create(:user, email: "other@example.com") }
+    let!(:other_pact) { create(:pact, user: other_user) }
+
+    context "ログイン中で goal / constraint_text を編集する場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返し、編集する" do
+        patch "/api/v1/pacts/#{my_pact.id}", params: {
+          goal: "新しい目標",
+          constraint_text: "新しい制約"
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["goal"]).to eq("新しい目標")
+        expect(response.parsed_body["constraint_text"]).to eq("新しい制約")
+      end
+    end
+
+    context "deadline / difficulty / signed_at を変更しようとする場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "200 OK を返すが、編集禁止属性は無視される" do
+        original_deadline = my_pact.deadline
+        original_difficulty = my_pact.difficulty
+
+        patch "/api/v1/pacts/#{my_pact.id}", params: {
+          goal: "新しい目標",
+          deadline: 100.days.from_now.to_date.to_s,
+          difficulty: 5,
+          signed_at: 1.year.from_now.iso8601
+        }, as: :json
+
+        my_pact.reload
+        expect(response).to have_http_status(:ok)
+        expect(my_pact.goal).to eq("新しい目標")          # ← goal は変更される
+        expect(my_pact.deadline).to eq(original_deadline) # ← deadline は変わらず
+        expect(my_pact.difficulty).to eq(original_difficulty)
+      end
+    end
+
+    context "他人の契約を編集しようとする場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "404 Not Found を返す" do
+        patch "/api/v1/pacts/#{other_pact.id}", params: { goal: "ハッキング" }, as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        patch "/api/v1/pacts/#{my_pact.id}", params: { goal: "x" }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/pacts/:id" do
+    let!(:my_pact) { create(:pact, user: user, status: :active) }
+    let!(:other_user) { create(:user, email: "other@example.com") }
+    let!(:other_pact) { create(:pact, user: other_user, status: :active) }
+
+    context "ログイン中で自分の契約を削除する場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "204 No Content を返し、status を abandoned に変更する（論理削除）" do
+        expect {
+          delete "/api/v1/pacts/#{my_pact.id}", as: :json
+        }.not_to change(Pact, :count)
+
+        expect(response).to have_http_status(:no_content)
+        expect(my_pact.reload.status).to eq("abandoned")
+      end
+    end
+
+    context "他人の契約を削除しようとする場合" do
+      before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+      it "404 Not Found を返し、削除しない" do
+        delete "/api/v1/pacts/#{other_pact.id}", as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(other_pact.reload.status).to eq("active")
+      end
+    end
+
+    context "未ログインの場合" do
+      it "401 Unauthorized を返す" do
+        delete "/api/v1/pacts/#{my_pact.id}", as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

Issue #18 の残り 5 endpoint のうち、**CheckIn 依存のない 3 endpoint** を TDD で追加実装。
これで Issue #18 のスコープのうち MVP 範囲（v0.4: API 実装）を完了する。

## 主な変更

### routes.rb

```ruby
resources :pacts, only: [ :index, :create, :show, :update, :destroy ]
```

→ POST /complete と GET /check_ins は CheckIn / Crest（v1.1）依存のため除外。

### PactsController

| アクション | 役割 | キーポイント |
| --- | --- | --- |
| `show` | 詳細取得 | `Current.user.pacts.find` で自分の契約だけ取得、他人は 404 |
| `update` | 編集 | `edit_params` で `goal` と `constraint_text` のみ許可、それ以外は無視 |
| `destroy` | 論理削除 | `status: :abandoned` に更新、DB からは消さない |

### CLAUDE.md 設計判断の遵守

- 編集可: `goal`, `constraint_text` のみ → Strong Parameters で構造的に担保
- 削除は論理削除（`status: abandoned`）→ `update!` で実装
- 他ユーザーの契約は見えない / 編集できない → `Current.user.pacts` スコープで構造的に担保

### request spec（11 ケース、TDD）

#### GET /pacts/:id
- 自分の契約取得 → 200 + 契約詳細
- 他人の契約 → 404
- 存在しない id → 404
- 未ログイン → 401

#### PATCH /pacts/:id
- goal / constraint_text 編集 → 200
- **deadline / difficulty / signed_at の編集試行は無視される**（CLAUDE.md ルール）
- 他人の契約 → 404
- 未ログイン → 401

#### DELETE /pacts/:id
- 自分の契約 → 204 + status: abandoned + **DB レコード残る**（物理削除ではない）
- 他人の契約 → 404 + status は変わらず
- 未ログイン → 401

## 動作確認

- [x] `./bin/rspec` 全件 PASS（**82 examples, 0 failures**）
- [x] `bundle exec rubocop`（51 files, no offenses）

## セキュリティ確認

- [x] `Current.user.pacts.find` で他ユーザーの契約に到達不可
- [x] Strong Parameters で `deadline / difficulty / signed_at` の改ざんを防止
- [x] 論理削除で監査ログ・履歴が残る

## 関連 Issue

- closes #18（v0.4 API 実装スコープ完了）
- 後続: v1.1 で実装予定の 2 endpoint
  - POST /api/v1/pacts/:id/complete（PactCompleter サービス）
  - GET /api/v1/pacts/:id/check_ins
  - 上記は **CheckIn テーブル（Issue #12）と Crest テーブル（Issue #13）依存**のため v1.1 で別 Issue 化

## やり残し（v1.1）

| endpoint | 依存 |
| --- | --- |
| POST /pacts/:id/complete | CheckIn + Crest + PactCompleter サービス |
| GET /pacts/:id/check_ins | CheckIn テーブル |

→ Issue #12 / #13 / #19 の前提が揃ってから別途実装。