### PR TITLE
feat(model): check_ins テーブル + StreakCalculator（v1.1 ベース）

### DIFF
--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -5,6 +5,11 @@ class CheckIn < ApplicationRecord
 
   NOTE_MAX_LENGTH = 500
 
+  # checked_on はサーバ側で自動設定（チート防止）。
+  # クライアント値はコントローラの strong params で除外される設計（Issue #19 で実装）。
+  # 内部呼び出しで明示指定された場合（テスト・データ補修等）は尊重する。
+  before_validation :set_checked_on_to_today, on: :create
+
   validates :checked_on, presence: true
   validates :status, presence: true
   validates :note, length: { maximum: NOTE_MAX_LENGTH }, allow_blank: true
@@ -40,6 +45,10 @@ class CheckIn < ApplicationRecord
   end
 
   def recalc_user_streak
-    StreakCalculator.new(pact.user).recalculate!
+    StreakCalculator.new(pact.user).call
+  end
+
+  def set_checked_on_to_today
+    self.checked_on = Date.current if checked_on.blank?
   end
 end

--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -1,0 +1,45 @@
+class CheckIn < ApplicationRecord
+  belongs_to :pact
+
+  enum :status, { kept: 0, broken: 1, skipped: 2 }
+
+  NOTE_MAX_LENGTH = 500
+
+  validates :checked_on, presence: true
+  validates :status, presence: true
+  validates :note, length: { maximum: NOTE_MAX_LENGTH }, allow_blank: true
+  # DB UNIQUE と二重防御（Rails レベルでも検出）
+  validates :checked_on, uniqueness: { scope: :pact_id }
+  validate :checked_on_not_in_future
+  validate :checked_on_after_pact_signed_at
+  validate :pact_must_be_active, on: :create
+
+  # 同一 transaction 内で User.streak_count を再計算する。
+  # update_columns は現在の transaction で UPDATE を発行するので、
+  # 外側が rollback されれば streak も巻き戻り整合性は保たれる。
+  # 並行 check-in による race は StreakCalculator 側の with_lock で吸収する。
+  after_save :recalc_user_streak
+  after_destroy :recalc_user_streak
+
+  private
+
+  def checked_on_not_in_future
+    return if checked_on.blank?
+    errors.add(:checked_on, "は未来の日付にできません") if checked_on > Time.zone.today
+  end
+
+  def checked_on_after_pact_signed_at
+    return if checked_on.blank? || pact.blank? || pact.signed_at.blank?
+    # pact.signed_at は datetime なので date に揃えて比較
+    errors.add(:checked_on, "は契約締結日以降である必要があります") if checked_on < pact.signed_at.to_date
+  end
+
+  def pact_must_be_active
+    return if pact.blank?
+    errors.add(:pact, "は active でなければなりません") unless pact.active?
+  end
+
+  def recalc_user_streak
+    StreakCalculator.new(pact.user).recalculate!
+  end
+end

--- a/app/models/pact.rb
+++ b/app/models/pact.rb
@@ -1,8 +1,6 @@
 class Pact < ApplicationRecord
-  # MVP に含めない関連（v1.1 で実装）
-  # has_many :check_ins, dependent: :destroy
-  # has_one :crest, dependent: :destroy
-  # has_many :ai_generations, dependent: :nullify
+  # has_one :crest / has_many :ai_generations は v1.1 (#13, #14) で実装予定
+  has_many :check_ins, dependent: :destroy
 
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ApplicationRecord
   # アソシエーション
   has_many :pacts, dependent: :destroy
   has_many :sessions, dependent: :destroy
-  # CheckIn / AiGeneration は v1.1 で実装
-  # has_many :check_ins, through: :pacts
+  has_many :check_ins, through: :pacts
+  # AiGeneration は v1.1 (#14) で実装予定
   # has_many :ai_generations, dependent: :destroy
 
   # バリデーション

--- a/app/services/streak_calculator.rb
+++ b/app/services/streak_calculator.rb
@@ -10,7 +10,8 @@ class StreakCalculator
     @user = user
   end
 
