### PR TITLE
feat(api): チェックイン CRUD + ランキング API + PactCompleter（達成判定）

### DIFF
--- a/app/controllers/api/v1/check_ins_controller.rb
+++ b/app/controllers/api/v1/check_ins_controller.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    class CheckInsController < Api::V1::BaseController
+      before_action :set_pact
+
+      # GET /api/v1/pacts/:pact_id/check_ins?month=YYYY-MM
+      # month を渡された場合は当該月のみ、未指定なら全件返す（カレンダー UI 用）。
+      def index
+        scope = @pact.check_ins.order(checked_on: :desc)
+        if params[:month].present?
+          range = month_range(params[:month])
+          scope = scope.where(checked_on: range)
+        end
+        render json: CheckInSerializer.new(scope).serializable_hash, status: :ok
+      end
+
+      # POST /api/v1/pacts/:pact_id/check_ins
+      def create
+        # checked_on / pact_id はクライアント受付不可（チート防止）
+        check_in, created = ApplicationRecord.transaction do
+          ci, c = CheckIns::Upsert.call(pact: @pact, status: params[:status], note: params[:note])
+          PactCompleter.new(@pact).call
+          [ ci, c ]
+        end
+
+        @pact.reload
+        achieved = @pact.completed? && @pact.completed_at.present? &&
+                   @pact.completed_at >= 1.minute.ago
+        status_code = created ? :created : :ok
+
+        render json: {
+          check_in: CheckInSerializer.new(check_in).to_h,
+          pact: PactSerializer.new(@pact).to_h,
+          achieved: achieved
+        }, status: status_code
+      end
+
+      # DELETE /api/v1/pacts/:pact_id/check_ins/:id
+      # 認可は二段階：自分の pact 配下のみ + その pact の check_ins のみ。
+      def destroy
+        check_in = @pact.check_ins.find(params[:id])
+        check_in.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_pact
+        @pact = Current.user.pacts.find(params[:pact_id])
+      end
+
+      # "2026-05" 形式 → Date 範囲。形式不正なら今月にフォールバック。
+      def month_range(month_str)
+        year, month = month_str.split("-").map(&:to_i)
+        start_date = Date.new(year, month, 1)
+        start_date..start_date.end_of_month
+      rescue StandardError
+        Time.zone.today.beginning_of_month..Time.zone.today.end_of_month
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/check_ins_controller.rb
+++ b/app/controllers/api/v1/check_ins_controller.rb
@@ -3,6 +3,10 @@ module Api
     class CheckInsController < Api::V1::BaseController
       before_action :set_pact
 
+      # 不正な enum 値（"invalid_status" など）が渡されると Rails は ArgumentError を
+      # 投げて 500 で落ちるため、422 に変換してクライアント側でハンドルできるようにする。
+      rescue_from ArgumentError, with: :render_invalid_argument
+
       # GET /api/v1/pacts/:pact_id/check_ins?month=YYYY-MM
       # month を渡された場合は当該月のみ、未指定なら全件返す（カレンダー UI 用）。
       def index
@@ -17,8 +21,9 @@ module Api
       # POST /api/v1/pacts/:pact_id/check_ins
       def create
         # checked_on / pact_id はクライアント受付不可（チート防止）
+        attrs = check_in_params
         check_in, created = ApplicationRecord.transaction do
-          ci, c = CheckIns::Upsert.call(pact: @pact, status: params[:status], note: params[:note])
+          ci, c = CheckIns::Upsert.call(pact: @pact, status: attrs[:status], note: attrs[:note])
           PactCompleter.new(@pact).call
           [ ci, c ]
         end
@@ -47,6 +52,18 @@ module Api
 
       def set_pact
         @pact = Current.user.pacts.find(params[:pact_id])
+      end
+
+      # クライアントから受け取れるのは status / note のみ。
+      # checked_on / pact_id はサーバ側で確定する（チート防止）。
+      def check_in_params
+        params.permit(:status, :note)
+      end
+
+      def render_invalid_argument(exception)
+        render json: {
+          errors: [ { code: "invalid_argument", field: "status", message: exception.message } ]
+        }, status: :unprocessable_entity
       end
 
       # "2026-05" 形式 → Date 範囲。形式不正なら今月にフォールバック。

