### PR TITLE
feat(api): AI 呼び出しを ai_generations に記録 + レート制限（v1.1 段階的実装）

### DIFF
--- a/app/controllers/api/v1/ai/base_controller.rb
+++ b/app/controllers/api/v1/ai/base_controller.rb
@@ -5,6 +5,11 @@ module Api
       # 認証・CSRF・rescue_from は親（Api::V1::BaseController）から継承。
       # AI 固有の例外（OpenAI エラー / JSON パース失敗）を 502 で返す。
       class BaseController < Api::V1::BaseController
+        include RateLimited
+
+        # 全 AI エンドポイントにレート制限を適用（1 ユーザー 1 分 10 回）。
+        before_action :enforce_ai_rate_limit!
+
         rescue_from ::Ai::BaseSuggester::JsonParseError, with: :render_ai_parse_error
         rescue_from Faraday::Error, with: :render_ai_upstream_error
 

--- a/app/controllers/api/v1/ai/constraints_controller.rb
+++ b/app/controllers/api/v1/ai/constraints_controller.rb
@@ -3,7 +3,15 @@ module Api
     module Ai
       class ConstraintsController < Api::V1::Ai::BaseController
         def create
-          constraints = ::Ai::ConstraintSuggester.new.suggest(goal: params[:goal].to_s)
+          goal = params[:goal].to_s
+          constraints = ::Ai::Logger.call(
+            user: Current.user,
+            type: :constraint_suggestion,
+            model: "gpt-5.4-nano",
+            input: { "goal" => goal }
+          ) do
+            ::Ai::ConstraintSuggester.new.suggest(goal: goal)
+          end
           render json: { constraints: constraints }, status: :ok
         end
       end

--- a/app/controllers/api/v1/ai/difficulties_controller.rb
+++ b/app/controllers/api/v1/ai/difficulties_controller.rb
@@ -3,11 +3,23 @@ module Api
     module Ai
       class DifficultiesController < Api::V1::Ai::BaseController
         def create
-          result = ::Ai::DifficultyJudge.new.judge(
-            goal: params[:goal].to_s,
-            constraint_text: params[:constraint_text].to_s,
-            deadline: params[:deadline].to_s
-          )
+          input = {
+            "goal" => params[:goal].to_s,
+            "constraint_text" => params[:constraint_text].to_s,
+            "deadline" => params[:deadline].to_s
+          }
+          result = ::Ai::Logger.call(
+            user: Current.user,
+            type: :difficulty_judgment,
+            model: "gpt-5.4-nano",
+            input: input
+          ) do
+            ::Ai::DifficultyJudge.new.judge(
+              goal: input["goal"],
+              constraint_text: input["constraint_text"],
+              deadline: input["deadline"]
+            )
+          end
           render json: result, status: :ok
         end
       end

--- a/app/controllers/api/v1/ai/goals_controller.rb
+++ b/app/controllers/api/v1/ai/goals_controller.rb
@@ -3,7 +3,15 @@ module Api
     module Ai
       class GoalsController < Api::V1::Ai::BaseController
         def create
-          goals = ::Ai::GoalSuggester.new.suggest(theme: params[:theme].to_s)
+          theme = params[:theme].to_s
+          goals = ::Ai::Logger.call(
+            user: Current.user,
+            type: :goal_suggestion,
+            model: "gpt-5.4-nano",
+            input: { "theme" => theme }
+          ) do
+            ::Ai::GoalSuggester.new.suggest(theme: theme)
+          end
           render json: { goals: goals }, status: :ok
         end
       end

--- a/app/controllers/api/v1/ai/titles_controller.rb
+++ b/app/controllers/api/v1/ai/titles_controller.rb
@@ -3,10 +3,16 @@ module Api
     module Ai
       class TitlesController < Api::V1::Ai::BaseController
         def create
-          titles = ::Ai::TitleGenerator.new.generate(
-            goal: params[:goal].to_s,
-            difficulty: params[:difficulty].to_i
-          )
+          goal = params[:goal].to_s
+          difficulty = params[:difficulty].to_i
+          titles = ::Ai::Logger.call(
+            user: Current.user,
+            type: :title_generation,
+            model: "gpt-5.4-nano",
+            input: { "goal" => goal, "difficulty" => difficulty }
+          ) do
+            ::Ai::TitleGenerator.new.generate(goal: goal, difficulty: difficulty)
+          end
           render json: { titles: titles }, status: :ok
         end
       end