-  def recalculate!
+  # サービスクラスのメインメソッドは call に統一（CLAUDE.md 規約）。
+  def call
     # 同一 user の並行 check-in で streak がレースしないよう row lock を取る。
     @user.with_lock do
       new_streak = calculate_current_streak

--- a/app/services/streak_calculator.rb
+++ b/app/services/streak_calculator.rb
@@ -1,0 +1,88 @@
+class StreakCalculator
+  # 仕様（Issue #12 / docs/data_model.md / Codex レビュー反映後）:
+  # - 起点は「今日 OR 昨日」。今日も昨日も kept が無ければ streak = 0
+  # - 同日に複数契約で kept があっても 1 日 1 カウント
+  # - kept     : 連続を伸ばす
+  # - broken   : そこで連続が切れる
+  # - skipped  : 切らないが伸ばさない（その日は飛ばして前日と接続）
+  # - abandoned / completed の契約のチェックインも履歴として算入する（過去達成は奪わない）
+  def initialize(user)
+    @user = user
+  end
+
+  def recalculate!
+    # 同一 user の並行 check-in で streak がレースしないよう row lock を取る。
+    @user.with_lock do
+      new_streak = calculate_current_streak
+      new_longest = [ @user.longest_streak.to_i, new_streak ].max
+      @user.update_columns(
+        streak_count: new_streak,
+        longest_streak: new_longest,
+        updated_at: Time.current
+      )
+    end
+  end
+
+  private
+
+  def calculate_current_streak
+    statuses_by_date = build_statuses_by_date
+    return 0 if statuses_by_date.empty?
+
+    today = Time.zone.today
+    cursor = decide_starting_cursor(statuses_by_date, today)
+    return 0 if cursor.nil?
+
+    walk_back_streak(statuses_by_date, cursor)
+  end
+
+  # その日の「最終的な扱い」を 1 つに集約：
+  # 同日 kept があれば :kept、kept が無く broken があれば :broken、
+  # 残りは :skipped。kept 優先（複数契約で 1 日 1 カウントの実現）。
+  def build_statuses_by_date
+    # Rails の enum は pluck で文字列を返す（"kept" / "broken" / "skipped"）。
+    rows = @user.check_ins.pluck(:checked_on, :status)
+    grouped = rows.group_by(&:first)
+    grouped.transform_values do |arr|
+      statuses = arr.map { |row| row[1].to_sym }.uniq
+      next :kept   if statuses.include?(:kept)
+      next :broken if statuses.include?(:broken)
+      :skipped
+    end
+  end
+
+  # 起点：今日 kept / skipped なら今日から、昨日 kept / skipped なら昨日から、
+  # それ以外（broken or 何も無い）は streak = 0
+  def decide_starting_cursor(statuses_by_date, today)
+    today_status = statuses_by_date[today]
+    return today if today_status == :kept
+    return today if today_status == :skipped
+
+    yesterday = today - 1
+    yesterday_status = statuses_by_date[yesterday]
+    return nil if today_status == :broken
+    return yesterday if yesterday_status == :kept
+    return yesterday if yesterday_status == :skipped
+
+    nil
+  end
+
+  # cursor から逆順に走査して連続日数を数える。
+  # kept で +1、skipped はスキップ（前日と接続）、broken or 履歴無しで終了。
+  def walk_back_streak(statuses_by_date, cursor)
+    streak = 0
+    while cursor
+      status = statuses_by_date[cursor]
+      case status
+      when :kept
+        streak += 1
+        cursor -= 1
+      when :skipped
+        cursor -= 1
+      else # :broken or nil
+        break
+      end
+    end
+    streak
+  end
+end

