### PR TITLE
feat(model): ai_generations テーブル + AiGeneration モデル

### DIFF
--- a/app/models/ai_generation.rb
+++ b/app/models/ai_generation.rb
@@ -1,0 +1,23 @@
+class AiGeneration < ApplicationRecord
+  belongs_to :user
+  # pact は AI 呼び出しタイミングによっては未確定（目標案 / 制約案）。
+  # 紐付いた pact が destroy されたら nullify でログは残す（コスト分析・監査用途）。
+  belongs_to :pact, optional: true
+
+  enum :generation_type, {
+    goal_suggestion: 0,        # 目標案
+    constraint_suggestion: 1,  # 制約案
+    difficulty_judgment: 2,    # 難易度判定
+    title_generation: 3        # 称号生成
+  }
+
+  enum :status, {
+    success: 0,
+    failed: 1,
+    filtered: 2  # コンテンツフィルタで弾かれた
+  }
+
+  validates :generation_type, presence: true
+  validates :status, presence: true
+  validates :model, presence: true
+end

--- a/app/models/pact.rb
+++ b/app/models/pact.rb
@@ -1,6 +1,8 @@
 class Pact < ApplicationRecord
-  # has_one :crest / has_many :ai_generations は v1.1 (#13, #14) で実装予定
+  # has_one :crest は v1.1 (#13) で実装予定
   has_many :check_ins, dependent: :destroy
+  # AI ログは契約削除時に nullify（履歴・コスト分析用に残す）
+  has_many :ai_generations, dependent: :nullify
 
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,7 @@ class User < ApplicationRecord
   has_many :pacts, dependent: :destroy
   has_many :sessions, dependent: :destroy
   has_many :check_ins, through: :pacts
-  # AiGeneration は v1.1 (#14) で実装予定
-  # has_many :ai_generations, dependent: :destroy
+  has_many :ai_generations, dependent: :destroy
 
   # バリデーション
   validates :email,

--- a/db/migrate/20260506040745_create_ai_generations.rb
+++ b/db/migrate/20260506040745_create_ai_generations.rb
@@ -1,0 +1,24 @@
+class CreateAiGenerations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :ai_generations do |t|
+      t.references :user, null: false, foreign_key: true
+      # pact がまだ無い段階の AI 呼び出し（目標案 / 制約案）も記録するため nullable
+      t.references :pact, null: true, foreign_key: true
+      t.integer :generation_type, null: false
+      t.jsonb :input_data, null: false, default: {}
+      t.jsonb :output_data, null: false, default: {}
+      t.string :model, null: false
+      t.integer :tokens_used
+      t.integer :latency_ms
+      t.integer :status, null: false
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    # 種類別の集計（コスト分析・成功率計算）
+    add_index :ai_generations, :generation_type
+    # ユーザーごとの履歴を時系列で取得 / レート制限判定（v1.1 #43）にも使う
+    add_index :ai_generations, [ :user_id, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_120723) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_040745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "ai_generations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error_message"
+    t.integer "generation_type", null: false
+    t.jsonb "input_data", default: {}, null: false
+    t.integer "latency_ms"
+    t.string "model", null: false
+    t.jsonb "output_data", default: {}, null: false
+    t.bigint "pact_id"
+    t.integer "status", null: false
+    t.integer "tokens_used"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["generation_type"], name: "index_ai_generations_on_generation_type"
+    t.index ["pact_id"], name: "index_ai_generations_on_pact_id"
+    t.index ["user_id", "created_at"], name: "index_ai_generations_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_ai_generations_on_user_id"
+  end
 
   create_table "check_ins", force: :cascade do |t|
     t.date "checked_on", null: false
@@ -67,6 +86,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_120723) do
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
   end
 
+  add_foreign_key "ai_generations", "pacts"
+  add_foreign_key "ai_generations", "users"
   add_foreign_key "check_ins", "pacts"
   add_foreign_key "pacts", "users"
   add_foreign_key "sessions", "users"

--- a/spec/factories/ai_generations.rb
+++ b/spec/factories/ai_generations.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :ai_generation do
+    association :user
+    pact { nil }
+    generation_type { :goal_suggestion }
+    input_data { { theme: "健康" } }
+    output_data { { goals: [ "毎日 30 分歩く", "週 3 回筋トレ", "23 時に寝る" ] } }
+    model { "gpt-5.4-nano" }
+    tokens_used { 120 }
+    latency_ms { 850 }
+    status { :success }
+    error_message { nil }
+  end
+end