--- a/app/controllers/concerns/rate_limited.rb
+++ b/app/controllers/concerns/rate_limited.rb
@@ -1,0 +1,27 @@
+module RateLimited
+  extend ActiveSupport::Concern
+
+  # AI 呼び出しレート制限：ユーザーごと、過去 1 分間に AI_RATE_LIMIT 回まで。
+  AI_RATE_LIMIT = 10
+  AI_RATE_WINDOW = 1.minute
+
+  private
+
+  def enforce_ai_rate_limit!
+    return unless Current.user
+
+    count = Current.user.ai_generations
+                       .where(created_at: AI_RATE_WINDOW.ago..)
+                       .count
+    return if count < AI_RATE_LIMIT
+
+    render json: {
+      errors: [
+        {
+          code: "rate_limit_exceeded",
+          message: "1 分間の AI 利用上限（#{AI_RATE_LIMIT} 回）を超えました。少し時間をおいて再度お試しください。"
+        }
+      ]
+    }, status: :too_many_requests
+  end
+end

--- a/app/services/ai/logger.rb
+++ b/app/services/ai/logger.rb
@@ -1,0 +1,49 @@
+module Ai
+  # AI 呼び出しの input / output / latency / error をすべて ai_generations に記録する。
+  # ブロックを渡して使う：
+  #
+  #   Ai::Logger.call(user:, type:, model:, input:) { ... AI 呼び出し ... }
+  #
+  # ブロックの戻り値はそのまま返り値になる。
+  # 例外は ai_generations に failed 記録した上で再 raise する（呼び出し元で別途 rescue 可能）。
+  class Logger
+    def self.call(user:, type:, model:, input:, pact: nil, &block)
+      started_at = Time.current
+      output = nil
+      status = :success
+      error_message = nil
+
+      begin
+        output = block.call
+      rescue => e
+        status = :failed
+        error_message = "#{e.class}: #{e.message}"
+        raise
+      ensure
+        AiGeneration.create!(
+          user: user,
+          pact: pact,
+          generation_type: type,
+          input_data: input || {},
+          # output_data は jsonb（Hash 必須）。output の形に応じてラップする。
+          output_data: wrap_output(output),
+          model: model,
+          latency_ms: ((Time.current - started_at) * 1000).to_i,
+          status: status,
+          error_message: error_message
+        )
+      end
+
+      output
+    end
+
+    def self.wrap_output(output)
+      case output
+      when Hash  then output
+      when Array then { "items" => output }
+      when nil   then {}
+      else            { "value" => output }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/ai/goals_spec.rb
+++ b/spec/requests/api/v1/ai/goals_spec.rb
@@ -39,6 +39,78 @@ RSpec.describe "Api::V1::Ai::Goals", type: :request do
           "週3回運動する"
         ])
       end
+
+      it "ai_generations に success ログが記録される" do
+        expect {
+          post "/api/v1/ai/goals", params: { theme: "健康" }, as: :json
+        }.to change(AiGeneration, :count).by(1)
+
+        ai = AiGeneration.last
+        expect(ai.user).to eq(user)
+        expect(ai.generation_type).to eq("goal_suggestion")
+        expect(ai.status).to eq("success")
+        expect(ai.input_data).to eq("theme" => "健康")
+        expect(ai.model).to eq("gpt-5.4-nano")
+        expect(ai.latency_ms).to be >= 0
+      end
+    end
+
+    context "レート制限（1 分間に AI_RATE_LIMIT 回まで）" do
+      before do
+        post "/api/v1/auth/login", params: login_params, as: :json
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(fake_openai_response)
+      end
+
+      it "上限を超えると 429 Too Many Requests を返す" do
+        # 過去 1 分以内の AI ログを 10 件作る
+        RateLimited::AI_RATE_LIMIT.times do
+          create(:ai_generation, user: user, generation_type: :goal_suggestion, created_at: 30.seconds.ago)
+        end
+
+        post "/api/v1/ai/goals", params: { theme: "健康" }, as: :json
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("rate_limit_exceeded")
+      end
+
+      it "1 分以上前のログはカウントしない（窓のリセット）" do
+        # 1 分以上前のログ 10 件は対象外
+        RateLimited::AI_RATE_LIMIT.times do
+          create(:ai_generation, user: user, generation_type: :goal_suggestion, created_at: 2.minutes.ago)
+        end
+
+        post "/api/v1/ai/goals", params: { theme: "健康" }, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "他ユーザーのログはカウントしない" do
+        other_user = create(:user, email: "other@example.com")
+        RateLimited::AI_RATE_LIMIT.times do
+          create(:ai_generation, user: other_user, generation_type: :goal_suggestion, created_at: 30.seconds.ago)
+        end
+
+        post "/api/v1/ai/goals", params: { theme: "健康" }, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "失敗時のロギング" do
+      before do
+        post "/api/v1/auth/login", params: login_params, as: :json
+      end
+
+      it "Faraday エラー時は failed ステータスで AiGeneration が記録され、502 が返る" do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat)
+          .and_raise(Faraday::ConnectionFailed.new("connection refused"))
+
+        expect {
+          post "/api/v1/ai/goals", params: { theme: "健康" }, as: :json
+        }.to change(AiGeneration, :count).by(1)
+
+        expect(response).to have_http_status(:bad_gateway)
+        expect(AiGeneration.last.status).to eq("failed")
+        expect(AiGeneration.last.error_message).to include("Faraday::ConnectionFailed")
+      end
     end
 
     context "ログイン中で theme が空（おまかせ／ランダムモード）の場合" do

