### PR TITLE
Render 本番デプロイ準備：build.sh + production.rb + sleep 対策 (refs #22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,17 @@
-# PostgreSQL
+# ============================================================================
+# 開発環境（Docker / ローカル）用
+# ============================================================================
+
+# PostgreSQL（docker-compose.yml の db コンテナ用）
 POSTGRES_USER=vow_pact
 POSTGRES_PASSWORD=
 POSTGRES_DB=vow_pact_development
 
-# Rails -> DB 接続URL
+# Rails -> DB 接続URL（dev 環境用）
 # 形式: postgresql://USER:PASSWORD@HOST:PORT/DBNAME
 DATABASE_URL=postgresql://vow_pact:PASSWORD@db:5432/vow_pact_development
 
-# フロントエンドURL
+# フロントエンドURL（dev 用）
 FRONTEND_URL=http://localhost:3000
 
 # CORS で許可するオリジン（React フロントエンド）
@@ -17,3 +21,22 @@ FRONTEND_ORIGIN=http://localhost:3036
 
 # OpenAI API
 OPENAI_API_KEY=
+
+# ============================================================================
+# 本番環境（Render + Neon）用
+# ============================================================================
+# 以下は Render Web UI の Environment セクションで設定する。
+# .env ファイルや Git には絶対に含めない（DATABASE_URL のパスワード漏洩防止）。
+#
+# RAILS_ENV=production
+#
+# RAILS_MASTER_KEY=<config/master.key の中身>
+#   ↑ ローカルで `cat config/master.key` で確認、Render Web UI に貼る
+#
+# DATABASE_URL=postgresql://USER:PASSWORD@HOST.neon.tech/DBNAME?sslmode=require
+#   ↑ Neon Dashboard の Pooled connection string
+#
+# OPENAI_API_KEY=<OpenAI ダッシュボードで発行>
+#
+# FRONTEND_ORIGIN=https://vow-pact.onrender.com
+#   ↑ Render の本番ドメイン（自分でカスタムドメインを設定する場合は変更）

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,24 @@
+name: Keep Render Awake
+
+# Render Free プランの sleep 対策。
+# 15 分連続でアクセスがないと Render の Web Service が sleep するため、
+# 14 分間隔で /up を ping して起動状態を維持する。
+#
+# 月間稼働枠（750h）を消費しすぎないよう、JST 7-23 時のみ実行。
+# 深夜帯は sleep を許容（早朝の最初のアクセスは cold start ~60 秒）。
+
+on:
+  schedule:
+    # GitHub Actions の cron は UTC で指定。
+    # JST 7-23 時 = UTC 22-23 時 + UTC 0-14 時（前日 / 当日）
+    - cron: "*/14 22-23,0-14 * * *"
+  workflow_dispatch: {} # 手動実行用
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Render health endpoint
+        run: |
+          curl -fsS --max-time 90 --retry 3 --retry-delay 10 \
+            https://vow-pact.onrender.com/up

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o errexit
+
+bundle install
+npm install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+bundle exec rails db:migrate

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,7 +2,7 @@
 set -o errexit
 
 bundle install
-npm install
+npm ci
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,9 +80,11 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
+  # Render が管理するドメインのみ許可（DNS rebinding 攻撃対策）。
+  # 先頭ドット形式は onrender.com とその全サブドメインを安全に許可（正規表現より厳密）。
   config.hosts = [
-    "vow-pact.onrender.com",   # Render の本番ドメイン
-    /.*\.onrender\.com/ # Render プレビュー / stagingドメイン
+    "vow-pact.onrender.com", # 本番ユーザートラフィック用
+    ".onrender.com"          # プレビュー / staging デプロイ URL 用
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
@@ -80,11 +80,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "vow-pact.onrender.com",   # Render の本番ドメイン
+    /.*\.onrender\.com/ # Render プレビュー / stagingドメイン
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要

Issue #22 の MVP スコープに沿って、**Render に最小デプロイ可能な状態** + **Render Free の sleep 対策** までコード側を整備する。  
README 整備は別 Issue 化（**#45 v1.x: バックログ**）。

## 主な変更

### 1. `bin/render-build.sh`（新規）

Render のビルドコマンドで実行するシェルスクリプト：

```bash
#!/usr/bin/env bash
set -o errexit

bundle install
npm ci
bundle exec rails assets:precompile
bundle exec rails assets:clean
bundle exec rails db:migrate
```

- `set -o errexit`: 1 つでも失敗したら即停止（エラー隠蔽防止）
- `npm ci` で本番ビルドの再現性を担保（CodeRabbit 指摘で `npm install` から変更）
- `chmod +x` で実行権限付与済み

### 2. `config/environments/production.rb`（修正）

- `config.force_ssl = true`: HTTPS 強制（secure Cookie が機能する条件）
- `config.hosts`: Render の本番ドメイン（vow-pact.onrender.com）+ 文字列形式 `.onrender.com` でサブドメインを安全に許可（CodeRabbit 指摘で正規表現から変更）
- `config.host_authorization` の exclude: `/up` エンドポイントは host チェック対象外（Render ヘルスチェック対応）

### 3. `.env.example`（追記）

開発環境用と本番環境用をセクション分割し、本番に必要な変数（RAILS_MASTER_KEY / DATABASE_URL / OPENAI_API_KEY / FRONTEND_ORIGIN）をドキュメント化。

### 4. `.github/workflows/keepalive.yml`（新規）

Render Free の sleep 対策。GitHub Actions Cron で 14 分ごとに `/up` を ping：

- JST 7-23 時のみ実行（月間稼働枠 750h を超えないため、深夜は sleep 許容）
- public repo なので GitHub Actions は無料・無制限

## CodeRabbit レビュー対応

| # | 指摘 | 対応 |
| --- | --- | --- |
| 1 | `npm install` → `npm ci` | ✅ 採用（コミット c01e583） |
| 2 | hosts 正規表現 → 文字列 `.onrender.com` | ✅ 採用（コミット 59d9e4a） |
| 3 | `db:migrate` を release phase へ | ❌ 持ち越し（Render 有料プランの機能、Free では build 内で OK） |
| 4 | コメントを WHY 中心に | ✅ 採用（コミット 59d9e4a） |

## 動作確認

- [x] `./bin/rspec` 全件 PASS（99 examples, 0 failures）
- [x] `bundle exec rubocop`（66 files, no offenses）
- [x] `bin/render-build.sh` の実行権限を確認（`-rwxr-xr-x`）
- [x] **本番デプロイ成功**：`https://vow-pact.onrender.com` で「誓約 ⚔ 契約」が表示
- [x] HTTPS 強制が有効（HTTP アクセス時に自動で HTTPS にリダイレクト）
- [x] `https://vow-pact.onrender.com/up` で 200 OK が返る

## デプロイ時のハマりポイント（再現用）

`RAILS_MASTER_KEY` を Render に登録する際、`cat config/master.key` の出力をコピペすると **末尾改行が混入**して `ArgumentError: key must be 16 bytes` でビルド失敗。

→ `cat config/master.key | tr -d '\n' | pbcopy` で改行除去してコピーするのが安全。

## マージ後の手動作業

1. **Render の Branch を `feature/issue-22-render-deploy` から `main` に切り替え**
   - Render Dashboard > Settings > Branch
2. **feature ブランチ削除**
   ```bash
   git switch main && git pull
   git branch -d feature/issue-22-render-deploy
   git push origin --delete feature/issue-22-render-deploy
   ```

## 関連 Issue

- closes #22（Render 本番デプロイ + Sleep 対策完了）
- 後続: #45（README 整備、v1.x: バックログ）

## 参照

- [Render Docs - Deploy Rails 8](https://render.com/docs/deploy-rails-8)
- [Render Docs - Free](https://render.com/docs/free)
- [GitHub Docs - Workflow syntax (cron)](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule)