### PR TITLE
feat(frontend): v1.1 体験ループの UI 完成（Guest導線 + 契約一覧 + チェックイン UI + 紋章ギャラリー）

### DIFF
--- a/app/controllers/api/v1/pacts_controller.rb
+++ b/app/controllers/api/v1/pacts_controller.rb
@@ -2,12 +2,13 @@ module Api
   module V1
     class PactsController < Api::V1::BaseController
       def index
-        pacts = Current.user.pacts.order(created_at: :desc)
+        # crest を eager load して N+1 を回避（紋章ギャラリーで参照される）
+        pacts = Current.user.pacts.includes(:crest).order(created_at: :desc)
         render json: PactSerializer.new(pacts).serializable_hash, status: :ok
       end
 
       def show
-        pact = Current.user.pacts.find(params[:id])
+        pact = Current.user.pacts.includes(:crest).find(params[:id])
         render json: PactSerializer.new(pact).serializable_hash, status: :ok
       end
 

--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -7,6 +7,9 @@ import CreatePactStep2Page from "./pages/CreatePactStep2Page"
 import CreatePactStep3Page from "./pages/CreatePactStep3Page"
 import CreatePactStep4Page from "./pages/CreatePactStep4Page"
 import SignedPage from "./pages/SignedPage"
+import PactsListPage from "./pages/PactsListPage"
+import PactDetailPage from "./pages/PactDetailPage"
+import CrestsGalleryPage from "./pages/CrestsGalleryPage"
 import RequireAuth from "./components/RequireAuth"
 import { CreatePactProvider } from "./contexts/CreatePactContext"
 