--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -1,0 +1,104 @@
+module Api
+  module V1
+    class RankingsController < Api::V1::BaseController
+      TOP_LIMIT = 10
+
+      # GET /api/v1/rankings/monthly
+      # 「今月 completed になった pact 数」のランキング。
+      # is_public = true のユーザーのみ一覧表示、自分は private でも my_rank を返す。
+      def monthly
+        month_start = Time.zone.today.beginning_of_month
+        month_end   = Time.zone.today.end_of_month
+
+        # ユーザーごとの completed 数を算出
+        scores = Pact.completed
+                     .where(completed_at: month_start..month_end)
+                     .group(:user_id)
+                     .count
+
+        rankings = build_monthly_rankings(scores)
+        my_rank  = build_monthly_my_rank(scores, rankings)
+
+        render json: {
+          month: Time.zone.today.strftime("%Y-%m"),
+          rankings: rankings,
+          my_rank: my_rank
+        }, status: :ok
+      end
+
+      # GET /api/v1/rankings/streak
+      # users.streak_count による連続日数ランキング。
+      def streak
+        public_users = User.where(is_public: true).order(streak_count: :desc, updated_at: :asc, id: :asc)
+
+        rankings = []
+        last_score = nil
+        last_rank = 0
+        public_users.each_with_index do |u, idx|
+          rank = (u.streak_count == last_score) ? last_rank : idx + 1
+          last_score = u.streak_count
+          last_rank = rank
+          break if rankings.size >= TOP_LIMIT && u.streak_count != last_score
+
+          if rankings.size < TOP_LIMIT
+            rankings << { rank: rank, user: user_summary(u), streak_count: u.streak_count }
+          end
+        end
+
+        my_rank = build_streak_my_rank
+        render json: { rankings: rankings, my_rank: my_rank }, status: :ok
+      end
+
+      private
+
+      def build_monthly_rankings(scores)
+        users = User.where(is_public: true, id: scores.keys).index_by(&:id)
+        sorted = scores
+                 .select { |uid, _| users.key?(uid) }
+                 .map { |uid, count| [ users[uid], count ] }
+                 .sort_by { |u, count| [ -count, u.updated_at, u.id ] }
+
+        rankings = []
+        last_score = nil
+        last_rank = 0
+        sorted.each_with_index do |(u, count), idx|
+          rank = (count == last_score) ? last_rank : idx + 1
+          last_score = count
+          last_rank = rank
+          break if rankings.size >= TOP_LIMIT
+          rankings << { rank: rank, user: user_summary(u), achievement_count: count }
+        end
+        rankings
+      end
+
+      def build_monthly_my_rank(scores, rankings)
+        my_count = scores[Current.user.id] || 0
+        # 自分の順位は「自分より高い score を持つ public users + 自分」で計算
+        higher = User.where(is_public: true)
+                     .where.not(id: Current.user.id)
+                     .where(id: scores.select { |_, c| c > my_count }.keys)
+                     .count
+        my_rank_value = higher + 1
+
+        # 自分が圏外なら my_rank.rank は nil
+        my_rank_value = nil if my_count.zero? && rankings.none? { |r| r[:user][:id] == Current.user.id }
+
+        { rank: my_rank_value, achievement_count: my_count }
+      end
+
+      def build_streak_my_rank
+        my_streak = Current.user.streak_count
+        higher = User.where(is_public: true)
+                     .where.not(id: Current.user.id)
+                     .where("streak_count > ?", my_streak)
+                     .count
+        my_rank_value = my_streak.zero? ? nil : higher + 1
+        { rank: my_rank_value, streak_count: my_streak }
+      end
+
+      def user_summary(u)
+        { id: u.id, nickname: u.nickname, avatar_url: u.avatar_url }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -7,8 +7,11 @@ module Api
       # 「今月 completed になった pact 数」のランキング。
       # is_public = true のユーザーのみ一覧表示、自分は private でも my_rank を返す。
       def monthly
-        month_start = Time.zone.today.beginning_of_month
-        month_end   = Time.zone.today.end_of_month
+        # Date#end_of_month は 00:00:00 として解釈されるため、月末当日の datetime レコードが
+        # ほぼ取得できない。Time.zone.now を使って TimeWithZone（23:59:59.999...）にする。
+        now         = Time.zone.now
+        month_start = now.beginning_of_month
+        month_end   = now.end_of_month
 
         # ユーザーごとの completed 数を算出
         scores = Pact.completed
@@ -29,20 +32,26 @@ module Api
       # GET /api/v1/rankings/streak
       # users.streak_count による連続日数ランキング。
       def streak
-        public_users = User.where(is_public: true).order(streak_count: :desc, updated_at: :asc, id: :asc)
+        # streak_count = 0 のユーザーは除外（圏外なので一覧に出さない）。
+        public_users = User.where(is_public: true)
+                           .where("streak_count > 0")
+                           .order(streak_count: :desc, updated_at: :asc, id: :asc)
+                           # TOP_LIMIT 件 + α を取れば、同点タイ用に余裕を持って取れる。
+                           .limit(TOP_LIMIT * 2)
 
         rankings = []
         last_score = nil
         last_rank = 0
         public_users.each_with_index do |u, idx|
-          rank = (u.streak_count == last_score) ? last_rank : idx + 1
-          last_score = u.streak_count
-          last_rank = rank
+          # 直前のスコアと比較する（last_score を更新する前に）
+          # TOP_LIMIT 件に達していて、かつスコアが変わったら終了。
+          # 同点タイは TOP_LIMIT を超えても全員含める。
           break if rankings.size >= TOP_LIMIT && u.streak_count != last_score
 
-          if rankings.size < TOP_LIMIT
-            rankings << { rank: rank, user: user_summary(u), streak_count: u.streak_count }
-          end
+          rank = (u.streak_count == last_score) ? last_rank : idx + 1
+          last_score = u.streak_count
+          last_rank  = rank
+          rankings << { rank: rank, user: user_summary(u), streak_count: u.streak_count }
         end
 
         my_rank = build_streak_my_rank
@@ -62,10 +71,12 @@ module Api
         last_score = nil
         last_rank = 0
         sorted.each_with_index do |(u, count), idx|
