### PR TITLE
feat(model): crests テーブル + CrestGenerator + PactCompleter hook 実装（v1.1 達成体験完成）

### DIFF
--- a/app/models/crest.rb
+++ b/app/models/crest.rb
@@ -1,0 +1,33 @@
+class Crest < ApplicationRecord
+  REQUIRED_CREST_DATA_KEYS = %w[base_shape central_motif decoration color_palette shimmer_level].freeze
+
+  belongs_to :pact
+
+  enum :rarity, {
+    common: 0,
+    rare: 1,
+    epic: 2,
+    legendary: 3
+  }
+
+  # DB UNIQUE と二重防御
+  validates :pact_id, uniqueness: true
+  validates :rarity, presence: true
+  validates :generated_at, presence: true
+  validate :crest_data_must_have_required_keys
+  validate :pact_must_be_completed
+
+  private
+
+  def crest_data_must_have_required_keys
+    return if crest_data.blank?
+    missing = REQUIRED_CREST_DATA_KEYS - crest_data.keys.map(&:to_s)
+    return if missing.empty?
+    errors.add(:crest_data, "は必須キー #{missing.join(', ')} を含む必要があります")
+  end
+
+  def pact_must_be_completed
+    return if pact.blank?
+    errors.add(:pact, "は completed 状態である必要があります") unless pact.completed?
+  end
+end

--- a/app/models/pact.rb
+++ b/app/models/pact.rb
@@ -1,6 +1,6 @@
 class Pact < ApplicationRecord
-  # has_one :crest は v1.1 (#13) で実装予定
   has_many :check_ins, dependent: :destroy
+  has_one :crest, dependent: :destroy
   # AI ログは契約削除時に nullify（履歴・コスト分析用に残す）
   has_many :ai_generations, dependent: :nullify
 

--- a/app/services/crest_generator.rb
+++ b/app/services/crest_generator.rb
@@ -1,0 +1,86 @@
+class CrestGenerator
+  # 達成した契約に対して紋章を生成するサービス。
+  # PactCompleter から呼ばれる前提だが、independently に呼んでも安全（冪等）。
+  #
+  # レアリティ計算（PactCompleter と整合）:
+  #   total_score = difficulty × compliance_rate × period_score
+  #     - difficulty: 1..5
+  #     - compliance_rate: kept_days / 期間日数（PactCompleter と同分母）
+  #     - period_score: 期間日数 / 30.0、ただし 0.5..6.0 にクランプ
+  #       （短すぎる契約と長すぎる契約で score が爆発しないように）
+  #
+  # スコア → rarity:
+  #   0..1.0    → common
+  #   1.0..2.5  → rare
+  #   2.5..4.0  → epic
+  #   それ以上  → legendary
+  PERIOD_SCORE_RANGE = 0.5..6.0
+
+  BASE_SHAPES     = %w[shield_round shield_pointed shield_square heater kite].freeze
+  CENTRAL_MOTIFS  = %w[sword moon flame eye book wolf eagle dragon star phoenix].freeze
+  DECORATIONS     = %w[wings chains plants stars thunderbolt].freeze
+  COLOR_PALETTES  = %w[crimson_gold midnight_silver emerald_bronze indigo_pearl
+                      ruby_obsidian sapphire_ivory amber_jet violet_steel
+                      onyx_rose verdant_copper].freeze
+  SHIMMER_BY_RARITY = { "common" => 1, "rare" => 2, "epic" => 3, "legendary" => 4 }.freeze
+
+  def initialize(pact)
+    @pact = pact
+  end
+
+  def call
+    return nil unless @pact.completed?
+    return @pact.crest if @pact.crest.present?  # 冪等性
+
+    rarity = calculate_rarity
+    crest_data = build_crest_data(rarity)
+
+    Crest.create!(
+      pact: @pact,
+      rarity: rarity,
+      crest_data: crest_data,
+      generated_at: Time.current
+    )
+  end
+
+  private
+
+  def calculate_rarity
+    score = @pact.difficulty * compliance_rate * period_score
+    case score
+    when 0..1.0   then :common
+    when 1.0..2.5 then :rare
+    when 2.5..4.0 then :epic
+    else               :legendary
+    end
+  end
+
+  # PactCompleter と同じ分母（期間日数）。チート防止 + 仕様統一。
+  def compliance_rate
+    expected_days = (@pact.deadline - @pact.signed_at.to_date).to_i + 1
+    return 0.0 unless expected_days.positive?
+
+    kept_days = @pact.check_ins.kept
+                     .where(checked_on: @pact.signed_at.to_date..@pact.deadline)
+                     .distinct
+                     .count(:checked_on)
+
+    [ kept_days.to_f / expected_days, 1.0 ].min
+  end
+
+  def period_score
+    days = (@pact.deadline - @pact.signed_at.to_date).to_i + 1
+    raw = days / 30.0
+    raw.clamp(*PERIOD_SCORE_RANGE.minmax)
+  end
+
+  def build_crest_data(rarity)
+    {
+      "base_shape"     => BASE_SHAPES.sample,
+      "central_motif"  => CENTRAL_MOTIFS.sample,
+      "decoration"     => DECORATIONS.sample,
+      "color_palette"  => COLOR_PALETTES.sample,
+      "shimmer_level"  => SHIMMER_BY_RARITY.fetch(rarity.to_s, 1)
+    }
+  end
+end