--- a/db/migrate/20260505120723_create_check_ins.rb
+++ b/db/migrate/20260505120723_create_check_ins.rb
@@ -1,0 +1,17 @@
+class CreateCheckIns < ActiveRecord::Migration[8.1]
+  def change
+    create_table :check_ins do |t|
+      t.references :pact, null: false, foreign_key: true
+      t.date :checked_on, null: false
+      t.integer :status, null: false
+      t.text :note
+
+      t.timestamps
+    end
+
+    # 1 日 1 契約 1 件を DB レベルで強制（同時 POST race も unique violation で弾く）
+    add_index :check_ins, [ :pact_id, :checked_on ], unique: true
+    # 連続日数計算 / 管理画面で日付集計するときの index
+    add_index :check_ins, :checked_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_140911) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_120723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "check_ins", force: :cascade do |t|
+    t.date "checked_on", null: false
+    t.datetime "created_at", null: false
+    t.text "note"
+    t.bigint "pact_id", null: false
+    t.integer "status", null: false
+    t.datetime "updated_at", null: false
+    t.index ["checked_on"], name: "index_check_ins_on_checked_on"
+    t.index ["pact_id", "checked_on"], name: "index_check_ins_on_pact_id_and_checked_on", unique: true
+    t.index ["pact_id"], name: "index_check_ins_on_pact_id"
+  end
 
   create_table "pacts", force: :cascade do |t|
     t.datetime "completed_at"
@@ -55,6 +67,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_140911) do
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
   end
 
+  add_foreign_key "check_ins", "pacts"
   add_foreign_key "pacts", "users"
   add_foreign_key "sessions", "users"
 end

--- a/spec/factories/check_ins.rb
+++ b/spec/factories/check_ins.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :check_in do
+    association :pact
+    checked_on { Date.current }
+    status { :kept }
+    note { nil }
+  end
+end

--- a/spec/models/check_in_spec.rb
+++ b/spec/models/check_in_spec.rb
@@ -24,9 +24,12 @@ RSpec.describe CheckIn, type: :model do
     end
 
     it "checked_on が必須" do
-      ci = build(:check_in, pact: pact, checked_on: nil)
-      expect(ci).not_to be_valid
-      expect(ci.errors[:checked_on]).to be_present
+      # before_validation で自動補完される前段で検証するため、save 経路ではなく
+      # 明示的に valid? を skip した状態で nil をセット → save で空のまま落とす
+      ci = build(:check_in, pact: pact)
+      ci.checked_on = nil
+      ci.valid?  # before_validation で Date.current が入る → 必須は満たされる
+      expect(ci.checked_on).to eq(Date.current)
     end
 
     it "checked_on が未来の日付なら invalid" do
@@ -67,6 +70,22 @@ RSpec.describe CheckIn, type: :model do
       ci = build(:check_in, pact: pact, checked_on: Date.current)
       expect(ci).not_to be_valid
       expect(ci.errors[:pact]).to be_present
+    end
+  end
+
+  describe "checked_on のサーバ側自動設定（チート防止）" do
+    let(:user) { create(:user) }
+    let(:pact) { create(:pact, user: user, signed_at: 3.days.ago) }
+
+    it "checked_on を未指定で create すると自動で Date.current が入る" do
+      ci = pact.check_ins.create!(status: :kept)
+      expect(ci.checked_on).to eq(Date.current)
+    end
+
+    it "明示指定時は尊重される（内部呼び出し / 訂正 / テスト用途）" do
+      past = pact.signed_at.to_date + 1
+      ci = pact.check_ins.create!(checked_on: past, status: :kept)
+      expect(ci.checked_on).to eq(past)
     end
   end
 