+          # 同点タイは TOP_LIMIT を超えても全員含める（streak と挙動を揃える）。
+          break if rankings.size >= TOP_LIMIT && count != last_score
+
           rank = (count == last_score) ? last_rank : idx + 1
           last_score = count
           last_rank = rank
-          break if rankings.size >= TOP_LIMIT
           rankings << { rank: rank, user: user_summary(u), achievement_count: count }
         end
         rankings

--- a/app/serializers/check_in_serializer.rb
+++ b/app/serializers/check_in_serializer.rb
@@ -1,0 +1,11 @@
+class CheckInSerializer
+  include Alba::Resource
+
+  attributes :id,
+             :pact_id,
+             :checked_on,
+             :status,
+             :note,
+             :created_at,
+             :updated_at
+end

--- a/app/services/check_ins/upsert.rb
+++ b/app/services/check_ins/upsert.rb
@@ -1,0 +1,15 @@
+module CheckIns
+  # 「同日の check_in があれば更新、無ければ作成」を行うサービス。
+  # pact.with_lock で同時 POST race を直列化し、UNIQUE 制約違反を防ぐ。
+  # 戻り値は [check_in, created]（created は新規=true / 訂正=false）。
+  class Upsert
+    def self.call(pact:, status:, note: nil)
+      pact.with_lock do
+        check_in = pact.check_ins.find_or_initialize_by(checked_on: Time.zone.today)
+        created = check_in.new_record?
+        check_in.update!(status: status, note: note)
+        [ check_in, created ]
+      end
+    end
+  end
+end

--- a/app/services/pact_completer.rb
+++ b/app/services/pact_completer.rb
@@ -1,0 +1,45 @@
+class PactCompleter
+  # 契約の達成判定とステータス更新を担当するサービス。
+  # 仕様（Codex レビュー反映後の MVP 版）:
+  # - active な契約のみ対象
+  # - Time.zone.today >= pact.deadline で判定
+  # - 分母 = signed_at.to_date..deadline の日数
+  # - 分子 = 期間内の kept チェックインの distinct(checked_on) 件数
+  # - kept_days >= 1 かつ kept_days / expected_days >= 0.5 で completed
+  # - completed は不可逆（後から訂正されても active に戻らない）
+  COMPLIANCE_THRESHOLD = 0.5
+
+  def initialize(pact)
+    @pact = pact
+  end
+
+  def call
+    return @pact unless completable?
+
+    @pact.update!(status: :completed, completed_at: Time.current)
+    enqueue_crest_generation_later
+    @pact
+  end
+
+  private
+
+  def completable?
+    return false unless @pact.active?
+    return false unless Time.zone.today >= @pact.deadline
+
+    expected_days = (@pact.deadline - @pact.signed_at.to_date).to_i + 1
+    return false unless expected_days.positive?
+
+    kept_days = @pact.check_ins.kept
+                     .where(checked_on: @pact.signed_at.to_date..@pact.deadline)
+                     .distinct
+                     .count(:checked_on)
+
+    kept_days.positive? && kept_days.to_f / expected_days >= COMPLIANCE_THRESHOLD
+  end
+
+  # Crest 生成は v1.1 #13 で実装。ここは hook ポイントだけ用意する。
+  def enqueue_crest_generation_later
+    # noop（v1.1 #13 で実装）
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,10 @@ Rails.application.routes.draw do
         patch  "password", to: "passwords#update"
       end
 
-      resources :pacts, only: [ :index, :create, :show, :update, :destroy ]
+      resources :pacts, only: [ :index, :create, :show, :update, :destroy ] do
+        # ネストしたチェックイン（必ず特定 pact 配下）
+        resources :check_ins, only: [ :index, :create, :destroy ]
+      end
 
       namespace :ai do
         post "goals",        to: "goals#create"
@@ -24,6 +27,10 @@ Rails.application.routes.draw do
         post "difficulties", to: "difficulties#create"
         post "titles",       to: "titles#create"
       end
+
+      # ランキング
+      get "rankings/monthly", to: "rankings#monthly"
+      get "rankings/streak",  to: "rankings#streak"
     end
   end
 

--- a/spec/requests/api/v1/check_ins_spec.rb
+++ b/spec/requests/api/v1/check_ins_spec.rb
@@ -133,6 +133,12 @@ RSpec.describe "Api::V1::CheckIns", type: :request do
       get "/api/v1/pacts/#{other_pact.id}/check_ins"
       expect(response).to have_http_status(:not_found)
     end
+
+    it "未ログインなら 401" do
+      delete "/api/v1/auth/logout"
+      get "/api/v1/pacts/#{pact.id}/check_ins"
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   describe "DELETE /api/v1/pacts/:pact_id/check_ins/:id" do
@@ -161,6 +167,20 @@ RSpec.describe "Api::V1::CheckIns", type: :request do
       other_pact = create(:pact, user: user, signed_at: 1.day.ago)
       delete "/api/v1/pacts/#{other_pact.id}/check_ins/#{check_in.id}"
       expect(response).to have_http_status(:not_found)
+    end
+
+    it "未ログインなら 401" do
+      delete "/api/v1/auth/logout"
+      delete "/api/v1/pacts/#{pact.id}/check_ins/#{check_in.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/v1/pacts/:pact_id/check_ins の不正な status" do
+    it "不正な enum 値（'admin' など）を渡すと 422 Unprocessable Content を返す" do
+      post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "admin" }, as: :json
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body["errors"][0]["code"]).to eq("invalid_argument")
     end
   end
 end

