### PR TITLE
feat(auth): Guest user モード（お試し + 本登録昇格 + 自動クリーンアップ）

### DIFF
--- a/app/controllers/api/v1/auth/guests_controller.rb
+++ b/app/controllers/api/v1/auth/guests_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    module Auth
+      # 「ログインせずに試す」用のゲストユーザーを作成し、即時ログイン状態にする。
+      # メールアドレス入力・パスワード入力は不要（サーバ側で auto-generated）。
+      # 後で /api/v1/auth/promote から本登録ユーザーへ昇格できる。
+      class GuestsController < Api::V1::BaseController
+        allow_unauthenticated_access only: [ :create ]
+        skip_forgery_protection only: [ :create ]
+
+        def create
+          user = User.create_guest!
+          start_new_session_for(user)
+          render json: UserSerializer.new(user).serializable_hash, status: :created
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/auth/promotions_controller.rb
+++ b/app/controllers/api/v1/auth/promotions_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module V1
+    module Auth
+      # ゲストユーザーを本登録ユーザーへ昇格する。
+      # email / password / password_confirmation を本物に更新し、is_guest=false に切り替える。
+      # 既存の Pact / CheckIn / Crest はそのまま引き継がれる（同じ User なので id 不変）。
+      class PromotionsController < Api::V1::BaseController
+        def update
+          unless Current.user&.is_guest?
+            render json: {
+              errors: [ { code: "not_a_guest", message: "登録済みユーザーは promote できません" } ]
+            }, status: :unprocessable_entity
+            return
+          end
+
+          Current.user.promote_to_registered!(
+            email: promote_params[:email],
+            password: promote_params[:password],
+            password_confirmation: promote_params[:password_confirmation],
+            nickname: promote_params[:nickname]
+          )
+
+          render json: UserSerializer.new(Current.user).serializable_hash, status: :ok
+        end
+
+        private
+
+        def promote_params
+          params.permit(:email, :password, :password_confirmation, :nickname)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/cleanup_expired_guests_job.rb
+++ b/app/jobs/cleanup_expired_guests_job.rb
@@ -1,0 +1,10 @@
+class CleanupExpiredGuestsJob < ApplicationJob
+  queue_as :default
+
+  # 30 日経過しても本登録に昇格していないゲストユーザーを削除する。
+  # User#dependent: :destroy 連鎖で Pact / CheckIn / Crest / Session も削除される
+  # （AiGeneration は dependent: :destroy なのでこれも削除）。
+  def perform
+    User.expired_guests.find_each(&:destroy!)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,42 @@
 class User < ApplicationRecord
+  GUEST_NICKNAME = "ゲスト".freeze
+  GUEST_EMAIL_DOMAIN = "guest.local".freeze
+  GUEST_EXPIRATION = 30.days
+
   has_secure_password
+
+  scope :guest, -> { where(is_guest: true) }
+  scope :registered, -> { where(is_guest: false) }
+  # 期限切れの未昇格ゲスト（クリーンアップ Job 対象）
+  scope :expired_guests, -> { guest.where("created_at < ?", GUEST_EXPIRATION.ago) }
+
+  # ランダムな email + パスワードで guest user を作成する。
+  # 通常の signup と違い、メアド入力不要で「お試しモード」を即開始できる。
+  def self.create_guest!
+    suffix = SecureRandom.hex(8)
+    create!(
+      email: "guest_#{suffix}@#{GUEST_EMAIL_DOMAIN}",
+      nickname: GUEST_NICKNAME,
+      password: SecureRandom.hex(16),
+      is_guest: true,
+      is_public: false   # ゲストはランキング非表示
+    )
+  end
+
+  # ゲストを本登録ユーザーに昇格する。
+  # email / password / nickname を本物に更新し、is_guest を false に切り替える。
+  # 既存の Pact / CheckIn / Crest はそのまま引き継がれる。
+  def promote_to_registered!(email:, password:, password_confirmation:, nickname: nil)
+    raise ArgumentError, "登録済みユーザーは promote できません" unless is_guest?
+
+    update!(
+      email: email,
+      password: password,
+      password_confirmation: password_confirmation,
+      nickname: nickname.presence || self.nickname,
+      is_guest: false
+    )
+  end
 
   # アソシエーション
   has_many :pacts, dependent: :destroy

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,6 +6,7 @@ class UserSerializer
              :nickname,
              :avatar_url,
              :is_public,
+             :is_guest,
              :streak_count,
              :longest_streak,
              :created_at,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
         patch  "me",       to: "users#update"
         patch  "email",    to: "users#update_email"
         patch  "password", to: "passwords#update"