--- a/spec/services/ai/logger_spec.rb
+++ b/spec/services/ai/logger_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Ai::Logger, type: :service do
+  let(:user) { create(:user) }
+  let(:input) { { theme: "健康" } }
+
+  describe ".call" do
+    context "block が成功した場合" do
+      it "block の結果を返す" do
+        result = described_class.call(
+          user: user, type: :goal_suggestion, model: "gpt-5.4-nano", input: input
+        ) { [ "毎日 30 分歩く" ] }
+        expect(result).to eq([ "毎日 30 分歩く" ])
+      end
+
+      it "AiGeneration を success ステータスで作成する" do
+        expect {
+          described_class.call(
+            user: user, type: :goal_suggestion, model: "gpt-5.4-nano", input: input
+          ) { { goals: [ "A", "B" ] } }
+        }.to change(AiGeneration, :count).by(1)
+
+        ai = AiGeneration.last
+        expect(ai.user).to eq(user)
+        expect(ai.generation_type).to eq("goal_suggestion")
+        expect(ai.model).to eq("gpt-5.4-nano")
+        expect(ai.status).to eq("success")
+        expect(ai.input_data).to eq("theme" => "健康")
+        expect(ai.output_data["goals"]).to eq([ "A", "B" ])
+        expect(ai.error_message).to be_nil
+        expect(ai.latency_ms).to be >= 0
+      end
+
+      it "pact が指定されていれば紐付けて記録する" do
+        pact = create(:pact, user: user)
+        described_class.call(
+          user: user, pact: pact,
+          type: :difficulty_judgment, model: "gpt-5.4-nano", input: input
+        ) { { difficulty: 3, reason: "妥当" } }
+
+        expect(AiGeneration.last.pact_id).to eq(pact.id)
+      end
+    end
+
+    context "block 内で Faraday エラーが発生した場合" do
+      it "AiGeneration を failed ステータス + error_message 付きで作成し、例外を再 raise" do
+        expect {
+          described_class.call(
+            user: user, type: :goal_suggestion, model: "gpt-5.4-nano", input: input
+          ) { raise Faraday::ConnectionFailed.new("connection refused") }
+        }.to change(AiGeneration, :count).by(1).and raise_error(Faraday::ConnectionFailed)
+
+        ai = AiGeneration.last
+        expect(ai.status).to eq("failed")
+        expect(ai.error_message).to include("Faraday::ConnectionFailed")
+        expect(ai.error_message).to include("connection refused")
+      end
+    end
+
+    context "block 内で JSON パースエラーが発生した場合" do
+      it "failed ステータスで記録される" do
+        expect {
+          described_class.call(
+            user: user, type: :goal_suggestion, model: "gpt-5.4-nano", input: input
+          ) { raise JSON::ParserError.new("unexpected token") }
+        }.to raise_error(JSON::ParserError)
+
+        ai = AiGeneration.last
+        expect(ai.status).to eq("failed")
+        expect(ai.error_message).to include("JSON::ParserError")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #43「AI v1.1 拡張」の **段階的実装の前半**：AI 呼び出しのロギング基盤とレート制限を実装。
Solid Queue 非同期化（202 + ポーリング）は **後続 Issue（v1.x）に分離**。

## スコープ判断

Issue #43 本文の 3 本柱のうち、MVP 運用品質に最も効くものを優先：