--- a/app/services/pact_completer.rb
+++ b/app/services/pact_completer.rb
@@ -38,8 +38,10 @@ class PactCompleter
     kept_days.positive? && kept_days.to_f / expected_days >= COMPLIANCE_THRESHOLD
   end
 
-  # Crest 生成は v1.1 #13 で実装。ここは hook ポイントだけ用意する。
+  # 達成した契約に紋章を付与する。
+  # MVP は同期生成（CrestGenerator は完全に Ruby 内処理で外部依存なし）。
+  # 将来 OpenAI で画像生成等を組み込む場合は Solid Queue にジョブ化する想定。
   def enqueue_crest_generation_later
-    # noop（v1.1 #13 で実装）
+    CrestGenerator.new(@pact).call
   end
 end

--- a/db/migrate/20260506045953_create_crests.rb
+++ b/db/migrate/20260506045953_create_crests.rb
@@ -1,0 +1,16 @@
+class CreateCrests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :crests do |t|
+      # references は自動で index を貼るので、unique 指定だけ追加して 1 契約 1 紋章を強制
+      t.references :pact, null: false, foreign_key: true, index: { unique: true }
+      t.jsonb :crest_data, null: false, default: {}
+      t.integer :rarity, null: false
+      t.datetime :generated_at, null: false
+
+      t.timestamps
+    end
+
+    # レアリティ別表示・集計用
+    add_index :crests, :rarity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_040745) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_045953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,6 +43,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_040745) do
     t.index ["checked_on"], name: "index_check_ins_on_checked_on"
     t.index ["pact_id", "checked_on"], name: "index_check_ins_on_pact_id_and_checked_on", unique: true
     t.index ["pact_id"], name: "index_check_ins_on_pact_id"
+  end
+
+  create_table "crests", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "crest_data", default: {}, null: false
+    t.datetime "generated_at", null: false
+    t.bigint "pact_id", null: false
+    t.integer "rarity", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pact_id"], name: "index_crests_on_pact_id", unique: true
+    t.index ["rarity"], name: "index_crests_on_rarity"
   end
 
   create_table "pacts", force: :cascade do |t|
@@ -89,6 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_040745) do
   add_foreign_key "ai_generations", "pacts"
   add_foreign_key "ai_generations", "users"
   add_foreign_key "check_ins", "pacts"