@@ -47,6 +50,36 @@ function App() {
             element={
               <RequireAuth>
                 <SignedPage />
+              </RequireAuth>
+            }
+          />
+
+          {/* 契約一覧 */}
+          <Route
+            path="/pacts"
+            element={
+              <RequireAuth>
+                <PactsListPage />
+              </RequireAuth>
+            }
+          />
+
+          {/* 契約詳細 + チェックイン UI */}
+          <Route
+            path="/pacts/:id"
+            element={
+              <RequireAuth>
+                <PactDetailPage />
+              </RequireAuth>
+            }
+          />
+
+          {/* 紋章ギャラリー（誓約の殿堂） */}
+          <Route
+            path="/crests"
+            element={
+              <RequireAuth>
+                <CrestsGalleryPage />
               </RequireAuth>
             }
           />

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -38,18 +38,35 @@ function Layout({ children, title, showHeader = true, showFooter = true }: Layou
               誓約 <span className="text-gold mx-1">⚔</span> 契約
             </Link>
             <div className="flex items-center gap-4">
-              {title && <h1 className="font-serif text-lg text-ink/80 hidden sm:block">{title}</h1>}
+              {title && <h1 className="font-serif text-lg text-ink/80 hidden md:block">{title}</h1>}
               {isAuthenticated && (
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-ink/70 hidden sm:inline">{user?.nickname}</span>
-                  <button
-                    type="button"
-                    onClick={handleLogout}
-                    className="text-sm text-ink/60 hover:text-seal transition underline-offset-2 hover:underline"
-                  >
-                    ログアウト
-                  </button>
-                </div>
+                <>
+                  <nav className="hidden sm:flex items-center gap-3 text-sm font-serif">
+                    <Link to="/pacts" className="text-ink/70 hover:text-seal transition">
+                      書庫
+                    </Link>
+                    <Link to="/crests" className="text-ink/70 hover:text-seal transition">
+                      殿堂
+                    </Link>
+                  </nav>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-ink/70 hidden sm:inline">
+                      {user?.nickname}
+                      {user?.is_guest && (
+                        <span className="ml-1 text-xs px-1 py-0.5 bg-gold/20 text-ink/60 rounded-sm">
+                          ゲスト
+                        </span>
+                      )}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleLogout}
+                      className="text-sm text-ink/60 hover:text-seal transition underline-offset-2 hover:underline"
+                    >
+                      ログアウト
+                    </button>
+                  </div>
+                </>
               )}
             </div>
           </div>

--- a/app/frontend/pages/CrestsGalleryPage.tsx
+++ b/app/frontend/pages/CrestsGalleryPage.tsx
@@ -1,0 +1,165 @@
+import { useState, useMemo } from "react"
+import { Link } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import Layout from "../components/Layout"
+import Button from "../components/Button"
+import { api, ApiError } from "../lib/api"
+import type { Pact, CrestRarity } from "../types/pact"
+
+const RARITY_TABS: { value: CrestRarity | "all"; label: string }[] = [
+  { value: "all", label: "全て" },
+  { value: "legendary", label: "伝説" },
+  { value: "epic", label: "英雄" },
+  { value: "rare", label: "稀少" },
+  { value: "common", label: "通常" },
+]
+
+const RARITY_STYLE: Record<CrestRarity, { label: string; className: string; ringClass: string }> = {
+  common: {
+    label: "Common",
+    className: "bg-ink/5 text-ink/70 border-ink/30",
+    ringClass: "ring-ink/20",
+  },
+  rare: {
+    label: "Rare",
+    className: "bg-seal/10 text-seal border-seal/40",
+    ringClass: "ring-seal/30",
+  },
+  epic: {
+    label: "Epic",
+    className: "bg-gold/20 text-ink border-gold",
+    ringClass: "ring-gold/50",
+  },
+  legendary: {
+    label: "Legendary",
+    className: "bg-gradient-to-br from-gold/40 to-seal/30 text-ink border-gold animate-pulse",
+    ringClass: "ring-gold",
+  },
+}
+
+const MOTIF_EMOJI: Record<string, string> = {
+  sword: "⚔",
+  moon: "🌙",
+  flame: "🔥",
+  eye: "👁",
+  book: "📖",
+  wolf: "🐺",
+  eagle: "🦅",
+  dragon: "🐉",
+  star: "⭐",
+  phoenix: "🦜",
+}
+
+function CrestsGalleryPage() {
+  const [filter, setFilter] = useState<CrestRarity | "all">("all")
+
+  const { data: pacts, isLoading, isError } = useQuery<Pact[], ApiError>({
+    queryKey: ["pacts"],
+    queryFn: () => api<Pact[]>("/pacts"),
+  })
+
+  const earned = useMemo(
+    () => (pacts ?? []).filter((p) => p.status === "completed" && p.crest),
+    [pacts]
+  )
+
+  const filtered = useMemo(
+    () =>
+      filter === "all"
+        ? earned
+        : earned.filter((p) => p.crest?.rarity === filter),
+    [earned, filter]
+  )
+
+  return (
+    <Layout title="誓約の殿堂">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-6 text-center">
+          <p className="font-serif text-xl text-seal mb-2">誓約の殿堂</p>
+          <p className="text-sm text-ink/60">これまでに刻みし {earned.length} 個の紋章</p>
+        </div>
+
+        {/* タブ */}
+        <div className="flex gap-1 mb-6 border-b border-gold/30 overflow-x-auto">
+          {RARITY_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setFilter(tab.value)}
+              className={`px-4 py-2 text-sm font-serif whitespace-nowrap transition ${
+                filter === tab.value
+                  ? "text-seal border-b-2 border-seal"
+                  : "text-ink/50 hover:text-ink"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {isLoading && <p className="text-center text-ink/60 mt-12">殿堂を開いている…</p>}
+
+        {isError && <p className="text-center text-seal mt-12">殿堂を開けませんでした</p>}
+
+        {!isLoading && !isError && filtered.length === 0 && (
+          <div className="text-center mt-12">
+            <p className="text-ink/60 mb-6">
+              {earned.length === 0
+                ? "まだ紋章を授かっていません。最初の誓いを成就させよう。"
+                : "該当する紋章がありません。"}
+            </p>
+            <Link to="/pacts/new/step1">
+              <Button variant="primary">新たな誓約を結ぶ</Button>
+            </Link>
+          </div>
+        )}
+
+        <ul className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {filtered.map((pact) => {
+            if (!pact.crest) return null
+            const style = RARITY_STYLE[pact.crest.rarity]
+            const motif = MOTIF_EMOJI[pact.crest.crest_data.central_motif] ?? "⚔"
+            const shimmer = pact.crest.crest_data.shimmer_level
+            return (
+              <li key={pact.id}>
+                <Link
+                  to={`/pacts/${pact.id}`}
+                  className={`block p-4 bg-parchment border-2 rounded-sm transition hover:scale-[1.02] ${style.className}`}
+                >
+                  {/* 紋章ビジュアル */}
+                  <div className="flex justify-center mb-3">
+                    <div
+                      className={`relative w-24 h-24 flex items-center justify-center rounded-full bg-parchment ring-4 ${style.ringClass}`}
+                    >
+                      <span className="text-4xl">{motif}</span>
+                    </div>
+                  </div>
+
+                  {/* レアリティバッジ */}
+                  <div className="flex justify-center mb-2">
+                    <span
+                      className={`text-xs font-bold uppercase tracking-wider px-2 py-0.5 border rounded-sm ${style.className}`}
+                    >
+                      {style.label}
+                    </span>
+                  </div>
+
+                  {/* 装飾レベル */}
+                  <p className="text-center text-xs text-ink/60 mb-2">
+                    {"✦".repeat(shimmer)}
+                  </p>
+
+                  {/* 目標 */}
+                  <p className="text-xs text-center font-serif text-ink line-clamp-2">
+                    {pact.goal}
+                  </p>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </Layout>
+  )
+}
+
+export default CrestsGalleryPage

--- a/app/frontend/pages/HomePage.tsx
+++ b/app/frontend/pages/HomePage.tsx
@@ -1,11 +1,24 @@
 import { useNavigate } from "react-router-dom"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import Layout from "../components/Layout"
 import Button from "../components/Button"
 import { useAuth } from "../hooks/useAuth"
+import { api, ApiError } from "../lib/api"
+import type { User } from "../types/user"
 
 function HomePage() {
   const { isAuthenticated, isLoading } = useAuth()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  // ゲスト作成 → 即時ログイン状態 → 新規契約フローへ
+  const guestMutation = useMutation<User, ApiError, void>({
+    mutationFn: () => api<User>("/auth/guest", { method: "POST" }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+      navigate("/pacts/new/step1")
+    },
+  })
 
   return (
     <Layout>
@@ -23,17 +36,47 @@ function HomePage() {
         {isLoading ? (
           <p className="text-ink/60">門を開いている…</p>
         ) : isAuthenticated ? (
-          <Button variant="primary" onClick={() => navigate("/pacts/new/step1")}>
-            新たな誓約を結ぶ
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button variant="primary" onClick={() => navigate("/pacts/new/step1")}>
+              新たな誓約を結ぶ
+            </Button>
+            <Button variant="ghost" onClick={() => navigate("/pacts")}>
+              書庫を見る
+            </Button>
+            <Button variant="ghost" onClick={() => navigate("/crests")}>
+              殿堂を見る
+            </Button>
+          </div>
         ) : (
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button variant="primary" onClick={() => navigate("/login")}>
-              ログイン
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button variant="primary" onClick={() => navigate("/login")}>
+                ログイン
+              </Button>
+              <Button variant="ghost" onClick={() => navigate("/signup")}>
+                新規登録
+              </Button>
+            </div>
+            <div className="flex items-center gap-2 mt-2 w-full max-w-xs">
+              <span className="flex-1 border-t border-ink/20" />
+              <span className="text-xs text-ink/50">または</span>
+              <span className="flex-1 border-t border-ink/20" />
+            </div>
+            <Button
+              variant="secondary"
+              onClick={() => guestMutation.mutate()}
+              disabled={guestMutation.isPending}
+            >
+              {guestMutation.isPending ? "支度中..." : "登録せずに試してみる"}
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/signup")}>
-              新規登録
-            </Button>
+            {guestMutation.isError && (
+              <p className="text-xs text-seal mt-2">
+                ゲストの開始に失敗しました。再度お試しください。
+              </p>
+            )}
+            <p className="text-xs text-ink/50 max-w-md">
+              30 日間お試しでご利用いただけます。気に入ったら設定画面から正式登録できます。
+            </p>
           </div>
         )}
       </div>

--- a/app/frontend/pages/PactDetailPage.tsx
+++ b/app/frontend/pages/PactDetailPage.tsx
@@ -1,0 +1,226 @@
+import { useState, useMemo } from "react"
+import { useParams, useNavigate, Link } from "react-router-dom"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import Layout from "../components/Layout"
+import Button from "../components/Button"
+import { api, ApiError } from "../lib/api"
+import type { Pact } from "../types/pact"
+import type { CheckIn, CheckInStatus } from "../types/check_in"
+
+type CheckInResponse = {
+  check_in: CheckIn
+  pact: Pact
+  achieved: boolean
+}
+
+const STATUS_LABELS: Record<CheckInStatus, { label: string; symbol: string; className: string }> = {
+  kept: { label: "守れた", symbol: "⚔", className: "bg-seal text-parchment hover:opacity-90" },
+  broken: { label: "破れた", symbol: "✗", className: "bg-ink/70 text-parchment hover:opacity-90" },
+  skipped: { label: "休戦", symbol: "—", className: "bg-gold text-ink hover:opacity-90" },
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function PactDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [note, setNote] = useState("")
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const { data: pact, isLoading: isPactLoading, isError: isPactError } = useQuery<Pact, ApiError>({
+    queryKey: ["pact", id],
+    queryFn: () => api<Pact>(`/pacts/${id}`),
+    enabled: !!id,
+  })
+
+  const { data: checkIns } = useQuery<CheckIn[], ApiError>({
+    queryKey: ["pact", id, "check_ins"],
+    queryFn: () => api<CheckIn[]>(`/pacts/${id}/check_ins`),
+    enabled: !!id,
+  })
+
+  const todayCheckIn = useMemo(
+    () => checkIns?.find((ci) => ci.checked_on === todayIso()),
+    [checkIns]
+  )
+
+  const checkInMutation = useMutation<CheckInResponse, ApiError, CheckInStatus>({
+    mutationFn: (status) =>
+      api<CheckInResponse>(`/pacts/${id}/check_ins`, {
+        method: "POST",
+        body: { status, note: note.trim() || undefined },
+      }),
+    onSuccess: async (result) => {
+      setNote("")
+      await queryClient.invalidateQueries({ queryKey: ["pact", id] })
+      await queryClient.invalidateQueries({ queryKey: ["pact", id, "check_ins"] })
+      await queryClient.invalidateQueries({ queryKey: ["pacts"] })
+      if (result.achieved) {
+        navigate(`/pacts/${id}/signed`)
+      }
+    },
+    onError: (err) => {
+      const errors = Array.isArray(err.errors) ? err.errors : []
+      const firstError = errors[0] as { message?: string } | undefined
+      setSubmitError(firstError?.message ?? "チェックインに失敗しました。")
+    },
+  })
+
+  const handleCheckIn = (status: CheckInStatus) => {
+    setSubmitError(null)
+    checkInMutation.mutate(status)
+  }
+
+  if (isPactLoading) {
+    return (
+      <Layout title="誓約">
+        <p className="text-center text-ink/60 mt-12">誓いを開いている…</p>
+      </Layout>
+    )
+  }
+
+  if (isPactError || !pact) {
+    return (
+      <Layout title="誓約">
+        <div className="text-center mt-12">
+          <p className="text-seal mb-4">誓いが見つかりませんでした</p>
+          <Link to="/pacts">
+            <Button variant="ghost">書庫へ戻る</Button>
+          </Link>
+        </div>
+      </Layout>
+    )
+  }
+
+  const isActive = pact.status === "active"
+  const difficulty = Math.min(5, Math.max(0, pact.difficulty))
+
+  return (
+    <Layout title="誓約">
+      <div className="max-w-2xl mx-auto">
+        {/* 契約サマリ */}
+        <div className="mb-6 p-6 bg-parchment border-2 border-gold/60 rounded-sm">
+          <div className="flex items-start justify-between gap-3 mb-4">
+            <p className="font-serif text-xl text-seal flex-1">{pact.goal}</p>
+            <span
+              className={`text-xs px-2 py-0.5 rounded-sm whitespace-nowrap ${
+                pact.status === "active"
+                  ? "bg-seal/10 text-seal border border-seal/30"
+                  : pact.status === "completed"
+                    ? "bg-gold/20 text-ink border border-gold"
+                    : "bg-ink/5 text-ink/40 border border-ink/20"
+              }`}
+            >
+              {pact.status === "active" ? "進行中" : pact.status === "completed" ? "達成" : pact.status}
+            </span>
+          </div>
+
+          <section className="mb-3">
+            <p className="text-xs text-ink/60 font-serif">試練</p>
+            <p className="text-sm text-ink">{pact.constraint_text}</p>
+          </section>
+          <section className="mb-3">
+            <p className="text-xs text-ink/60 font-serif">期日</p>
+            <p className="text-sm text-ink">{pact.deadline}</p>
+          </section>
+          <section>
+            <p className="text-xs text-ink/60 font-serif">難易度</p>
+            <p className="text-sm text-ink">
+              {"⚔".repeat(difficulty)}
+              <span className="text-ink/30">{"⚔".repeat(5 - difficulty)}</span>
+              <span className="ml-2">{pact.difficulty} / 5</span>
+            </p>
+          </section>
+        </div>
+
+        {/* 今日のチェックイン */}
+        {isActive && (
+          <div className="mb-6 p-5 bg-parchment/60 border border-gold/40 rounded-sm">
+            <p className="font-serif text-base text-ink mb-3">
+              今日（{todayIso()}）のチェックイン
+              {todayCheckIn && (
+                <span className="ml-2 text-xs text-ink/50">
+                  既に記録済み（再度押すと訂正されます）
+                </span>
+              )}
+            </p>
+
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="メモ（任意・500 文字まで）"
+              rows={2}
+              maxLength={500}
+              className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none mb-3"
+            />
+
+            <div className="grid grid-cols-3 gap-2">
+              {(Object.keys(STATUS_LABELS) as CheckInStatus[]).map((status) => {
+                const meta = STATUS_LABELS[status]
+                return (
+                  <button
+                    key={status}
+                    type="button"
+                    onClick={() => handleCheckIn(status)}
+                    disabled={checkInMutation.isPending}
+                    className={`px-3 py-3 rounded-sm font-serif font-bold transition disabled:opacity-50 disabled:cursor-not-allowed ${meta.className}`}
+                  >
+                    <span className="block text-2xl mb-1">{meta.symbol}</span>
+                    <span className="block text-sm">{meta.label}</span>
+                  </button>
+                )
+              })}
+            </div>
+
+            {submitError && (
+              <p className="mt-3 text-xs text-seal" role="alert">
+                {submitError}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* 履歴 */}
+        <div className="mb-6">
+          <p className="font-serif text-base text-ink mb-3">これまでの記録</p>
+          {checkIns && checkIns.length > 0 ? (
+            <ul className="space-y-2">
+              {checkIns.map((ci) => {
+                const meta = STATUS_LABELS[ci.status]
+                return (
+                  <li
+                    key={ci.id}
+                    className="flex items-start gap-3 p-3 bg-parchment/40 border border-gold/30 rounded-sm"
+                  >
+                    <span className="font-serif text-xl text-seal w-6 text-center">{meta.symbol}</span>
+                    <div className="flex-1">
+                      <p className="text-sm text-ink">
+                        {ci.checked_on}：{meta.label}
+                      </p>
+                      {ci.note && (
+                        <p className="text-xs text-ink/60 mt-1 whitespace-pre-wrap">{ci.note}</p>
+                      )}
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <p className="text-sm text-ink/50">まだ記録はありません。</p>
+          )}
+        </div>
+
+        <div className="flex justify-between">
+          <Button variant="ghost" onClick={() => navigate("/pacts")}>
+            書庫へ戻る
+          </Button>
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default PactDetailPage

--- a/app/frontend/pages/PactsListPage.tsx
+++ b/app/frontend/pages/PactsListPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import Layout from "../components/Layout"
+import Button from "../components/Button"
+import { api, ApiError } from "../lib/api"
+import type { Pact, PactStatus } from "../types/pact"
+
+const STATUS_TABS: { value: PactStatus | "all"; label: string }[] = [
+  { value: "all", label: "全て" },
+  { value: "active", label: "進行中" },
+  { value: "completed", label: "達成" },
+  { value: "abandoned", label: "破棄" },
+  { value: "failed", label: "失敗" },
+]
+
+const STATUS_BADGE: Record<PactStatus, { text: string; className: string }> = {
+  active: { text: "進行中", className: "bg-seal/10 text-seal border border-seal/30" },
+  completed: { text: "達成", className: "bg-gold/20 text-ink border border-gold" },
+  failed: { text: "失敗", className: "bg-ink/10 text-ink/60 border border-ink/30" },
+  abandoned: { text: "破棄", className: "bg-ink/5 text-ink/40 border border-ink/20" },
+}
+
+function PactsListPage() {
+  const [filter, setFilter] = useState<PactStatus | "all">("all")
+
+  const { data: pacts, isLoading, isError } = useQuery<Pact[], ApiError>({
+    queryKey: ["pacts"],
+    queryFn: () => api<Pact[]>("/pacts"),
+  })
+
+  const filtered = pacts?.filter((p) => filter === "all" || p.status === filter) ?? []
+
+  return (
+    <Layout title="誓約の書庫">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-6 text-center">
+          <p className="font-serif text-xl text-seal mb-2">誓約の書庫</p>
+          <p className="text-sm text-ink/60">これまでに結んだすべての契約</p>
+        </div>
+
+        {/* タブ */}
+        <div className="flex gap-1 mb-6 border-b border-gold/30 overflow-x-auto">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setFilter(tab.value)}
+              className={`px-4 py-2 text-sm font-serif whitespace-nowrap transition ${
+                filter === tab.value
+                  ? "text-seal border-b-2 border-seal"
+                  : "text-ink/50 hover:text-ink"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {isLoading && (
+          <p className="text-center text-ink/60 mt-12">書庫を開いている…</p>
+        )}
+
+        {isError && (
+          <p className="text-center text-seal mt-12">書庫を開けませんでした</p>
+        )}
+
+        {!isLoading && !isError && filtered.length === 0 && (
+          <div className="text-center mt-12">
+            <p className="text-ink/60 mb-6">該当する誓約がありません。</p>
+            <Link to="/pacts/new/step1">
+              <Button variant="primary">新たな誓約を結ぶ</Button>
+            </Link>
+          </div>
+        )}
+
+        <ul className="space-y-3">
+          {filtered.map((pact) => {
+            const badge = STATUS_BADGE[pact.status]
+            return (
+              <li key={pact.id}>
+                <Link
+                  to={`/pacts/${pact.id}`}
+                  className="block p-4 bg-parchment/60 border border-gold/40 rounded-sm hover:border-seal transition"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-2">
+                    <p className="font-serif text-base text-ink flex-1">{pact.goal}</p>
+                    <span className={`text-xs px-2 py-0.5 rounded-sm ${badge.className}`}>
+                      {badge.text}
+                    </span>
+                  </div>
+                  <p className="text-xs text-ink/60 mb-1">
+                    試練：{pact.constraint_text}
+                  </p>
+                  <div className="flex items-center justify-between text-xs text-ink/50 mt-2">
+                    <span>
+                      期日：{pact.deadline}
+                    </span>
+                    <span>
+                      {"⚔".repeat(Math.min(5, Math.max(0, pact.difficulty)))}
+                      <span className="text-ink/20">
+                        {"⚔".repeat(5 - Math.min(5, Math.max(0, pact.difficulty)))}
+                      </span>
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </Layout>
+  )
+}
+
+export default PactsListPage

--- a/app/frontend/types/check_in.ts
+++ b/app/frontend/types/check_in.ts
@@ -1,0 +1,11 @@
+export type CheckInStatus = "kept" | "broken" | "skipped"
+
+export type CheckIn = {
+  id: number
+  pact_id: number
+  checked_on: string
+  status: CheckInStatus
+  note: string | null
+  created_at: string
+  updated_at: string
+}

--- a/app/frontend/types/pact.ts
+++ b/app/frontend/types/pact.ts
@@ -1,5 +1,25 @@
 export type PactStatus = "active" | "completed" | "failed" | "abandoned"
 
+export type CrestRarity = "common" | "rare" | "epic" | "legendary"
+
+export type CrestData = {
+  base_shape: string
+  central_motif: string
+  decoration: string
+  color_palette: string
+  shimmer_level: number
+}
+
+export type Crest = {
+  id: number
+  pact_id: number
+  crest_data: CrestData
+  rarity: CrestRarity
+  generated_at: string
+  created_at: string
+  updated_at: string
+}
+
 export type Pact = {
   id: number
   user_id: number
@@ -12,6 +32,7 @@ export type Pact = {
   title: string | null
   signed_at: string
   completed_at: string | null
+  crest: Crest | null
   created_at: string
   updated_at: string
 }

--- a/app/frontend/types/user.ts
+++ b/app/frontend/types/user.ts
@@ -4,6 +4,7 @@ export type User = {
   nickname: string
   avatar_url: string | null
   is_public: boolean
+  is_guest: boolean
   streak_count: number
   longest_streak: number
   created_at: string

--- a/app/serializers/crest_serializer.rb
+++ b/app/serializers/crest_serializer.rb
@@ -1,0 +1,11 @@
+class CrestSerializer
+  include Alba::Resource
+
+  attributes :id,
+             :pact_id,
+             :crest_data,
+             :rarity,
+             :generated_at,
+             :created_at,
+             :updated_at
+end

--- a/app/serializers/pact_serializer.rb
+++ b/app/serializers/pact_serializer.rb
@@ -14,4 +14,7 @@ class PactSerializer
              :completed_at,
              :created_at,
              :updated_at
+
+  # 達成済み契約には紋章が紐づく。未達成なら null。
+  one :crest, resource: CrestSerializer
 end


### PR DESCRIPTION
## 概要

v1.1 のバックエンド機能を UI で完結させる **4 つの導線・画面**を一気に追加。
これで **「誓って → 守って → 達成 → 紋章を眺める」の体験ループが UI でつながる**。

## 主な実装

### 1. Guest user 導線（HomePage + Layout）

PR #55 で実装したゲストモードの FE 導線：

- **HomePage**：未ログイン時に「**登録せずに試してみる**」ボタン
  - \`POST /api/v1/auth/guest\` で即時ログイン → \`/pacts/new/step1\` へ
- **HomePage**：ログイン済み時に「書庫を見る」「殿堂を見る」ボタンを追加
- **Layout ヘッダー**：\`/pacts\` \`/crests\` へのナビ + nickname 横に「ゲスト」バッジ

### 2. 契約一覧画面（\`/pacts\`）

- 自分の契約を一覧表示（created_at 降順）
- 状態タブ：全て / 進行中 / 達成 / 破棄 / 失敗
- カードに目標・試練・期日・難易度（⚔ アイコン）+ 状態バッジ
- 0 件のときは「新たな誓約を結ぶ」CTA

### 3. 契約詳細 + チェックイン UI（\`/pacts/:id\`）

- 契約サマリ表示
- **今日のチェックイン UI**：kept（⚔）/ broken（✗）/ skipped（—）の 3 ボタン + メモ欄（500 文字）
- 既に今日記録済みなら「訂正されます」と注記
- **達成（achieved=true）したら自動で SignedPage に遷移**
- これまでの記録（checked_on 降順、メモ付き）

### 4. 紋章ギャラリー（\`/crests\`）

- 達成済み契約の紋章をグリッド表示（2〜3 列）
- レアリティタブ：全て / 伝説 / 英雄 / 稀少 / 通常
- **central_motif を絵文字で表現**（sword=⚔ / dragon=🐉 / phoenix=🦜 等）
- レアリティ別の色・リング・shimmer_level の装飾
- legendary は \`animate-pulse\` でアニメーション

### 5. PactSerializer の拡張（BE 微修正）

紋章ギャラリーで「達成済み契約の紋章」を 1 リクエストで取得するため：

\`\`\`ruby
class PactSerializer
  one :crest, resource: CrestSerializer
end
\`\`\`

\`PactsController#index\` / \`#show\` に \`includes(:crest)\` を追加して N+1 回避。
未達成契約では \`crest: null\` が返る。

## 動作確認

ブラウザで通しシナリオを確認：

- [x] HomePage の「登録せずに試してみる」 → ゲスト作成 + 契約フロー進入
- [x] /pacts でタブ切替によるフィルタ
- [x] /pacts/:id でチェックイン記録 + 訂正動作
- [x] 達成判定発火で自動 /pacts/:id/signed 遷移
- [x] /crests で紋章ビジュアル + レアリティタブ表示
- [x] Layout のナビとゲストバッジ表示

### 自動チェック

- [x] \`./bin/rspec\` パス（247/247、BE への影響なし）
- [x] \`bundle exec rubocop\` クリーン
- [x] \`npm run lint\` / \`typecheck\` クリーン

## 残作業（後続 PR）

- **設定画面**（\`/settings\`）：プロフィール編集 + email/password 変更 + **ゲストの正式登録（promote）UI**
- **ランキング画面**（\`/rankings\`）：streak / monthly の 2 軸タブ
- **CleanupExpiredGuestsJob の Solid Queue Cron 設定**

これらは別 PR に分離。

## v1.1 進捗

- [x] BE：CheckIn / Streak / Pact 達成判定 / Crest / AI ロギング / レート制限
- [x] FE：契約作成 4 ステップ + 締結ページ
- [x] FE：**Guest 導線 + 契約一覧 + チェックイン UI + 紋章ギャラリー**（今回）
- [ ] FE：ランキング / 設定 / promote UI（次の PR）