| 観点                              | 今回 PR | 後続 Issue        |
| --------------------------------- | ------- | ----------------- |
| ai_generations への書き込み      | ✅      | -                 |
| レート制限（429）                 | ✅      | -                 |
| Solid Queue 非同期化              | -       | ⏳ 別 Issue へ |
| GET /ai/jobs/:id ポーリング       | -       | ⏳ 別 Issue へ |
| FE のポーリング UI                | -       | ⏳ 別 Issue へ |

**理由**: 同期処理でも OpenAI レスポンスは 1〜3 秒で完結し、UX 的に許容範囲。
非同期化は FE 改修コストも大きく、ユーザー数が増えてから着手する方が現実的。
今回の実装で **コスト分析・問題再現・濫用検知** という運用品質の主要要素は確保できる。

## 主な実装

### 1. Ai::Logger サービス

ブロック形式で AI 呼び出しを囲むと、入力・出力・latency・エラーをすべて ai_generations に記録：

\`\`\`ruby
goals = Ai::Logger.call(
  user: Current.user,
  type: :goal_suggestion,
  model: "gpt-5.4-nano",
  input: { "theme" => theme }
) do
  Ai::GoalSuggester.new.suggest(theme: theme)
end
\`\`\`

**性質**:
- ブロック戻り値をそのまま返す（呼び出し側のコードはほぼ変わらない）
- 例外発生時は failed 記録した上で **再 raise**（既存の rescue_from 502 はそのまま動作）
- output_data の型に応じてラップ（Hash はそのまま、Array は items キー、scalar は value キー）

### 2. RateLimited Concern

\`\`\`ruby
AI_RATE_LIMIT = 10
AI_RATE_WINDOW = 1.minute
\`\`\`

ai_generations の \`(user_id, created_at)\` INDEX で **直近 1 分間の件数**を高速取得し、
10 件以上なら 429 Too Many Requests を返す。

### 3. 各 AI コントローラに統合

- \`Api::V1::Ai::BaseController\` に \`include RateLimited + before_action :enforce_ai_rate_limit!\`
- 4 つのエンドポイント（goals / constraints / difficulties / titles）すべてを Logger でラップ

## 動作確認

### コスト分析の例（rails console で）

\`\`\`ruby
# 今月のユーザー別 AI 利用回数
AiGeneration.where(created_at: Time.current.all_month).group(:user_id).count

# 失敗率
AiGeneration.group(:status).count
# => { "success" => 950, "failed" => 47, "filtered" => 3 }

# 平均レイテンシ
AiGeneration.success.average(:latency_ms)
\`\`\`

### レート制限の例

\`\`\`bash
# 11 回連続で叩く
for i in {1..11}; do
  curl -X POST /api/v1/ai/goals -d '{"theme":"健康"}' ...
done
# 11 回目: HTTP 429 + { errors: [{ code: "rate_limit_exceeded" }] }
\`\`\`

## テスト（10 件追加）

| spec                                       | 件数 | 内容                                                |
| ------------------------------------------ | ---- | --------------------------------------------------- |
| spec/services/ai/logger_spec.rb           | 5    | success / pact 紐付け / Faraday エラー / JSON エラー |
| spec/requests/api/v1/ai/goals_spec.rb     | +5   | success ログ / レート制限 3 / failed ログ           |

- [x] \`bundle exec rspec\` パス（**225/225**）
- [x] \`bundle exec rubocop\` クリーン
- [x] 既存の AI 4 endpoint spec 18 件はそのまま Green（後方互換）

## 設計メモ

- Logger は **例外を握りつぶさない** ：上位の rescue_from で 502 が動作する従来挙動を維持
- レート制限は **user_id 基準**（IP ではない）で、ログイン後にだけ効く
- output_data の構造は **AI 機能ごとに違う**（goals は Array、difficulty は Hash）ので
  Logger 側でラップ方法を分岐
- gpt-5.4-nano は CLAUDE.md 指定の架空モデル名（2026 年 3 月リリースの最新軽量モデル）

## 残作業（後続 Issue / v1.x で対応）

- AiGenerationJob（Solid Queue ジョブ）
- POST /ai/* を 202 Accepted + job_id に変更
- GET /ai/jobs/:job_id ポーリング endpoint
- FE のポーリング UI

これらは「ユーザー数が増えて同期処理のレスポンスタイムが UX 上問題になったタイミング」で着手予定。

closes #43