+  add_foreign_key "crests", "pacts"
   add_foreign_key "pacts", "users"
   add_foreign_key "sessions", "users"
 end

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -413,12 +413,20 @@ enum :rarity, {
 
 #### レアリティ計算ロジック
 
+PactCompleter と分母を統一して、`compliance_rate = kept_days / 期間日数`。
+1 日だけ kept すれば 100% 扱いになるチート（旧仕様の check_in 件数分母）を防ぐ。
+
 ```ruby
 def calculate_rarity(pact)
-  difficulty = pact.difficulty                              # 1-5
-  compliance_rate = pact.check_ins.kept.count.to_f /
-                    [pact.check_ins.count, 1].max           # 0.0-1.0
-  period_score = (pact.deadline - pact.signed_at.to_date) / 30.0  # 月数
+  difficulty = pact.difficulty                                          # 1-5
+  expected_days = (pact.deadline - pact.signed_at.to_date).to_i + 1
+  kept_days = pact.check_ins.kept
+                  .where(checked_on: pact.signed_at.to_date..pact.deadline)
+                  .distinct
+                  .count(:checked_on)
+  compliance_rate = expected_days.positive? ? [ kept_days.to_f / expected_days, 1.0 ].min : 0.0
+  # 短すぎる契約・長すぎる契約で score が爆発しないようクランプ
+  period_score = (expected_days / 30.0).clamp(0.5, 6.0)
 
   total_score = difficulty * compliance_rate * period_score
 
@@ -435,6 +443,7 @@ end
 
 - **計算データは保存しない**: difficulty, compliance_rate, period_days などは Pact / CheckIn から計算可能なので保存不要（YAGNI 原則）
 - **rarity は永久に保護**: レアリティ計算ロジックが変わっても、過去に確定した rarity は変わらない
+- **compliance_rate の分母は期間日数**: PactCompleter と統一。check_in 件数分母にすると「1 回 kept で 100%」のチートが可能になるため
 
 #### マイグレーション例
 

--- a/spec/factories/crests.rb
+++ b/spec/factories/crests.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :crest do
+    association :pact
+    rarity { :common }
+    generated_at { Time.current }
+    crest_data do
+      {
+        "base_shape" => "shield_round",
+        "central_motif" => "sword",
+        "decoration" => "wings",
+        "color_palette" => "crimson_gold",
+        "shimmer_level" => 1
+      }
+    end
+  end
+end

--- a/spec/models/crest_spec.rb
+++ b/spec/models/crest_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe Crest, type: :model do
+  let(:user) { create(:user) }
+
+  # completed pact をテスト用に作るヘルパー（deadline_must_be_in_the_future を回避）
+  def build_completed_pact(signed_at: 10.days.ago, deadline: 1.day.ago.to_date)
+    pact = build(:pact, user: user, signed_at: signed_at, deadline: deadline,
+                         status: :completed, completed_at: 1.hour.ago)
+    pact.save!(validate: false)
+    pact
+  end
+
+  describe "associations" do
+    it "belongs_to :pact" do
+      assoc = described_class.reflect_on_association(:pact)
+      expect(assoc.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe "enum rarity" do
+    it "common / rare / epic / legendary を持つ" do
+      expect(described_class.rarities).to eq(
+        "common" => 0,
+        "rare" => 1,
+        "epic" => 2,
+        "legendary" => 3
+      )
+    end
+  end
+
+  describe "validations" do
+    let(:pact) { build_completed_pact }
+
+    it "正しい属性なら valid" do
+      crest = build(:crest, pact: pact)
+      expect(crest).to be_valid
+    end
+
+    it "rarity は必須" do
+      crest = build(:crest, pact: pact, rarity: nil)
+      expect(crest).not_to be_valid
+    end
+
+    it "generated_at は必須" do
+      crest = build(:crest, pact: pact, generated_at: nil)
+      expect(crest).not_to be_valid
+      expect(crest.errors[:generated_at]).to be_present
+    end
+
+    it "crest_data に必須キーが揃っていれば valid" do
+      crest = build(:crest, pact: pact, crest_data: {
+        "base_shape" => "shield_round",
+        "central_motif" => "sword",
+        "decoration" => "wings",
+        "color_palette" => "crimson_gold",
+        "shimmer_level" => 2
+      })
+      expect(crest).to be_valid
+    end
+
+    it "crest_data に必須キーが欠けていると invalid" do
+      crest = build(:crest, pact: pact, crest_data: { "base_shape" => "shield_round" })
+      expect(crest).not_to be_valid
+      expect(crest.errors[:crest_data]).to be_present
+    end
+
+    it "対応する Pact が completed でないと invalid" do
+      active_pact = create(:pact, user: user, status: :active)
+      crest = build(:crest, pact: active_pact)
+      expect(crest).not_to be_valid
+      expect(crest.errors[:pact]).to be_present
+    end
+
+    it "1 契約 1 紋章（同 pact_id で 2 件目はDB UNIQUE で弾かれる）" do
+      pact = build_completed_pact
+      create(:crest, pact: pact)
+      duplicate = build(:crest, pact: pact)
+      expect(duplicate).not_to be_valid
+    end
+  end
+
+  describe "Pact からのアソシエーション（has_one）" do
+    it "Pact#crest で取得できる" do
+      pact = build_completed_pact
+      crest = create(:crest, pact: pact)
+      expect(pact.reload.crest).to eq(crest)
+    end
+
+    it "Pact が destroy されたら関連 crest も destroy される" do
+      pact = build_completed_pact
+      create(:crest, pact: pact)
+      expect { pact.destroy! }.to change(described_class, :count).by(-1)
+    end
+  end
+end

--- a/spec/services/crest_generator_spec.rb
+++ b/spec/services/crest_generator_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe CrestGenerator, type: :service do
+  let(:user) { create(:user) }
+
+  def build_completed_pact(signed_at:, deadline:, difficulty: 3)
+    pact = build(:pact, user: user, signed_at: signed_at, deadline: deadline,
+                         difficulty: difficulty, status: :completed, completed_at: 1.hour.ago)
+    pact.save!(validate: false)
+    pact
+  end
+
+  def add_kept(pact:, on:)
+    pact.check_ins.new(checked_on: on, status: :kept).save!(validate: false)
+  end
+
+  describe "#call" do
+    context "completed でない pact" do
+      it "Crest を作らない（戻り値 nil）" do
+        active_pact = create(:pact, user: user)
+        result = described_class.new(active_pact).call
+        expect(result).to be_nil
+        expect(active_pact.reload.crest).to be_nil
+      end
+    end
+
+    context "既に Crest が存在する pact" do
+      it "再度 call しても新規作成しない（既存を返す）" do
+        pact = build_completed_pact(signed_at: 30.days.ago, deadline: 1.day.ago.to_date)
+        existing = create(:crest, pact: pact, rarity: :rare)
+
+        result = described_class.new(pact).call
+        expect(result).to eq(existing)
+        expect(Crest.where(pact_id: pact.id).count).to eq(1)
+      end
+    end
+
+    context "completed pact に Crest を新規生成" do
+      it "Crest が作成され、必須キーを含む crest_data が入る" do
+        pact = build_completed_pact(signed_at: 30.days.ago, deadline: 1.day.ago.to_date, difficulty: 3)
+        20.times { |i| add_kept(pact: pact, on: 30.days.ago.to_date + i) }
+
+        crest = described_class.new(pact).call
+        expect(crest).to be_persisted
+        expect(crest.pact).to eq(pact)
+        expect(crest.generated_at).to be_within(5.seconds).of(Time.current)
+        %w[base_shape central_motif decoration color_palette shimmer_level].each do |key|
+          expect(crest.crest_data).to have_key(key)
+        end
+      end
+    end
+
+    describe "レアリティ計算（difficulty × compliance_rate × period_score）" do
+      # period_score = (期間日数 / 30.0).clamp(0.5, 6.0)
+      # compliance_rate = kept_days / 期間日数
+
+      it "簡単（difficulty=1）+ 短期間 + 低 compliance なら common" do
+        # 5 日契約、1 日 kept = 20% / difficulty=1 / period_score=0.5
+        # score = 1 * 0.2 * 0.5 = 0.1 → common
+        pact = build_completed_pact(signed_at: 4.days.ago, deadline: Time.zone.today, difficulty: 1)
+        add_kept(pact: pact, on: 1.day.ago.to_date)
+
+        crest = described_class.new(pact).call
+        expect(crest.rarity).to eq("common")
+      end
+
+      it "中程度（difficulty=3）+ 30 日 + 60% compliance なら rare" do
+        # 30 日中 18 日 kept = 60% / difficulty=3 / period_score=1.0
+        # score = 3 * 0.6 * 1.0 = 1.8 → rare（1.0..2.5）
+        pact = build_completed_pact(signed_at: 29.days.ago, deadline: Time.zone.today, difficulty: 3)
+        18.times { |i| add_kept(pact: pact, on: 29.days.ago.to_date + i) }
+
+        crest = described_class.new(pact).call
+        expect(crest.rarity).to eq("rare")
+      end
+
+      it "高難度（difficulty=5）+ 60 日 + 80% compliance なら epic" do
+        # 60 日中 48 日 kept = 80% / difficulty=5 / period_score=2.0
+        # score = 5 * 0.8 * 2.0 = 8.0 → legendary（4.0 超）
+        # → 異なる組み合わせで epic を狙う
+        # difficulty=4, 30 日中 25 kept (83%), period_score=1.0
+        # score = 4 * 0.83 * 1.0 ≈ 3.33 → epic
+        pact = build_completed_pact(signed_at: 29.days.ago, deadline: Time.zone.today, difficulty: 4)
+        25.times { |i| add_kept(pact: pact, on: 29.days.ago.to_date + i) }
+
+        crest = described_class.new(pact).call
+        expect(crest.rarity).to eq("epic")
+      end
+
+      it "最高（difficulty=5）+ 長期間 + 高 compliance なら legendary" do
+        # 90 日中 80 日 kept ≈ 89% / difficulty=5 / period_score=3.0
+        # score = 5 * 0.89 * 3.0 ≈ 13.3 → legendary
+        pact = build_completed_pact(signed_at: 89.days.ago, deadline: Time.zone.today, difficulty: 5)
+        80.times { |i| add_kept(pact: pact, on: 89.days.ago.to_date + i) }
+
+        crest = described_class.new(pact).call
+        expect(crest.rarity).to eq("legendary")
+      end
+
+      it "極端に長期間でも period_score は 6.0 でクランプされる" do
+        # 1000 日契約でも period_score は 6.0 が上限
+        # difficulty=1, compliance=10%（少なめ）, period_score=6.0
+        # score = 1 * 0.1 * 6.0 = 0.6 → common
+        # クランプが効いていることを確認するため、極端な期間でも legendary にならないことを保証
+        pact = build_completed_pact(signed_at: 1000.days.ago, deadline: 1.day.ago.to_date, difficulty: 1)
+        100.times { |i| add_kept(pact: pact, on: 1000.days.ago.to_date + i) }
+        # compliance_rate = 100/1001 ≈ 0.1
+        # score = 1 * 0.1 * 6.0 = 0.6 → common（クランプなしだと period_score≈33 → 異常値）
+
+        crest = described_class.new(pact).call
+        expect(crest.rarity).to eq("common")
+      end
+    end
+
+    describe "crest_data のパーツ抽選" do
+      it "shimmer_level は rarity に応じて決まる（legendary が最も高い）" do
+        legendary_pact = build_completed_pact(signed_at: 89.days.ago, deadline: Time.zone.today, difficulty: 5)
+        80.times { |i| add_kept(pact: legendary_pact, on: 89.days.ago.to_date + i) }
+
+        common_pact = build_completed_pact(signed_at: 4.days.ago, deadline: Time.zone.today, difficulty: 1)
+        add_kept(pact: common_pact, on: 1.day.ago.to_date)
+
+        legendary_crest = described_class.new(legendary_pact).call
+        common_crest = described_class.new(common_pact).call
+
+        expect(legendary_crest.crest_data["shimmer_level"]).to be > common_crest.crest_data["shimmer_level"]
+      end
+    end
+  end
+end

--- a/spec/services/pact_completer_spec.rb
+++ b/spec/services/pact_completer_spec.rb
@@ -104,5 +104,17 @@ RSpec.describe PactCompleter, type: :service do
       expect(service).to receive(:enqueue_crest_generation_later)
       service.call
     end
+
+    it "completable な場合に CrestGenerator が呼ばれて Crest が DB に生成される" do
+      pact = build_pact(signed_at: 1.day.ago.beginning_of_day, deadline: Time.zone.today)
+      add_kept(pact: pact, on: Time.zone.today)
+
+      expect {
+        described_class.new(pact).call
+      }.to change(Crest, :count).by(1)
+
+      expect(pact.reload.crest).to be_present
+      expect(pact.crest.pact_id).to eq(pact.id)
+    end
   end
 end


### PR DESCRIPTION
## 概要

Issue #13: 達成時の紋章付与を実装。**v1.1 体験ループ「チェックイン → streak → 達成 → 🏆 紋章付与」が完成**。
PR #50 で空メソッドにしておいた \`PactCompleter#enqueue_crest_generation_later\` の中身を実装。

## 主な実装

### 1. crests テーブル

| カラム       | 型      | 制約                       |
| ------------ | ------- | -------------------------- |
| pact_id      | bigint  | NOT NULL FK + **UNIQUE**   |
| crest_data   | jsonb   | NOT NULL（パーツ情報）    |
| rarity       | int     | NOT NULL（enum 4 種）    |
| generated_at | datetime | NOT NULL                  |

- UNIQUE INDEX で「1 契約 1 紋章」を DB 強制
- rarity 別検索用 B-tree INDEX

### 2. Crest モデル

- \`belongs_to :pact\`
- \`enum :rarity\`: common / rare / epic / legendary
- バリデーション：
  - pact_id ユニーク（DB と Rails で二重防御）
  - rarity / generated_at 必須
  - crest_data の必須 5 キー検証（base_shape / central_motif / decoration / color_palette / shimmer_level）
  - **pact が completed でなければ invalid**（紋章は達成時のみ）

### 3. Pact 側のアソシエーション

- \`has_one :crest, dependent: :destroy\`

### 4. CrestGenerator サービス

#### レアリティ計算（PactCompleter と分母統一）

\`\`\`
total_score = difficulty × compliance_rate × period_score
\`\`\`

- **compliance_rate = kept_days / 期間日数**（PactCompleter と同分母）
  → 「1 回 kept で 100%」のチートを防ぐ
- **period_score = (期間日数 / 30.0).clamp(0.5, 6.0)**
  → 短期（1 日契約）と長期（1000 日契約）で score が爆発しないようクランプ
- スコアレンジ：
  | range      | rarity     |
  | ---------- | ---------- |
  | 0..1.0     | common     |
  | 1.0..2.5   | rare       |
  | 2.5..4.0   | epic       |
  | 4.0 超     | legendary  |

#### パーツ抽選（crest_data）

| キー           | 候補数 |
| -------------- | ------ |
| base_shape     | 5      |
| central_motif  | 10     |
| decoration     | 5      |
| color_palette  | 10     |
| shimmer_level  | 1〜4（rarity 連動） |

#### 冪等性

- 既存 \`pact.crest\` があれば既存を返す（再 call で重複作成しない）
- \`pact.completed?\` でない場合は nil

### 5. PactCompleter#enqueue_crest_generation_later

\`\`\`ruby
def enqueue_crest_generation_later
  CrestGenerator.new(@pact).call
end
\`\`\`

→ チェックイン後に達成判定 → completed 化 → **その場で紋章生成**まで自動。

### 6. ドキュメント整合

\`docs/data_model.md\` の旧仕様（compliance_rate を check_in 件数で割る）を新仕様（期間日数分母 + クランプ）に更新し、チート防止の意図をコメント。

## 設計判断

| 観点                              | 判断                                                                |
| --------------------------------- | ------------------------------------------------------------------- |
| compliance_rate の分母            | **期間日数**（PactCompleter と統一、check_in 件数だとチート可能）  |
| period_score の最大値             | **6.0 でクランプ**（1000 日契約でも score が爆発しない）            |
| 同期 vs 非同期生成                | **同期**（CrestGenerator は外部依存なしの Ruby 内処理）             |
| 1 契約 1 紋章                     | DB UNIQUE + Rails uniqueness の二重防御                             |
| completed pact のみ Crest 作成可  | カスタムバリデーションで強制                                        |
| pact.destroy で crest も destroy  | dependent: :destroy（紋章は契約に紐付き必須）                       |

## テスト（21 件追加）

| spec                                    | 件数 | 内容                                              |
| --------------------------------------- | ---- | ------------------------------------------------- |
| spec/models/crest_spec.rb               | 11   | アソシエーション / enum / バリデーション 7 / has_one / destroy |
| spec/services/crest_generator_spec.rb   | 9    | not completed / 冪等 / 新規生成 / 各レアリティ境界 4 / クランプ / shimmer |
| spec/services/pact_completer_spec.rb    | +1   | Crest が実際に DB に生成されることを検証          |

## 動作確認

- [x] \`bundle exec rspec\` パス（**215/215**）
- [x] \`bundle exec rubocop\` クリーン

## 残作業（後続 Issue）

- **#43 AI v1.1**: ai_generations への書き込み + レート制限
- **FE 側**: 紋章ギャラリー画面（後続 Issue で実装）

closes #13