--- a/spec/requests/api/v1/check_ins_spec.rb
+++ b/spec/requests/api/v1/check_ins_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::CheckIns", type: :request do
+  let!(:user) do
+    create(:user, email: "test@example.com",
+           password: "password123", password_confirmation: "password123")
+  end
+  let(:login_params) { { email: "test@example.com", password: "password123" } }
+  let!(:pact) { create(:pact, user: user, signed_at: 3.days.ago) }
+
+  before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+  describe "POST /api/v1/pacts/:pact_id/check_ins" do
+    context "新規作成（同日初回）" do
+      it "201 Created を返し、check_in / pact / achieved を含むレスポンスを返す" do
+        expect {
+          post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "kept", note: "やった" }, as: :json
+        }.to change(CheckIn, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body["check_in"]["status"]).to eq("kept")
+        expect(body["check_in"]["note"]).to eq("やった")
+        expect(body["check_in"]["checked_on"]).to eq(Time.zone.today.to_s)
+        expect(body["pact"]["id"]).to eq(pact.id)
+        expect(body["achieved"]).to be false
+      end
+    end
+
+    context "同日 2 回（訂正）" do
+      before do
+        post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "kept" }, as: :json
+      end
+
+      it "200 OK を返し、新規レコードは増えず status が更新される" do
+        expect {
+          post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "broken", note: "破った" }, as: :json
+        }.not_to change(CheckIn, :count)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["check_in"]["status"]).to eq("broken")
+        expect(body["check_in"]["note"]).to eq("破った")
+      end
+    end
+
+    context "checked_on を渡してもサーバー側で当日に上書きされる（チート防止）" do
+      it "クライアント値は無視される" do
+        post "/api/v1/pacts/#{pact.id}/check_ins",
+             params: { status: "kept", checked_on: "2020-01-01" }, as: :json
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["check_in"]["checked_on"]).to eq(Time.zone.today.to_s)
+      end
+    end
+
+    context "他人の pact に POST すると" do
+      let!(:other_user) { create(:user, email: "other@example.com") }
+      let!(:other_pact) { create(:pact, user: other_user, signed_at: 1.day.ago) }
+
+      it "404 Not Found を返す" do
+        post "/api/v1/pacts/#{other_pact.id}/check_ins", params: { status: "kept" }, as: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "active でない pact への POST" do
+      it "422 Unprocessable Content（pact_must_be_active）" do
+        pact.update!(status: :abandoned)
+        post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "kept" }, as: :json
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "未ログイン" do
+      it "401 Unauthorized を返す" do
+        delete "/api/v1/auth/logout"
+        post "/api/v1/pacts/#{pact.id}/check_ins", params: { status: "kept" }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "達成判定（completed 化）" do
+      let!(:completable_pact) do
+        # deadline が今日の pact を validation skip で作る
+        p = build(:pact, user: user, signed_at: 1.day.ago.beginning_of_day, deadline: Time.zone.today)
+        p.save!(validate: false)
+        # 期間 2 日中、昨日 kept（既に 50%）
+        p.check_ins.new(checked_on: Time.zone.today - 1, status: :kept).save!(validate: false)
+        p
+      end
+
+      it "今日 kept にすると completed に遷移し achieved=true を返す" do
+        post "/api/v1/pacts/#{completable_pact.id}/check_ins",
+             params: { status: "kept" }, as: :json
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body["pact"]["status"]).to eq("completed")
+        expect(body["achieved"]).to be true
+      end
+    end
+  end
+
+  describe "GET /api/v1/pacts/:pact_id/check_ins" do
+    before do
+      pact.check_ins.new(checked_on: 2.days.ago.to_date, status: :kept).save!(validate: false)
+      pact.check_ins.new(checked_on: 1.day.ago.to_date, status: :broken).save!(validate: false)
+      pact.check_ins.new(checked_on: Time.zone.today, status: :kept).save!(validate: false)
+    end
+
+    it "全件返す（checked_on 降順）" do
+      get "/api/v1/pacts/#{pact.id}/check_ins"
+      expect(response).to have_http_status(:ok)
+      list = response.parsed_body
+      expect(list.size).to eq(3)
+      expect(list.first["checked_on"]).to eq(Time.zone.today.to_s)
+    end
+
+    it "month=YYYY-MM で当該月のみに絞る" do
+      this_month = Time.zone.today.strftime("%Y-%m")
+      get "/api/v1/pacts/#{pact.id}/check_ins", params: { month: this_month }
+      expect(response).to have_http_status(:ok)
+      list = response.parsed_body
+      list.each do |ci|
+        expect(ci["checked_on"]).to start_with(this_month)
+      end
+    end
+
+    it "他人の pact からは 404" do
+      other_user = create(:user, email: "other@example.com")
+      other_pact = create(:pact, user: other_user, signed_at: 1.day.ago)
+      get "/api/v1/pacts/#{other_pact.id}/check_ins"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/v1/pacts/:pact_id/check_ins/:id" do
+    let!(:check_in) do
+      ci = pact.check_ins.new(checked_on: 1.day.ago.to_date, status: :kept)
+      ci.save!(validate: false)
+      ci
+    end
+
+    it "204 No Content を返し、レコードを削除する" do
+      expect {
+        delete "/api/v1/pacts/#{pact.id}/check_ins/#{check_in.id}"
+      }.to change(CheckIn, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "他人の pact 経由では 404 Not Found" do
+      other_user = create(:user, email: "other@example.com")
+      other_pact = create(:pact, user: other_user, signed_at: 1.day.ago)
+
+      delete "/api/v1/pacts/#{other_pact.id}/check_ins/#{check_in.id}"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "自分の pact だが、別 pact の check_in id を指定すると 404" do
+      other_pact = create(:pact, user: user, signed_at: 1.day.ago)
+      delete "/api/v1/pacts/#{other_pact.id}/check_ins/#{check_in.id}"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/rankings_spec.rb
+++ b/spec/requests/api/v1/rankings_spec.rb
@@ -67,6 +67,45 @@ RSpec.describe "Api::V1::Rankings", type: :request do
       get "/api/v1/rankings/monthly"
       expect(response).to have_http_status(:unauthorized)
     end
+
+    context "dense rank / タイブレーク / TOP_LIMIT 仕様" do
+      it "achievement_count 同点は dense rank で同順位、updated_at asc → id asc で並ぶ" do
+        # me / public_user_a / public_user_b の既存データはクリア
+        Pact.delete_all
+        # 同点（達成数 2）のユーザーを 2 人用意（updated_at に差をつける）
+        u_old = create(:user, email: "old@example.com", nickname: "Old",
+                              is_public: true, updated_at: 2.days.ago)
+        u_new = create(:user, email: "new@example.com", nickname: "New",
+                              is_public: true, updated_at: 1.day.ago)
+        2.times { make_completed_pact(user: u_old, completed_at: 1.day.ago) }
+        2.times { make_completed_pact(user: u_new, completed_at: 1.day.ago) }
+
+        get "/api/v1/rankings/monthly"
+        list = response.parsed_body["rankings"]
+        # 同点のスコアを持つユーザーは dense rank（同順位）
+        same_score = list.select { |r| r["achievement_count"] == 2 }
+        expect(same_score.size).to eq(2)
+        expect(same_score.map { |r| r["rank"] }.uniq.size).to eq(1)
+        # tie breaker: updated_at が古い方が先
+        expect(same_score.map { |r| r["user"]["id"] }).to eq([ u_old.id, u_new.id ])
+      end
+
+      it "上位 10 件まで表示（同点タイは超過 OK だが基本は TOP_LIMIT）" do
+        Pact.delete_all
+        # 達成数を 1〜15 で用意（全員 public、is_public=true）
+        15.times do |i|
+          u = create(:user, email: "u#{i}@example.com", nickname: "U#{i}", is_public: true)
+          (i + 1).times { make_completed_pact(user: u, completed_at: 1.day.ago) }
+        end
+
+        get "/api/v1/rankings/monthly"
+        list = response.parsed_body["rankings"]
+        # 自分（me）は 0 件なので含まれない。15 ユーザー中上位 10。
+        expect(list.size).to eq(10)
+        expect(list.first["achievement_count"]).to eq(15)
+        expect(list.last["achievement_count"]).to eq(6)
+      end
+    end
   end
 
   describe "GET /api/v1/rankings/streak" do
@@ -113,6 +152,46 @@ RSpec.describe "Api::V1::Rankings", type: :request do
       delete "/api/v1/auth/logout"
       get "/api/v1/rankings/streak"
       expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "dense rank / タイブレーク / TOP_LIMIT 仕様" do
+      it "streak_count 同点は dense rank で同順位、updated_at asc → id asc で並ぶ" do
+        # 既存ユーザーは別スコアなので、新規に同点ユーザーを 2 人作る
+        u_old = create(:user, email: "tiel@example.com", nickname: "TieOld",
+                              is_public: true, streak_count: 7, updated_at: 2.days.ago)
+        u_new = create(:user, email: "tien@example.com", nickname: "TieNew",
+                              is_public: true, streak_count: 7, updated_at: 1.day.ago)
+
+        get "/api/v1/rankings/streak"
+        list = response.parsed_body["rankings"]
+        same_score = list.select { |r| r["streak_count"] == 7 }
+        expect(same_score.size).to eq(2)
+        expect(same_score.map { |r| r["rank"] }.uniq.size).to eq(1)
+        expect(same_score.map { |r| r["user"]["id"] }).to eq([ u_old.id, u_new.id ])
+      end
+
+      it "上位 10 件まで表示" do
+        # 既存ユーザーをクリアしないので 15 人分追加
+        15.times do |i|
+          create(:user, email: "us#{i}@example.com", nickname: "US#{i}",
+                        is_public: true, streak_count: 100 + i)
+        end
+
+        get "/api/v1/rankings/streak"
+        list = response.parsed_body["rankings"]
+        expect(list.size).to eq(10)
+        # 一番大きい streak（100+14=114）が 1 位
+        expect(list.first["streak_count"]).to eq(114)
+      end
+
+      it "streak_count = 0 のユーザーは rankings に含まれない（圏外）" do
+        create(:user, email: "zero@example.com", nickname: "Zero",
+                      is_public: true, streak_count: 0)
+
+        get "/api/v1/rankings/streak"
+        ranked_streaks = response.parsed_body["rankings"].map { |r| r["streak_count"] }
+        expect(ranked_streaks).not_to include(0)
+      end
     end
   end
 end

--- a/spec/requests/api/v1/rankings_spec.rb
+++ b/spec/requests/api/v1/rankings_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Rankings", type: :request do
+  let!(:me) do
+    create(:user, email: "me@example.com", nickname: "Me",
+                  password: "password123", password_confirmation: "password123",
+                  is_public: true, streak_count: 5)
+  end
+  let(:login_params) { { email: "me@example.com", password: "password123" } }
+
+  before { post "/api/v1/auth/login", params: login_params, as: :json }
+
+  # validation skip して completed pact を作るヘルパー
+  def make_completed_pact(user:, completed_at:)
+    p = build(:pact, user: user, signed_at: 10.days.ago, deadline: 1.day.ago.to_date,
+                      status: :completed, completed_at: completed_at)
+    p.save!(validate: false)
+    p
+  end
+
+  describe "GET /api/v1/rankings/monthly" do
+    let!(:public_user_a) { create(:user, email: "a@example.com", nickname: "A", is_public: true) }
+    let!(:public_user_b) { create(:user, email: "b@example.com", nickname: "B", is_public: true) }
+    let!(:private_user)  { create(:user, email: "c@example.com", nickname: "C", is_public: false) }
+
+    before do
+      # 今月の completed pact を各ユーザーに付与
+      3.times { make_completed_pact(user: public_user_a, completed_at: 1.day.ago) }
+      2.times { make_completed_pact(user: public_user_b, completed_at: 1.day.ago) }
+      5.times { make_completed_pact(user: private_user,  completed_at: 1.day.ago) }
+      1.times { make_completed_pact(user: me, completed_at: 1.day.ago) }
+      # 先月の completed は対象外
+      make_completed_pact(user: public_user_a, completed_at: 2.months.ago)
+    end
+
+    it "200 OK で月情報・ランキング配列・my_rank を返す" do
+      get "/api/v1/rankings/monthly"
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["month"]).to eq(Time.zone.today.strftime("%Y-%m"))
+      expect(body["rankings"]).to be_an(Array)
+      expect(body["my_rank"]).to be_a(Hash)
+    end
+
+    it "is_public=true のユーザーのみ rankings に含まれる（private user は除外）" do
+      get "/api/v1/rankings/monthly"
+      ranked_ids = response.parsed_body["rankings"].map { |r| r["user"]["id"] }
+      expect(ranked_ids).not_to include(private_user.id)
+    end
+
+    it "achievement_count 降順で並ぶ（A=3 > B=2 > Me=1）" do
+      get "/api/v1/rankings/monthly"
+      list = response.parsed_body["rankings"]
+      expect(list.first["user"]["id"]).to eq(public_user_a.id)
+      expect(list.first["achievement_count"]).to eq(3)
+    end
+
+    it "my_rank には自分の今月達成数が含まれる（自分が public でランクインしていれば rank も）" do
+      get "/api/v1/rankings/monthly"
+      my_rank = response.parsed_body["my_rank"]
+      expect(my_rank["achievement_count"]).to eq(1)
+      expect(my_rank["rank"]).to be_a(Integer) # 3 位想定（A=3, B=2, Me=1）
+    end
+
+    it "未ログインなら 401" do
+      delete "/api/v1/auth/logout"
+      get "/api/v1/rankings/monthly"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/v1/rankings/streak" do
+    let!(:user_streak_10) do
+      create(:user, email: "s10@example.com", nickname: "S10", is_public: true, streak_count: 10)
+    end
+    let!(:user_streak_20) do
+      create(:user, email: "s20@example.com", nickname: "S20", is_public: true, streak_count: 20)
+    end
+    let!(:user_streak_15_private) do
+      create(:user, email: "p15@example.com", nickname: "P15", is_public: false, streak_count: 15)
+    end
+
+    it "200 OK で rankings 配列と my_rank を返す" do
+      get "/api/v1/rankings/streak"
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["rankings"]).to be_an(Array)
+      expect(body["my_rank"]).to be_a(Hash)
+    end
+
+    it "is_public=false のユーザーは rankings に含まれない" do
+      get "/api/v1/rankings/streak"
+      ranked_ids = response.parsed_body["rankings"].map { |r| r["user"]["id"] }
+      expect(ranked_ids).not_to include(user_streak_15_private.id)
+    end
+
+    it "streak_count 降順（S20=20 が 1 位）" do
+      get "/api/v1/rankings/streak"
+      list = response.parsed_body["rankings"]
+      expect(list.first["user"]["id"]).to eq(user_streak_20.id)
+      expect(list.first["streak_count"]).to eq(20)
+    end
+
+    it "my_rank には自分の streak_count が含まれる（rank も）" do
+      get "/api/v1/rankings/streak"
+      my_rank = response.parsed_body["my_rank"]
+      expect(my_rank["streak_count"]).to eq(5)
+      # 自分の上位 = S20(20), S10(10) → 自分は 3 位
+      expect(my_rank["rank"]).to eq(3)
+    end
+
+    it "未ログインなら 401" do
+      delete "/api/v1/auth/logout"
+      get "/api/v1/rankings/streak"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/services/check_ins/upsert_spec.rb
+++ b/spec/services/check_ins/upsert_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe CheckIns::Upsert, type: :service do
+  let(:user) { create(:user) }
+  let(:pact) { create(:pact, user: user, signed_at: 3.days.ago) }
+
+  describe ".call" do
+    it "新規 check_in を作成する（created=true を返す）" do
+      check_in, created = described_class.call(pact: pact, status: :kept, note: "やった")
+      expect(check_in).to be_persisted
+      expect(check_in.status).to eq("kept")
+      expect(check_in.note).to eq("やった")
+      expect(check_in.checked_on).to eq(Time.zone.today)
+      expect(created).to be true
+    end
+
+    it "同日 2 回呼ぶと既存レコードを更新する（created=false を返す）" do
+      first, c1 = described_class.call(pact: pact, status: :kept)
+      second, c2 = described_class.call(pact: pact, status: :broken, note: "やっぱり破った")
+
+      expect(c1).to be true
+      expect(c2).to be false
+      expect(first.id).to eq(second.id)
+      expect(pact.check_ins.where(checked_on: Time.zone.today).count).to eq(1)
+      expect(second.status).to eq("broken")
+      expect(second.note).to eq("やっぱり破った")
+    end
+
+    it "checked_on は Time.zone.today で固定（クライアント値は受け付けない設計）" do
+      check_in, _ = described_class.call(pact: pact, status: :kept)
+      expect(check_in.checked_on).to eq(Time.zone.today)
+    end
+  end
+end