--- a/spec/models/ai_generation_spec.rb
+++ b/spec/models/ai_generation_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe AiGeneration, type: :model do
+  describe "associations" do
+    it "belongs_to :user" do
+      assoc = described_class.reflect_on_association(:user)
+      expect(assoc.macro).to eq(:belongs_to)
+      expect(assoc.options[:optional]).to be_falsey
+    end
+
+    it "belongs_to :pact, optional" do
+      assoc = described_class.reflect_on_association(:pact)
+      expect(assoc.macro).to eq(:belongs_to)
+      expect(assoc.options[:optional]).to be true
+    end
+  end
+
+  describe "enum generation_type" do
+    it "目標案 / 制約案 / 難易度判定 / 称号生成 を持つ" do
+      expect(described_class.generation_types).to eq(
+        "goal_suggestion" => 0,
+        "constraint_suggestion" => 1,
+        "difficulty_judgment" => 2,
+        "title_generation" => 3
+      )
+    end
+  end
+
+  describe "enum status" do
+    it "success / failed / filtered を持つ" do
+      expect(described_class.statuses).to eq(
+        "success" => 0,
+        "failed" => 1,
+        "filtered" => 2
+      )
+    end
+  end
+
+  describe "validations" do
+    let(:user) { create(:user) }
+
+    it "正しい属性なら valid（pact なし = 目標案系）" do
+      ai = build(:ai_generation, user: user)
+      expect(ai).to be_valid
+    end
+
+    it "user は必須" do
+      ai = build(:ai_generation, user: nil)
+      expect(ai).not_to be_valid
+      expect(ai.errors[:user]).to be_present
+    end
+
+    it "pact は省略可（目標案 / 制約案では契約未確定なので nil もありうる）" do
+      ai = build(:ai_generation, user: user, pact: nil)
+      expect(ai).to be_valid
+    end
+
+    it "pact が存在する場合は紐付けられる（難易度判定 / 称号生成）" do
+      pact = create(:pact, user: user)
+      ai = build(:ai_generation, user: user, pact: pact, generation_type: :difficulty_judgment)
+      expect(ai).to be_valid
+      expect(ai.pact_id).to eq(pact.id)
+    end
+
+    it "generation_type は必須" do
+      ai = build(:ai_generation, user: user, generation_type: nil)
+      expect(ai).not_to be_valid
+    end
+
+    it "model は必須" do
+      ai = build(:ai_generation, user: user, model: nil)
+      expect(ai).not_to be_valid
+      expect(ai.errors[:model]).to be_present
+    end
+
+    it "status は必須" do
+      ai = build(:ai_generation, user: user, status: nil)
+      expect(ai).not_to be_valid
+    end
+
+    it "input_data / output_data は jsonb で保存される" do
+      ai = create(:ai_generation, user: user,
+        input_data: { theme: "学習", model: "gpt-5.4-nano" },
+        output_data: { goals: %w[A B C] })
+      ai.reload
+      expect(ai.input_data["theme"]).to eq("学習")
+      expect(ai.output_data["goals"]).to eq(%w[A B C])
+    end
+
+    it "tokens_used / latency_ms は省略可（API エラー時は記録できない）" do
+      ai = build(:ai_generation, user: user, tokens_used: nil, latency_ms: nil)
+      expect(ai).to be_valid
+    end
+
+    it "失敗時は error_message を伴う" do
+      ai = build(:ai_generation, user: user, status: :failed, error_message: "rate limit exceeded")
+      expect(ai).to be_valid
+      expect(ai.error_message).to eq("rate limit exceeded")
+    end
+  end
+
+  describe "scope と検索" do
+    let(:user) { create(:user) }
+
+    before do
+      create(:ai_generation, user: user, generation_type: :goal_suggestion, created_at: 2.days.ago)
+      create(:ai_generation, user: user, generation_type: :constraint_suggestion, created_at: 1.day.ago)
+      create(:ai_generation, user: user, generation_type: :goal_suggestion, created_at: 1.hour.ago)
+    end
+
+    it "generation_type で絞り込めて、件数集計に使える" do
+      expect(described_class.goal_suggestion.count).to eq(2)
+      expect(described_class.constraint_suggestion.count).to eq(1)
+    end
+
+    it "ユーザーごとの履歴を created_at 降順で取得できる" do
+      list = user.ai_generations.order(created_at: :desc)
+      expect(list.first.created_at).to be > list.last.created_at
+    end
+  end
+
+  describe "User / Pact からのアソシエーション" do
+    let(:user) { create(:user) }
+
+    it "User#ai_generations で取得できる" do
+      ai = create(:ai_generation, user: user)
+      expect(user.reload.ai_generations).to include(ai)
+    end
+
+    it "Pact が destroy されたら関連 ai_generations の pact_id は nullify される" do
+      pact = create(:pact, user: user)
+      ai = create(:ai_generation, user: user, pact: pact, generation_type: :difficulty_judgment)
+      pact.destroy!
+      expect(ai.reload.pact_id).to be_nil
+    end
+
+    it "User が destroy されたら関連 ai_generations も destroy される" do
+      create(:ai_generation, user: user)
+      expect { user.destroy! }.to change(described_class, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #14: AI 生成履歴のログ用テーブル `ai_generations` を追加。デバッグ・コスト分析・改善のためのモデル層。
v1.1（チェックイン + 紋章）の AI 機能群（目標案 / 制約案 / 難易度判定 / 称号生成）の **記録基盤**。

## 主な実装

### 1. ai_generations テーブル

| カラム             | 型      | 制約                          | 用途                                |
| ------------------ | ------- | ----------------------------- | ----------------------------------- |
| user_id            | bigint  | NOT NULL FK→users.id          | リクエスト者                        |
| pact_id            | bigint  | NULLABLE FK→pacts.id          | 関連契約（目標案では未確定）        |
| generation_type    | int     | NOT NULL（enum 4 種類）      | どの AI 機能か                      |
| input_data         | jsonb   | NOT NULL                      | プロンプト・パラメータ全文          |
| output_data        | jsonb   | NOT NULL                      | レスポンス全文                      |
| model              | string  | NOT NULL                      | 使用モデル（gpt-5.4-nano 等）       |
| tokens_used        | int     | NULLABLE                      | コスト計測                          |
| latency_ms         | int     | NULLABLE                      | パフォーマンス計測                  |
| status             | int     | NOT NULL（enum 3 種類）      | success / failed / filtered         |
| error_message      | text    | NULLABLE                      | 失敗時の詳細                        |

INDEX:
- `generation_type`: 種類別の集計（コスト分析・成功率）
- `(user_id, created_at)`: ユーザー別履歴 + **レート制限判定（#43）の前提**

### 2. AiGeneration モデル

- `belongs_to :user`（必須）
- `belongs_to :pact, optional: true`（目標案 / 制約案では未確定）
- `enum :generation_type`: 4 種類
- `enum :status`: success / failed / filtered
- バリデーション: generation_type / status / model 必須

### 3. アソシエーション

- `User#has_many :ai_generations, dependent: :destroy`
- `Pact#has_many :ai_generations, dependent: :nullify`
  - **契約削除時もログは残す**（コスト分析・監査に使えるように）

## 設計判断

| 観点                         | 判断                                                                                |
| ---------------------------- | ----------------------------------------------------------------------------------- |
| pact_id を nullable にする   | 目標案 / 制約案は契約作成前に呼ばれるので、pact がまだ存在しない                    |
| jsonb で input/output 全文保存 | コスト分析と問題再現のため、プロンプトも含めて全部保存                              |
| Pact 削除時 nullify          | 契約を消しても **AI 利用ログは残す**（監査・改善のため）                            |
| User 削除時 destroy          | プライバシー観点でユーザー消去時は AI ログも消す                                    |
| INDEX `(user_id, created_at)` | #43（レート制限）で「過去 1 分の生成数」を高速取得する前提                          |

## テスト

19 件:
- アソシエーション (3) / enum (2) / バリデーション (8) / scope (2) / jsonb 永続化 / destroy 連鎖 (3)

## 動作確認

- [x] \`bundle exec rspec\` パス（152 / 0、19 件追加）
- [x] \`bundle exec rubocop\` クリーン
- [x] \`bin/rails db:migrate\` 成功

## 残作業（後続 Issue）

- **#43**: AI v1.1 拡張（Solid Queue 非同期化 + ジョブポーリング + **このテーブルに書き込み** + レート制限）
- 既存 AI コントローラ（goals / constraints / difficulties / titles）から書き込みを行う統合は #43 で実施

closes #14