+        # ゲストモード（お試し用）
+        post   "guest",    to: "guests#create"
+        # ゲスト → 本登録ユーザーへの昇格（既存データを引き継ぐ）
+        patch  "promote",  to: "promotions#update"
       end
 
       resources :pacts, only: [ :index, :create, :show, :update, :destroy ] do

--- a/db/migrate/20260506055554_add_is_guest_to_users.rb
+++ b/db/migrate/20260506055554_add_is_guest_to_users.rb
@@ -1,0 +1,9 @@
+class AddIsGuestToUsers < ActiveRecord::Migration[8.1]
+  def change
+    # is_guest = true なら「お試しモード」のユーザー。
+    # 本登録（promote）すると false に切り替わり、メアド・パスワードが本物に置き換わる。
+    add_column :users, :is_guest, :boolean, null: false, default: false
+    # 30 日経過した未昇格ゲストをクリーンアップする Job 用 INDEX
+    add_index :users, [ :is_guest, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_045953) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_055554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_045953) do
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.string "email", null: false
+    t.boolean "is_guest", default: false, null: false
     t.boolean "is_public", default: true, null: false
     t.integer "longest_streak", default: 0, null: false
     t.string "nickname", null: false
@@ -95,6 +96,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_045953) do
     t.integer "streak_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
+    t.index ["is_guest", "created_at"], name: "index_users_on_is_guest_and_created_at"
   end
 
   add_foreign_key "ai_generations", "pacts"

--- a/spec/jobs/cleanup_expired_guests_job_spec.rb
+++ b/spec/jobs/cleanup_expired_guests_job_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe CleanupExpiredGuestsJob, type: :job do
+  describe "#perform" do
+    it "30 日以上前に作成された未昇格ゲストを削除する" do
+      old_guest = User.create_guest!
+      old_guest.update_columns(created_at: 31.days.ago)
+
+      expect {
+        described_class.perform_now
+      }.to change(User, :count).by(-1)
+
+      expect(User.where(id: old_guest.id)).to be_empty
+    end
+
+    it "29 日前のゲストは残す（GUEST_EXPIRATION 以内）" do
+      recent_guest = User.create_guest!
+      recent_guest.update_columns(created_at: 29.days.ago)
+
+      expect {
+        described_class.perform_now
+      }.not_to change(User, :count)
+    end
+
+    it "本登録ユーザーは古くても削除しない" do
+      old_user = create(:user, is_guest: false)
+      old_user.update_columns(created_at: 100.days.ago)
+
+      expect {
+        described_class.perform_now
+      }.not_to change(User, :count)
+    end
+
+    it "削除されたゲストの Pact / CheckIn も連鎖削除される" do
+      guest = User.create_guest!
+      guest.update_columns(created_at: 31.days.ago)
+      pact = create(:pact, user: guest, signed_at: 30.days.ago)
+      pact.check_ins.new(checked_on: 25.days.ago.to_date, status: :kept).save!(validate: false)
+
+      expect {
+        described_class.perform_now
+      }.to change(User, :count).by(-1)
+        .and change(Pact, :count).by(-1)
+        .and change(CheckIn, :count).by(-1)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -126,4 +126,87 @@ RSpec.describe User, type: :model do
       expect(user.password_digest).not_to eq("mypassword")
     end
   end