--- a/spec/models/check_in_spec.rb
+++ b/spec/models/check_in_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe CheckIn, type: :model do
+  describe "associations" do
+    it "belongs_to :pact" do
+      assoc = described_class.reflect_on_association(:pact)
+      expect(assoc.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe "enum status" do
+    it "kept / broken / skipped を持つ" do
+      expect(described_class.statuses).to eq("kept" => 0, "broken" => 1, "skipped" => 2)
+    end
+  end
+
+  describe "validations" do
+    let(:user) { create(:user) }
+    let(:pact) { create(:pact, user: user, signed_at: 3.days.ago) }
+
+    it "正しい属性の CheckIn は valid" do
+      ci = build(:check_in, pact: pact, checked_on: Date.current)
+      expect(ci).to be_valid
+    end
+
+    it "checked_on が必須" do
+      ci = build(:check_in, pact: pact, checked_on: nil)
+      expect(ci).not_to be_valid
+      expect(ci.errors[:checked_on]).to be_present
+    end
+
+    it "checked_on が未来の日付なら invalid" do
+      ci = build(:check_in, pact: pact, checked_on: Date.current + 1)
+      expect(ci).not_to be_valid
+      expect(ci.errors[:checked_on]).to be_present
+    end
+
+    it "checked_on が pact.signed_at より前なら invalid" do
+      ci = build(:check_in, pact: pact, checked_on: pact.signed_at.to_date - 1)
+      expect(ci).not_to be_valid
+      expect(ci.errors[:checked_on]).to be_present
+    end
+
+    it "checked_on が pact.signed_at の当日なら valid" do
+      ci = build(:check_in, pact: pact, checked_on: pact.signed_at.to_date)
+      expect(ci).to be_valid
+    end
+
+    it "status 無し（nil）なら invalid" do
+      ci = build(:check_in, pact: pact, status: nil)
+      expect(ci).not_to be_valid
+    end
+
+    it "note は 500 文字まで OK" do
+      ci = build(:check_in, pact: pact, note: "あ" * 500)
+      expect(ci).to be_valid
+    end
+
+    it "note が 501 文字なら invalid" do
+      ci = build(:check_in, pact: pact, note: "あ" * 501)
+      expect(ci).not_to be_valid
+      expect(ci.errors[:note]).to be_present
+    end
+
+    it "active でない pact への新規 CheckIn は invalid" do
+      pact.update!(status: :abandoned)
+      ci = build(:check_in, pact: pact, checked_on: Date.current)
+      expect(ci).not_to be_valid
+      expect(ci.errors[:pact]).to be_present
+    end
+  end
+
+  describe "DB unique 制約（pact_id, checked_on）" do
+    let(:user) { create(:user) }
+    let(:pact) { create(:pact, user: user, signed_at: 3.days.ago) }
+
+    it "同じ (pact, checked_on) の組み合わせは Rails レベルで invalid" do
+      create(:check_in, pact: pact, checked_on: Date.current)
+      duplicate = build(:check_in, pact: pact, checked_on: Date.current)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "同じ (pact, checked_on) で create! すると DB レベルでも RecordNotUnique になる" do
+      create(:check_in, pact: pact, checked_on: Date.current)
+      expect {
+        # validation を skip して直接 INSERT したいので raw に作る
+        described_class.new(pact: pact, checked_on: Date.current, status: :kept).save!(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "find_or_initialize_by + update! で訂正パターンが動く（同日 2 回 = UPDATE）" do
+      first = pact.check_ins.find_or_initialize_by(checked_on: Date.current)
+      first.update!(status: :kept)
+
+      second = pact.check_ins.find_or_initialize_by(checked_on: Date.current)
+      second.update!(status: :broken, note: "やっぱり破った")
+
+      expect(pact.check_ins.where(checked_on: Date.current).count).to eq(1)
+      expect(pact.check_ins.find_by(checked_on: Date.current).status).to eq("broken")
+      expect(pact.check_ins.find_by(checked_on: Date.current).note).to eq("やっぱり破った")
+    end
+  end
+
+  describe "コールバックで User.streak_count が再計算される" do
+    let(:user) { create(:user) }
+    let(:pact) { create(:pact, user: user, signed_at: 7.days.ago) }
+
+    it "create で streak_count が更新される" do
+      expect {
+        create(:check_in, pact: pact, checked_on: Date.current, status: :kept)
+      }.to change { user.reload.streak_count }.from(0).to(1)
+    end
+
+    it "destroy で streak_count が再計算される（0 に戻る）" do
+      ci = create(:check_in, pact: pact, checked_on: Date.current, status: :kept)
+      expect { ci.destroy! }.to change { user.reload.streak_count }.from(1).to(0)
+    end
+
+    it "update で streak_count が再計算される（kept → broken で 0 になる）" do
+      ci = create(:check_in, pact: pact, checked_on: Date.current, status: :kept)
+      expect {
+        ci.update!(status: :broken)
+      }.to change { user.reload.streak_count }.from(1).to(0)
+    end
+  end
+end

--- a/spec/services/streak_calculator_spec.rb
+++ b/spec/services/streak_calculator_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe StreakCalculator, type: :service do
+  let(:user) { create(:user, streak_count: 0, longest_streak: 0) }
+
+  # コールバックの自動再計算と独立して挙動を検証したいので、
+  # save 時のコールバックをスキップしてレコードを直接作る。
+  def add_check_in(pact:, on:, status: :kept)
+    pact.check_ins.new(checked_on: on, status: status).save!(validate: false)
+  end
+
+  describe "#recalculate!" do
+    context "チェックインが 0 件のとき" do
+      it "streak_count = 0、longest_streak = 0" do
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(0)
+        expect(user.longest_streak).to eq(0)
+      end
+    end
+
+    context "今日 kept がある場合" do
+      it "streak_count = 1" do
+        pact = create(:pact, user: user, signed_at: 7.days.ago)
+        add_check_in(pact: pact, on: Date.current, status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(1)
+      end
+    end
+
+    context "今日と昨日 kept があれば" do
+      it "streak_count = 2" do
+        pact = create(:pact, user: user, signed_at: 7.days.ago)
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        add_check_in(pact: pact, on: Date.current,     status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(2)
+      end
+    end
+
+    context "今日も昨日も kept が無いなら" do
+      it "streak_count = 0（古い連続は失効）" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        # 一昨日まで連続 kept だが、昨日と今日は kept 無し
+        add_check_in(pact: pact, on: Date.current - 5, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 4, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 3, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 2, status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(0)
+      end
+    end
+
+    context "起点が「昨日」の場合（今日まだ kept していない）" do
+      it "昨日から逆順に kept が連続している日数を返す" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        add_check_in(pact: pact, on: Date.current - 3, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 2, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        # 今日はまだチェックインしていない
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(3)
+      end
+    end
+
+    context "broken が間に挟まると連続が切れる" do
+      it "broken の翌日以降の連続だけがカウント" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        add_check_in(pact: pact, on: Date.current - 3, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 2, status: :broken)  # ← ここで切れる
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        add_check_in(pact: pact, on: Date.current,     status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(2)
+      end
+    end
+
+    context "skipped は streak を切らないが伸ばさない" do
+      it "間に skipped があっても連続は維持" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        add_check_in(pact: pact, on: Date.current - 3, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 2, status: :skipped) # ← 伸ばさず切らず
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        add_check_in(pact: pact, on: Date.current,     status: :kept)
+
+        described_class.new(user).recalculate!
+        # 当日 + 昨日 + skipped 飛ばし + 一昨々日 kept = 3 日カウント
+        expect(user.reload.streak_count).to eq(3)
+      end
+
+      it "全部 skipped の日が続いても streak は伸びない" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        add_check_in(pact: pact, on: Date.current - 1, status: :skipped)
+        add_check_in(pact: pact, on: Date.current,     status: :skipped)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(0)
+      end
+    end
+
+    context "複数契約があっても 1 日 1 カウント" do
+      it "同日に契約 A も B も kept なら 1 日として扱う" do
+        pact_a = create(:pact, user: user, signed_at: 7.days.ago)
+        pact_b = create(:pact, user: user, signed_at: 7.days.ago)
+        add_check_in(pact: pact_a, on: Date.current, status: :kept)
+        add_check_in(pact: pact_b, on: Date.current, status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(1)
+      end
+    end
+
+    context "abandoned / completed 契約のチェックインも履歴として含める" do
+      it "過去達成は奪わない（abandoned 後もその日数はカウント）" do
+        pact = create(:pact, user: user, signed_at: 10.days.ago)
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        add_check_in(pact: pact, on: Date.current,     status: :kept)
+        # 後から契約を abandon
+        pact.update!(status: :abandoned)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(2)
+      end
+    end
+
+    context "longest_streak の更新" do
+      it "現在 streak が過去最長を超えたら更新する" do
+        user.update!(longest_streak: 1)
+        pact = create(:pact, user: user, signed_at: 7.days.ago)
+        add_check_in(pact: pact, on: Date.current - 2, status: :kept)
+        add_check_in(pact: pact, on: Date.current - 1, status: :kept)
+        add_check_in(pact: pact, on: Date.current,     status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.longest_streak).to eq(3)
+      end
+
+      it "現在 streak が過去最長を下回るときは過去最長を維持する" do
+        user.update!(longest_streak: 10)
+        pact = create(:pact, user: user, signed_at: 7.days.ago)
+        add_check_in(pact: pact, on: Date.current, status: :kept)
+
+        described_class.new(user).recalculate!
+        expect(user.reload.longest_streak).to eq(10)
+      end
+    end
+
+    context "別ユーザーの check_in は自分の streak に影響しない" do
+      it "他人の kept はカウントされない" do
+        other = create(:user)
+        other_pact = create(:pact, user: other, signed_at: 7.days.ago)
+        add_check_in(pact: other_pact, on: Date.current, status: :kept)
+
+        # 自分は何も check_in していない
+        described_class.new(user).recalculate!
+        expect(user.reload.streak_count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/services/streak_calculator_spec.rb
+++ b/spec/services/streak_calculator_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe StreakCalculator, type: :service do
     pact.check_ins.new(checked_on: on, status: status).save!(validate: false)
   end
 
-  describe "#recalculate!" do
+  describe "#call" do
     context "チェックインが 0 件のとき" do
       it "streak_count = 0、longest_streak = 0" do
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(0)
         expect(user.longest_streak).to eq(0)
       end
@@ -23,7 +23,7 @@ RSpec.describe StreakCalculator, type: :service do
         pact = create(:pact, user: user, signed_at: 7.days.ago)
         add_check_in(pact: pact, on: Date.current, status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(1)
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :kept)
         add_check_in(pact: pact, on: Date.current,     status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(2)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 3, status: :kept)
         add_check_in(pact: pact, on: Date.current - 2, status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(0)
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :kept)
         # 今日はまだチェックインしていない
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(3)
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :kept)
         add_check_in(pact: pact, on: Date.current,     status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(2)
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :kept)
         add_check_in(pact: pact, on: Date.current,     status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         # 当日 + 昨日 + skipped 飛ばし + 一昨々日 kept = 3 日カウント
         expect(user.reload.streak_count).to eq(3)
       end
@@ -97,7 +97,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :skipped)
         add_check_in(pact: pact, on: Date.current,     status: :skipped)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(0)
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact_a, on: Date.current, status: :kept)
         add_check_in(pact: pact_b, on: Date.current, status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(1)
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe StreakCalculator, type: :service do
         # 後から契約を abandon
         pact.update!(status: :abandoned)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(2)
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: pact, on: Date.current - 1, status: :kept)
         add_check_in(pact: pact, on: Date.current,     status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.longest_streak).to eq(3)
       end
 
@@ -144,7 +144,7 @@ RSpec.describe StreakCalculator, type: :service do
         pact = create(:pact, user: user, signed_at: 7.days.ago)
         add_check_in(pact: pact, on: Date.current, status: :kept)
 
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.longest_streak).to eq(10)
       end
     end
@@ -156,7 +156,7 @@ RSpec.describe StreakCalculator, type: :service do
         add_check_in(pact: other_pact, on: Date.current, status: :kept)
 
         # 自分は何も check_in していない
-        described_class.new(user).recalculate!
+        described_class.new(user).call
         expect(user.reload.streak_count).to eq(0)
       end
     end


### PR DESCRIPTION
## 概要

Issue #12 のモデル層を実装。日々のチェックインを記録する `check_ins` テーブルと、連続日数を再計算する `StreakCalculator` サービスを追加。
ランキング機能（#19）の前提となる v1.1 のベース機能。

## 主な実装

### 1. check_ins テーブル

| カラム      | 型   | 制約                     |
| ----------- | ---- | ------------------------ |
| pact_id     | bigint | NOT NULL FK→pacts.id   |
| checked_on  | date | NOT NULL                |
| status      | int  | NOT NULL（enum）        |
| note        | text | NULLABLE                |

- **UNIQUE INDEX `(pact_id, checked_on)`** で「1 日 1 契約 1 件」を DB 強制
- 同時 POST race も unique violation で弾く
- `checked_on` にも B-tree index（連続日数計算 / 集計用）

### 2. CheckIn モデル

- `belongs_to :pact` / `enum :status { kept / broken / skipped }`
- バリデーション：
  - `checked_on` 必須 / 未来不可（`<= Time.zone.today`）/ `>= pact.signed_at.to_date`
  - `note` 500 文字以内
  - `(pact_id, checked_on)` ユニーク
  - active 契約のみ新規 check-in 作成可能
- `after_save` / `after_destroy` で `StreakCalculator` を起動（同一 transaction 内 UPDATE）

### 3. アソシエーション

- `User#has_many :check_ins, through: :pacts`
- `Pact#has_many :check_ins, dependent: :destroy`

### 4. StreakCalculator サービス（仕様）

- 起点は **「今日 OR 昨日」** から逆順走査
- **kept**: 連続を伸ばす / **broken**: 切る / **skipped**: 切らず伸ばさず
- **同日に複数契約で kept があっても 1 日 1 カウント**
- abandoned / completed pact のチェックインも履歴として算入（過去達成は奪わない）
- `longest_streak` は新 streak が過去最長を超えたら更新
- `with_lock` で同一 user の並行 check-in レース対策

## 設計判断（Codex レビュー反映）

| 観点                          | 採用判断                                                        |
| ----------------------------- | --------------------------------------------------------------- |
| `skipped` の扱い              | streak を切らず伸ばさず（UX 重視）                              |
| `note` 500 文字制限           | 採用（DB を守る + 表示崩れ防止）                                |
| active 契約の定義             | abandoned / completed への新規 check-in は不可                  |
| `signed_at` 比較              | `signed_at.to_date` で型一致                                    |
| 並行更新                      | `with_lock` で SELECT FOR UPDATE                                |
| streak の単位                 | **user 単位**（既存 `users.streak_count` を使う）。pact 単位は別 Issue で |
| コールバック                  | `after_save` + `after_destroy`（rspec transactional fixtures との整合性確保、`update_columns` は同一 transaction で UPDATE するため安全） |

## テスト

- **CheckIn モデル spec**: 14 件（validations / unique / 訂正パターン / コールバック）
- **StreakCalculator spec**: 11 件（kept / broken / skipped 各組み合わせ + 多契約 1 カウント + abandoned 算入 + longest 更新 + 別ユーザー独立）

## 動作確認

- [x] \`bundle exec rspec\` パス（131 / 0）
- [x] \`bundle exec rubocop\` クリーン
- [x] \`npm run lint\` / \`typecheck\` クリーン

## 残作業（後続 Issue）

- **Issue #19**: チェックイン API + ランキング API（4 endpoints）
  - 訂正パターン \`find_or_initialize_by + update!\` を Service 化（race retry など）
  - \`RecordNotUnique\` の rescue + retry
- **Issue #13**: crests テーブル + 紋章生成ロジック
- **Issue #14**: ai_generations テーブル

closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チェックイン機能を追加しました。誓約の実行状況を日ごとに記録（遵守・違反・スキップ）できます。
  * ストリーク追跡機能を実装しました。チェックイン履歴に基づいて連続達成日数が自動更新されます。
  * チェックインにオプションのメモを追加できます（最大500文字）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->