--- a/spec/services/pact_completer_spec.rb
+++ b/spec/services/pact_completer_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe PactCompleter, type: :service do
+  let(:user) { create(:user) }
+
+  # check_in を意図的に過去日で作るため validation を skip するヘルパー
+  def add_kept(pact:, on:)
+    pact.check_ins.new(checked_on: on, status: :kept).save!(validate: false)
+  end
+
+  # deadline_must_be_in_the_future（on: :create）を回避して、
+  # 「deadline が今日や過去」の pact をテスト用に作るヘルパー。
+  def build_pact(signed_at:, deadline:, status: :active, completed_at: nil)
+    pact = build(:pact, user: user, signed_at: signed_at, deadline: deadline,
+                         status: status, completed_at: completed_at)
+    pact.save!(validate: false)
+    pact
+  end
+
+  describe "#call" do
+    context "deadline 未到達のとき" do
+      it "completed にしない（active のまま、戻り値は pact）" do
+        pact = create(:pact, user: user, signed_at: 5.days.ago, deadline: 5.days.from_now.to_date)
+        add_kept(pact: pact, on: Time.zone.today - 1)
+
+        result = described_class.new(pact).call
+        expect(result.reload.status).to eq("active")
+      end
+    end
+
+    context "deadline 当日に compliance_rate が 0.5 以上のとき" do
+      it "completed にする（completed_at が設定される）" do
+        pact = build_pact(signed_at: 9.days.ago.beginning_of_day, deadline: Time.zone.today)
+        # 期待日数 = 10 日（9 日前 .. 今日）。kept 6 日 = 60% で達成
+        6.times { |i| add_kept(pact: pact, on: pact.signed_at.to_date + i) }
+
+        described_class.new(pact).call
+        pact.reload
+        expect(pact.status).to eq("completed")
+        expect(pact.completed_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context "compliance_rate が 0.5 未満のとき" do
+      it "completed にしない" do
+        pact = build_pact(signed_at: 9.days.ago.beginning_of_day, deadline: Time.zone.today)
+        # 10 日中 4 日だけ kept = 40%
+        4.times { |i| add_kept(pact: pact, on: pact.signed_at.to_date + i) }
+
+        described_class.new(pact).call
+        expect(pact.reload.status).to eq("active")
+      end
+    end
+
+    context "kept が 0 日のとき" do
+      it "deadline 到達でも completed にしない" do
+        pact = build_pact(signed_at: 1.day.ago.beginning_of_day, deadline: Time.zone.today)
+        # check_in 自体無し
+        described_class.new(pact).call
+        expect(pact.reload.status).to eq("active")
+      end
+    end
+
+    context "既に completed の pact" do
+      it "再度 call しても何もしない（completed 不可逆）" do
+        pact = build_pact(signed_at: 9.days.ago.beginning_of_day, deadline: Time.zone.today,
+                          status: :completed, completed_at: 1.hour.ago)
+        original_completed_at = pact.completed_at
+
+        result = described_class.new(pact).call
+        expect(result.reload.status).to eq("completed")
+        expect(result.completed_at).to be_within(1.second).of(original_completed_at)
+      end
+    end
+
+    context "abandoned / failed の pact" do
+      it "completed にしない" do
+        pact = build_pact(signed_at: 9.days.ago.beginning_of_day, deadline: Time.zone.today,
+                          status: :abandoned)
+        4.times { |i| add_kept(pact: pact, on: pact.signed_at.to_date + i) }
+
+        described_class.new(pact).call
+        expect(pact.reload.status).to eq("abandoned")
+      end
+    end
+
+    context "期間内に同日 kept が 2 つ（複数契約ではないが念のため）" do
+      it "distinct で 1 日扱いになる" do
+        pact = build_pact(signed_at: 1.day.ago.beginning_of_day, deadline: Time.zone.today)
+        # 同じ日に 2 件 kept があっても 1 日としてカウントされる前提
+        # ただし UNIQUE 制約で同じ pact では同日 1 件のみ → ここは scenario として異常系
+        add_kept(pact: pact, on: Time.zone.today)
+        # 2 日中 1 日 kept = 50% で達成
+        described_class.new(pact).call
+        expect(pact.reload.status).to eq("completed")
+      end
+    end
+
+    it "completable な場合に Crest 生成 hook（enqueue_crest_generation_later）が呼ばれる" do
+      pact = build_pact(signed_at: 1.day.ago.beginning_of_day, deadline: Time.zone.today)
+      add_kept(pact: pact, on: Time.zone.today)
+
+      service = described_class.new(pact)
+      expect(service).to receive(:enqueue_crest_generation_later)
+      service.call
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #19: v1.1 体験ループ「**チェックイン → streak 伸びる → 達成 → 紋章**」のうち、**チェックイン CRUD + ランキング 2 軸 + 自動達成判定** を実装。
紋章生成（Issue #13）の前提となる達成イベントが発火する状態まで完成。

## エンドポイント（5 つ）

| メソッド | URL                                                | 動作                              |
| -------- | -------------------------------------------------- | --------------------------------- |
| POST     | \`/api/v1/pacts/:pact_id/check_ins\`               | 記録 / 訂正（同日 2 回 = UPDATE）|
| GET      | \`/api/v1/pacts/:pact_id/check_ins\`               | 履歴取得（\`?month=YYYY-MM\`）    |
| DELETE   | \`/api/v1/pacts/:pact_id/check_ins/:id\`           | 訂正削除                          |
| GET      | \`/api/v1/rankings/monthly\`                       | 今月 completed な pact 数         |
| GET      | \`/api/v1/rankings/streak\`                        | 連続日数（users.streak_count）   |

## サービス

### PactCompleter（達成判定）
- 分母 = \`signed_at.to_date..deadline\` の日数
- 分子 = 期間内の \`kept\` の distinct(checked_on)
- 閾値 50% で completed
- **completed 不可逆**（後から訂正されても active に戻らない）
- Crest 生成は空 hook（Issue #13 で実装）

### CheckIns::Upsert（race 対策）
- \`pact.with_lock\` で同時 POST race を直列化
- \`find_or_initialize_by + update!\` で訂正パターン
- 戻り値で created（新規 / 訂正）を判定 → controller が 201/200 を出し分け

## Codex レビュー反映ポイント

| 観点                                               | 反映                                             |
| -------------------------------------------------- | ------------------------------------------------ |
| GET に month パラメータ追加                        | \`?month=YYYY-MM\` で範囲絞り                    |
| DELETE 二段階認可                                  | \`Current.user.pacts.find → pact.check_ins.find\` |
| POST 戻り値に check_in / pact / achieved          | UI が即時反映できるように                        |
| 201 Created（新規）/ 200 OK（訂正）の出し分け     | created フラグで判定                            |
| Time.zone.today に統一                             | 日付境界の意図を明確化                          |
| PactCompleter の分母明示                           | signed_at..deadline の日数                       |
| completed 不可逆                                   | 達成は祝祭、奪わない哲学                        |
| Crest hook は空メソッド                            | コメントより保守しやすい                        |
| ランキング dense rank + tie breaker                | updated_at asc, id asc                          |
| monthly = completed pact 数                        | CLAUDE.md「達成数」と整合                       |
| my_rank は private でも返す                        | 本人には自分の順位を見せる                      |

## チート対策の二層防御

```
[クライアント]
   ↓
[Controller: strong params で checked_on / pact_id 受け付けない]
   ↓
[Model: before_validation で Date.current 強制（既存）]
```

## テスト（34 件追加）

| spec                                          | 件数 | 内容                                          |
| --------------------------------------------- | ---- | --------------------------------------------- |
| spec/services/pact_completer_spec.rb         | 8    | 境界条件 + 不可逆 + Crest hook                |
| spec/services/check_ins/upsert_spec.rb       | 3    | 新規 / 訂正 / checked_on 固定                |
| spec/requests/api/v1/check_ins_spec.rb       | 13   | POST 7 / GET 3 / DELETE 3 + 認可・チート対策 |
| spec/requests/api/v1/rankings_spec.rb        | 10   | monthly 5 / streak 5                          |

## 動作確認

- [x] \`bundle exec rspec\` パス（**186/186**）
- [x] \`bundle exec rubocop\` クリーン

## 残作業（後続 Issue）

- **#13 crests テーブル + 紋章生成ロジック**: PactCompleter の \`enqueue_crest_generation_later\` に実装を入れる
- **#43 AI v1.1**: ai_generations への書き込みを既存 AI コントローラに追加

closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ユーザーが日々の誓約チェックインを記録・追跡できるようになりました
  * チェックイン履歴の閲覧機能と月単位のフィルタリングに対応
  * 月間ランキングと連続達成ランキングを追加
  * コンプライアンス率50%以上で誓約が自動完了

* **Tests**
  * チェックイン管理とランキング機能の包括的なテスト追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->