+
+  describe "Guest user" do
+    describe ".create_guest!" do
+      it "is_guest=true / nickname=ゲスト / email=guest_xxx@guest.local の User を作成" do
+        guest = described_class.create_guest!
+        expect(guest).to be_persisted
+        expect(guest.is_guest).to be true
+        expect(guest.nickname).to eq(User::GUEST_NICKNAME)
+        expect(guest.email).to match(/\Aguest_[0-9a-f]{16}@guest\.local\z/)
+        expect(guest.is_public).to be false
+      end
+
+      it "create_guest! は何度呼んでも email が衝突しない" do
+        guests = 5.times.map { described_class.create_guest! }
+        expect(guests.map(&:email).uniq.size).to eq(5)
+      end
+    end
+
+    describe "#promote_to_registered!" do
+      let(:guest) { described_class.create_guest! }
+
+      it "email / password / nickname を更新し is_guest=false に切り替える" do
+        guest.promote_to_registered!(
+          email: "real@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          nickname: "勇者"
+        )
+        guest.reload
+        expect(guest.email).to eq("real@example.com")
+        expect(guest.is_guest).to be false
+        expect(guest.nickname).to eq("勇者")
+        expect(guest.authenticate("password123")).to eq(guest)
+      end
+
+      it "nickname 未指定なら既存の nickname を保持" do
+        guest.promote_to_registered!(
+          email: "real2@example.com", password: "password123", password_confirmation: "password123"
+        )
+        expect(guest.reload.nickname).to eq(User::GUEST_NICKNAME)
+      end
+
+      it "既に登録済みのユーザーを promote しようとすると ArgumentError" do
+        registered = create(:user, is_guest: false)
+        expect {
+          registered.promote_to_registered!(
+            email: "x@example.com", password: "password123", password_confirmation: "password123"
+          )
+        }.to raise_error(ArgumentError)
+      end
+
+      it "promote 後も既存の Pact が引き継がれる（同じ User なので id 不変）" do
+        pact = create(:pact, user: guest, signed_at: 1.day.ago)
+        guest.promote_to_registered!(
+          email: "real3@example.com", password: "password123", password_confirmation: "password123"
+        )
+        expect(guest.reload.pacts).to include(pact)
+      end
+    end
+
+    describe "scopes" do
+      let!(:guest1) { described_class.create_guest! }
+      let!(:guest2) { described_class.create_guest! }
+      let!(:registered) { create(:user, is_guest: false) }
+
+      it "guest scope で is_guest=true のみ取得" do
+        expect(described_class.guest).to match_array([ guest1, guest2 ])
+      end
+
+      it "registered scope で is_guest=false のみ取得" do
+        expect(described_class.registered).to include(registered)
+        expect(described_class.registered).not_to include(guest1, guest2)
+      end
+
+      it "expired_guests は GUEST_EXPIRATION より古いゲストのみ" do
+        old_guest = described_class.create_guest!
+        old_guest.update_columns(created_at: 31.days.ago)
+
+        expect(described_class.expired_guests).to include(old_guest)
+        expect(described_class.expired_guests).not_to include(guest1, registered)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/auth/guests_spec.rb
+++ b/spec/requests/api/v1/auth/guests_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Guests", type: :request do
+  describe "POST /api/v1/auth/guest" do
+    it "201 Created を返し、is_guest=true のユーザーを作成 + ログイン状態にする" do
+      expect {
+        post "/api/v1/auth/guest", as: :json
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body["nickname"]).to eq(User::GUEST_NICKNAME)
+      expect(body["is_guest"]).to be true
+
+      # 即時ログイン状態：/me が 200 を返す
+      get "/api/v1/auth/me"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "未認証でも 401 にならない（ゲスト作成は誰でも可能）" do
+      post "/api/v1/auth/guest", as: :json
+      expect(response).not_to have_http_status(:unauthorized)
+    end
+
+    it "ゲストユーザーで Pact を作成できる" do
+      post "/api/v1/auth/guest", as: :json
+      expect(response).to have_http_status(:created)
+
+      post "/api/v1/pacts", params: {
+        goal: "毎日 30 分歩く",
+        constraint_text: "夜 22 時以降スマホを触らない",
+        difficulty: 3,
+        deadline: 30.days.from_now.to_date.to_s
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/promotions_spec.rb
+++ b/spec/requests/api/v1/auth/promotions_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Promotions", type: :request do
+  describe "PATCH /api/v1/auth/promote" do
+    let(:promote_params) do
+      {
+        email: "real@example.com",
+        password: "password123",
+        password_confirmation: "password123",
+        nickname: "勇者"
+      }
+    end
+
+    context "ゲストユーザーがログイン中" do
+      before { post "/api/v1/auth/guest", as: :json }
+
+      it "200 OK を返し、is_guest=false / 入力した email & nickname に更新される" do
+        patch "/api/v1/auth/promote", params: promote_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["email"]).to eq("real@example.com")
+        expect(body["nickname"]).to eq("勇者")
+        expect(body["is_guest"]).to be false
+      end
+
+      it "promote 後は新しい email / password でログインできる" do
+        patch "/api/v1/auth/promote", params: promote_params, as: :json
+        expect(response).to have_http_status(:ok)
+
+        delete "/api/v1/auth/logout"
+        post "/api/v1/auth/login", params: {
+          email: "real@example.com", password: "password123"
+        }, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "promote 前に作った Pact が引き継がれる" do
+        post "/api/v1/pacts", params: {
+          goal: "目標", constraint_text: "制約", difficulty: 3,
+          deadline: 30.days.from_now.to_date.to_s
+        }, as: :json
+        expect(response).to have_http_status(:created)
+        pact_id = response.parsed_body["id"]
+
+        patch "/api/v1/auth/promote", params: promote_params, as: :json
+        expect(response).to have_http_status(:ok)
+
+        # 同じセッションでそのまま自分の Pact を取得できる
+        get "/api/v1/pacts/#{pact_id}"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "登録済みユーザーがログイン中" do
+      let!(:user) do
+        create(:user, email: "existing@example.com",
+               password: "password123", password_confirmation: "password123", is_guest: false)
+      end
+
+      before { post "/api/v1/auth/login", params: { email: "existing@example.com", password: "password123" }, as: :json }
+
+      it "422 Unprocessable Content + not_a_guest コードを返す" do
+        patch "/api/v1/auth/promote", params: promote_params, as: :json
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"][0]["code"]).to eq("not_a_guest")
+      end
+    end
+
+    context "未ログイン" do
+      it "401 Unauthorized" do
+        patch "/api/v1/auth/promote", params: promote_params, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "バリデーションエラー（email 重複）" do
+      before do
+        create(:user, email: "taken@example.com", is_guest: false)
+        post "/api/v1/auth/guest", as: :json
+      end
+
+      it "422 + 既存の RecordInvalid 形式のエラーレスポンス" do
+        patch "/api/v1/auth/promote", params: promote_params.merge(email: "taken@example.com"), as: :json
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #9 対応：登録なしで全機能を試せる **Guest User モード**を実装。
気に入ったらメアド + パスワードを後付けして本登録ユーザーに昇格できる。

## 設計判断：案 C（Guest 専用 User レコード）

Issue 本文の 3 案から **C（Guest 専用 User レコード）** を採用：

| 案 | 仕組み                                  | 採用 | 理由                                            |
| -- | --------------------------------------- | ---- | ----------------------------------------------- |
| A  | セッションに guest user 情報            | ❌   | 認証ミドルウェアの分岐が必要、引き継ぎが複雑    |
| B  | 完全匿名（LocalStorage のみ）           | ❌   | AI / ランキング / 紋章が動かない、体験が薄い    |
| **C** | **Guest 専用 User レコード**           | **✅** | **既存機能が全部動く、引き継ぎが email 更新だけ** |

## 主な実装

### 1. User モデル拡張

\`\`\`ruby
# 新フィールド: is_guest:boolean (default false)
# is_public は guest 作成時に false（ランキング非表示）

User.create_guest!  # email: guest_<hex>@guest.local + nickname: ゲスト
guest.promote_to_registered!(email:, password:, ...)  # 本物に更新

User.guest          # is_guest=true scope
User.registered     # is_guest=false scope
User.expired_guests # 30 日超の未昇格ゲスト
\`\`\`

### 2. API エンドポイント（2 つ）

| Method | URL                       | 動作                             |
| ------ | ------------------------- | -------------------------------- |
| POST   | \`/api/v1/auth/guest\`    | Guest 作成 + 即時ログイン        |
| PATCH  | \`/api/v1/auth/promote\`  | Guest → 本登録ユーザーへ昇格    |

### 3. CleanupExpiredGuestsJob

30 日経過しても本登録に昇格していないゲストを Solid Queue で定期削除。
\`User#dependent: :destroy\` 連鎖で関連 Pact / CheckIn / Crest / Session も削除される。

## チート対策の継続性

| 項目                     | ゲストでも有効 |
| ------------------------ | -------------- |
| \`signed_at\` サーバ確定 | ✅             |
| \`checked_on\` サーバ確定 | ✅             |
| 1 契約 1 紋章 UNIQUE     | ✅             |
| ランキング is_public 制御| ✅（ゲストは非表示）|
| AI レート制限            | ✅（user 基準なので有効）|

## 既存機能との互換性

- ✅ 既存の認証ミドルウェアは変更なし（ゲストも通常ログインと同じ仕組み）
- ✅ AI 4 endpoint はそのまま動く（ゲスト User の id でロギング・レート制限）
- ✅ 契約作成 / チェックイン / 達成判定 / 紋章生成すべて動く
- ✅ ランキングは is_public=false なのでゲストは表示されない

## テスト（22 件追加）

| spec                                              | 件数 | 内容                                                    |
| ------------------------------------------------- | ---- | ------------------------------------------------------- |
| spec/models/user_spec.rb                          | +12  | create_guest! / promote / scope 3 種類                |
| spec/requests/api/v1/auth/guests_spec.rb         | 3    | 作成 / Pact 作成可能 / 認証不要                        |
| spec/requests/api/v1/auth/promotions_spec.rb     | 5    | 通常 promote / 再ログイン / Pact 引き継ぎ / 登録済拒否 / 401 |
| spec/jobs/cleanup_expired_guests_job_spec.rb     | 4    | 30 日超削除 / 29 日残す / 登録済残す / 連鎖削除         |

## 動作確認

- [x] \`./bin/rspec\` パス（**247/247**）
- [x] \`bundle exec rubocop\` クリーン

## 残作業（後続 Issue）

- **FE 実装**：HomePage に「ログインせずに始める」導線 + 設定画面に「正式登録」ボタン
- **Solid Queue 定期実行設定**：CleanupExpiredGuestsJob を毎日 or 週次で起動

これらは別 PR に分離（FE と Solid Queue cron 設定は独立した関心）。

closes #9