### PR TITLE
feat(frontend): 設定画面 + ランキング画面 + Solid Queue Cron（v1.1 仕上げ）

### DIFF
--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -10,6 +10,8 @@ import SignedPage from "./pages/SignedPage"
 import PactsListPage from "./pages/PactsListPage"
 import PactDetailPage from "./pages/PactDetailPage"
 import CrestsGalleryPage from "./pages/CrestsGalleryPage"
+import RankingsPage from "./pages/RankingsPage"
+import SettingsPage from "./pages/SettingsPage"
 import RequireAuth from "./components/RequireAuth"
 import { CreatePactProvider } from "./contexts/CreatePactContext"
 
@@ -80,6 +82,26 @@ function App() {
             element={
               <RequireAuth>
                 <CrestsGalleryPage />
+              </RequireAuth>
+            }
+          />
+
+          {/* ランキング（誓約者の番付） */}
+          <Route
+            path="/rankings"
+            element={
+              <RequireAuth>
+                <RankingsPage />
+              </RequireAuth>
+            }
+          />
+
+          {/* 設定（プロフィール / メール / パスワード / ログアウト / 正式登録） */}
+          <Route
+            path="/settings"
+            element={
+              <RequireAuth>
+                <SettingsPage />
               </RequireAuth>
             }
           />

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -48,6 +48,12 @@ function Layout({ children, title, showHeader = true, showFooter = true }: Layou
                     <Link to="/crests" className="text-ink/70 hover:text-seal transition">
                       殿堂
                     </Link>
+                    <Link to="/rankings" className="text-ink/70 hover:text-seal transition">
+                      番付
+                    </Link>
+                    <Link to="/settings" className="text-ink/70 hover:text-seal transition">
+                      設定
+                    </Link>
                   </nav>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-ink/70 hidden sm:inline">

--- a/app/frontend/pages/RankingsPage.tsx
+++ b/app/frontend/pages/RankingsPage.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import Layout from "../components/Layout"
+import { api, ApiError } from "../lib/api"
+import { useAuth } from "../hooks/useAuth"
+import type {
+  MonthlyRankingResponse,
+  StreakRankingResponse,
+} from "../types/ranking"
+
+type Tab = "streak" | "monthly"
+
+function rankBadge(rank: number) {
+  if (rank === 1) return { emoji: "🥇", className: "text-gold" }
+  if (rank === 2) return { emoji: "🥈", className: "text-ink/60" }
+  if (rank === 3) return { emoji: "🥉", className: "text-seal/80" }
+  return { emoji: `${rank}`, className: "text-ink/50" }
+}
+
+function RankingsPage() {
+  const [tab, setTab] = useState<Tab>("streak")
+  const { user } = useAuth()
+
+  const streakQuery = useQuery<StreakRankingResponse, ApiError>({
+    queryKey: ["rankings", "streak"],
+    queryFn: () => api<StreakRankingResponse>("/rankings/streak"),
+    enabled: tab === "streak",
+  })
+
+  const monthlyQuery = useQuery<MonthlyRankingResponse, ApiError>({
+    queryKey: ["rankings", "monthly"],
+    queryFn: () => api<MonthlyRankingResponse>("/rankings/monthly"),
+    enabled: tab === "monthly",
+  })
+
+  return (
+    <Layout title="ランキング">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-6 text-center">
+          <p className="font-serif text-xl text-seal mb-2">誓約者の番付</p>
+          <p className="text-sm text-ink/60">公開ユーザー同士で競う</p>
+        </div>
+
+        {/* タブ */}
+        <div className="flex gap-1 mb-6 border-b border-gold/30">
+          <button
+            onClick={() => setTab("streak")}
+            className={`flex-1 px-4 py-2 text-sm font-serif transition ${
+              tab === "streak" ? "text-seal border-b-2 border-seal" : "text-ink/50 hover:text-ink"
+            }`}
+          >
+            連続日数
+          </button>
+          <button
+            onClick={() => setTab("monthly")}
+            className={`flex-1 px-4 py-2 text-sm font-serif transition ${
+              tab === "monthly" ? "text-seal border-b-2 border-seal" : "text-ink/50 hover:text-ink"
+            }`}
+          >
+            今月の達成数
+          </button>
+        </div>
+
+        {/* 自分の順位（is_public=false でも見える） */}
+        {user && !user.is_public && (
+          <div className="mb-4 p-3 bg-gold/10 border border-gold/40 rounded-sm text-xs text-ink/70">
+            あなたは「ランキング非表示」設定です。一覧には載りませんが、自分の順位は見えます。
+            <span className="block mt-1">設定画面で公開に変更できます。</span>
+          </div>
+        )}
+
+        {tab === "streak" && (
+          <>
+            {streakQuery.isLoading && <p className="text-center text-ink/60 mt-12">読み込み中…</p>}
+            {streakQuery.isError && <p className="text-center text-seal mt-12">取得に失敗しました</p>}
+            {streakQuery.data && (
+              <div>
+                <RankingList
+                  entries={streakQuery.data.rankings.map((e) => ({
+                    rank: e.rank,
+                    nickname: e.user.nickname,
+                    score: e.streak_count,
+                    suffix: "日",
+                    isMe: e.user.id === user?.id,
+                  }))}
+                />
+                <MyRank
+                  rank={streakQuery.data.my_rank.rank}
+                  score={streakQuery.data.my_rank.streak_count}
+                  suffix="日"
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {tab === "monthly" && (
+          <>
+            {monthlyQuery.isLoading && <p className="text-center text-ink/60 mt-12">読み込み中…</p>}
+            {monthlyQuery.isError && <p className="text-center text-seal mt-12">取得に失敗しました</p>}
+            {monthlyQuery.data && (
+              <div>
+                <p className="text-center text-xs text-ink/60 mb-3">{monthlyQuery.data.month}</p>
+                <RankingList
+                  entries={monthlyQuery.data.rankings.map((e) => ({
+                    rank: e.rank,
+                    nickname: e.user.nickname,
+                    score: e.achievement_count,
+                    suffix: "件",
+                    isMe: e.user.id === user?.id,
+                  }))}
+                />
+                <MyRank
+                  rank={monthlyQuery.data.my_rank.rank}
+                  score={monthlyQuery.data.my_rank.achievement_count}
+                  suffix="件"
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Layout>
+  )
+}
+
+type Entry = { rank: number; nickname: string; score: number; suffix: string; isMe: boolean }
+
+function RankingList({ entries }: { entries: Entry[] }) {
+  if (entries.length === 0) {
+    return <p className="text-center text-ink/50 mt-12">まだランキングに人がいません。</p>
+  }
+  return (
+    <ul className="space-y-2">
+      {entries.map((e, i) => {
+        const badge = rankBadge(e.rank)
+        return (
+          <li
+            key={`${e.rank}-${i}`}
+            className={`flex items-center gap-3 p-3 border rounded-sm ${
+              e.isMe ? "bg-seal/10 border-seal" : "bg-parchment/60 border-gold/40"
+            }`}
+          >
+            <span className={`w-10 text-center text-xl font-serif ${badge.className}`}>
+              {badge.emoji}
+            </span>
+            <span className="flex-1 font-serif text-base text-ink">
+              {e.nickname}
+              {e.isMe && <span className="ml-2 text-xs text-seal">あなた</span>}
+            </span>
+            <span className="font-serif text-base text-ink">
+              {e.score}
+              <span className="text-sm text-ink/60 ml-1">{e.suffix}</span>
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function MyRank({ rank, score, suffix }: { rank: number | null; score: number; suffix: string }) {
+  return (
+    <div className="mt-6 p-4 bg-parchment border-2 border-seal/40 rounded-sm">
+      <p className="text-xs text-ink/60 font-serif mb-1">あなたの順位</p>
+      <p className="font-serif text-base text-ink">
+        {rank ? `${rank} 位` : "圏外"}
+        <span className="ml-3 text-sm text-ink/60">
+          （{score} {suffix}）
+        </span>
+      </p>
+    </div>
+  )
+}
+
+export default RankingsPage

--- a/app/frontend/pages/SettingsPage.tsx
+++ b/app/frontend/pages/SettingsPage.tsx
@@ -1,0 +1,445 @@
+import { useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import Layout from "../components/Layout"
+import Button from "../components/Button"
+import FormField from "../components/FormField"
+import { useAuth } from "../hooks/useAuth"
+import { api, ApiError } from "../lib/api"
+import type { User } from "../types/user"
+
+function SettingsPage() {
+  const { user, isLoading } = useAuth()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  if (isLoading) {
+    return (
+      <Layout title="設定">
+        <p className="text-center text-ink/60 mt-12">読み込み中…</p>
+      </Layout>
+    )
+  }
+
+  if (!user) {
+    navigate("/login")
+    return null
+  }
+
+  return (
+    <Layout title="設定">
+      <div className="max-w-xl mx-auto space-y-8">
+        <div className="text-center mb-2">
+          <p className="font-serif text-xl text-seal mb-1">設定</p>
+          <p className="text-sm text-ink/60">
+            {user.nickname}
+            {user.is_guest && (
+              <span className="ml-2 text-xs px-1 py-0.5 bg-gold/20 text-ink/60 rounded-sm">
+                ゲスト
+              </span>
+            )}
+          </p>
+        </div>
+
+        {user.is_guest && <PromoteSection />}
+        <ProfileSection user={user} />
+        {!user.is_guest && (
+          <>
+            <EmailSection />
+            <PasswordSection />
+          </>
+        )}
+        <LogoutSection
+          onLogout={async () => {
+            await queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+            navigate("/login")
+          }}
+        />
+      </div>
+    </Layout>
+  )
+}
+
+// ============================================================
+// Promote（ゲスト → 本登録）
+// ============================================================
+
+function PromoteSection() {
+  const queryClient = useQueryClient()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [passwordConfirmation, setPasswordConfirmation] = useState("")
+  const [nickname, setNickname] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [success, setSuccess] = useState(false)
+
+  const promoteMutation = useMutation<User, ApiError, void>({
+    mutationFn: () =>
+      api<User>("/auth/promote", {
+        method: "PATCH",
+        body: {
+          email,
+          password,
+          password_confirmation: passwordConfirmation,
+          nickname: nickname.trim() || undefined,
+        },
+      }),
+    onSuccess: async () => {
+      setSuccess(true)
+      setErrors({})
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+    },
+    onError: (err) => {
+      setSuccess(false)
+      const errorMap: Record<string, string> = {}
+      const errorList = Array.isArray(err.errors) ? err.errors : []
+      errorList.forEach((e) => {
+        const item = e as { field?: string; message?: string; code?: string }
+        if (item.field) errorMap[item.field] = item.message ?? "エラー"
+        else errorMap.base = item.message ?? "登録に失敗しました"
+      })
+      setErrors(errorMap)
+    },
+  })
+
+  return (
+    <section className="p-5 bg-gold/10 border-2 border-gold rounded-sm">
+      <h3 className="font-serif text-base text-ink mb-2">
+        <span className="text-gold mr-2">⚜</span>正式登録する
+      </h3>
+      <p className="text-xs text-ink/70 mb-4">
+        メールアドレスとパスワードを登録すると、これまでの誓約・チェックイン・紋章が
+        そのまま引き継がれます。30 日経過すると自動で削除されます。
+      </p>
+
+      {success ? (
+        <p className="text-sm text-seal font-serif">
+          ✦ 正式登録が完了しました。これからもよろしく。
+        </p>
+      ) : (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            promoteMutation.mutate()
+          }}
+        >
+          {errors.base && (
+            <p className="mb-3 text-xs text-seal" role="alert">
+              {errors.base}
+            </p>
+          )}
+          <FormField
+            label="メールアドレス"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={errors.email}
+            required
+          />
+          <FormField
+            label="ニックネーム（任意）"
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder="ゲストのまま使うなら空欄でOK"
+            error={errors.nickname}
+          />
+          <FormField
+            label="パスワード（6 文字以上）"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={errors.password}
+            required
+          />
+          <FormField
+            label="パスワード（確認）"
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            error={errors.password_confirmation}
+            required
+          />
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={promoteMutation.isPending}
+            fullWidth
+          >
+            {promoteMutation.isPending ? "登録中..." : "正式登録する"}
+          </Button>
+        </form>
+      )}
+    </section>
+  )
+}
+
+// ============================================================
+// Profile（nickname / avatar_url / is_public）
+// ============================================================
+
+function ProfileSection({ user }: { user: User }) {
+  const queryClient = useQueryClient()
+  const [nickname, setNickname] = useState(user.nickname)
+  const [avatarUrl, setAvatarUrl] = useState(user.avatar_url ?? "")
+  const [isPublic, setIsPublic] = useState(user.is_public)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [savedRecently, setSavedRecently] = useState(false)
+
+  const updateMutation = useMutation<User, ApiError, void>({
+    mutationFn: () =>
+      api<User>("/auth/me", {
+        method: "PATCH",
+        body: {
+          nickname,
+          avatar_url: avatarUrl.trim() || null,
+          is_public: isPublic,
+        },
+      }),
+    onSuccess: async () => {
+      setErrors({})
+      setSavedRecently(true)
+      setTimeout(() => setSavedRecently(false), 3000)
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+    },
+    onError: (err) => {
+      const errorMap: Record<string, string> = {}
+      const errorList = Array.isArray(err.errors) ? err.errors : []
+      errorList.forEach((e) => {
+        const item = e as { field?: string; message?: string }
+        if (item.field) errorMap[item.field] = item.message ?? "エラー"
+        else errorMap.base = item.message ?? "更新に失敗しました"
+      })
+      setErrors(errorMap)
+    },
+  })
+
+  return (
+    <section className="p-5 bg-parchment/60 border border-gold/40 rounded-sm">
+      <h3 className="font-serif text-base text-ink mb-3">プロフィール</h3>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          updateMutation.mutate()
+        }}
+      >
+        <FormField
+          label="ニックネーム"
+          type="text"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          error={errors.nickname}
+          required
+        />
+        <FormField
+          label="アバター URL（任意）"
+          type="url"
+          value={avatarUrl}
+          onChange={(e) => setAvatarUrl(e.target.value)}
+          error={errors.avatar_url}
+          placeholder="https://..."
+        />
+        <label className="flex items-center gap-2 mb-4 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={(e) => setIsPublic(e.target.checked)}
+            className="accent-seal"
+          />
+          <span className="text-sm text-ink">ランキングに公開する</span>
+        </label>
+        <div className="flex items-center gap-3">
+          <Button variant="primary" type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? "保存中..." : "保存"}
+          </Button>
+          {savedRecently && <span className="text-xs text-seal">✦ 保存しました</span>}
+        </div>
+        {errors.base && (
+          <p className="mt-3 text-xs text-seal" role="alert">
+            {errors.base}
+          </p>
+        )}
+      </form>
+    </section>
+  )
+}
+
+// ============================================================
+// Email 変更
+// ============================================================
+
+function EmailSection() {
+  const queryClient = useQueryClient()
+  const [email, setEmail] = useState("")
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [success, setSuccess] = useState(false)
+
+  const mutation = useMutation<User, ApiError, void>({
+    mutationFn: () =>
+      api<User>("/auth/email", {
+        method: "PATCH",
+        body: { email, current_password: currentPassword },
+      }),
+    onSuccess: async () => {
+      setSuccess(true)
+      setErrors({})
+      setEmail("")
+      setCurrentPassword("")
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+    },
+    onError: (err) => {
+      setSuccess(false)
+      const errorMap: Record<string, string> = {}
+      const errorList = Array.isArray(err.errors) ? err.errors : []
+      errorList.forEach((e) => {
+        const item = e as { field?: string; message?: string; code?: string }
+        if (item.code === "invalid_password") errorMap.current_password = item.message ?? "現在のパスワードが正しくありません"
+        else if (item.field) errorMap[item.field] = item.message ?? "エラー"
+        else errorMap.base = item.message ?? "更新に失敗しました"
+      })
+      setErrors(errorMap)
+    },
+  })
+
+  return (
+    <section className="p-5 bg-parchment/60 border border-gold/40 rounded-sm">
+      <h3 className="font-serif text-base text-ink mb-3">メールアドレス変更</h3>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          mutation.mutate()
+        }}
+      >
+        <FormField
+          label="新しいメールアドレス"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={errors.email}
+          required
+        />
+        <FormField
+          label="現在のパスワード"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          error={errors.current_password}
+          required
+        />
+        <Button variant="primary" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? "変更中..." : "メールアドレスを変更"}
+        </Button>
+        {success && <p className="mt-2 text-xs text-seal">✦ 変更しました</p>}
+        {errors.base && <p className="mt-2 text-xs text-seal">{errors.base}</p>}
+      </form>
+    </section>
+  )
+}
+
+// ============================================================
+// Password 変更
+// ============================================================
+
+function PasswordSection() {
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [password, setPassword] = useState("")
+  const [passwordConfirmation, setPasswordConfirmation] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [success, setSuccess] = useState(false)
+
+  const mutation = useMutation<void, ApiError, void>({
+    mutationFn: () =>
+      api<void>("/auth/password", {
+        method: "PATCH",
+        body: {
+          current_password: currentPassword,
+          password,
+          password_confirmation: passwordConfirmation,
+        },
+      }),
+    onSuccess: () => {
+      setSuccess(true)
+      setErrors({})
+      setCurrentPassword("")
+      setPassword("")
+      setPasswordConfirmation("")
+    },
+    onError: (err) => {
+      setSuccess(false)
+      const errorMap: Record<string, string> = {}
+      const errorList = Array.isArray(err.errors) ? err.errors : []
+      errorList.forEach((e) => {
+        const item = e as { field?: string; message?: string; code?: string }
+        if (item.code === "invalid_password") errorMap.current_password = item.message ?? "現在のパスワードが正しくありません"
+        else if (item.field) errorMap[item.field] = item.message ?? "エラー"
+        else errorMap.base = item.message ?? "更新に失敗しました"
+      })
+      setErrors(errorMap)
+    },
+  })
+
+  return (
+    <section className="p-5 bg-parchment/60 border border-gold/40 rounded-sm">
+      <h3 className="font-serif text-base text-ink mb-3">パスワード変更</h3>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          mutation.mutate()
+        }}
+      >
+        <FormField
+          label="現在のパスワード"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          error={errors.current_password}
+          required
+        />
+        <FormField
+          label="新しいパスワード（6 文字以上）"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={errors.password}
+          required
+        />
+        <FormField
+          label="新しいパスワード（確認）"
+          type="password"
+          value={passwordConfirmation}
+          onChange={(e) => setPasswordConfirmation(e.target.value)}
+          error={errors.password_confirmation}
+          required
+        />
+        <Button variant="primary" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? "変更中..." : "パスワードを変更"}
+        </Button>
+        {success && <p className="mt-2 text-xs text-seal">✦ 変更しました</p>}
+        {errors.base && <p className="mt-2 text-xs text-seal">{errors.base}</p>}
+      </form>
+    </section>
+  )
+}
+
+// ============================================================
+// Logout
+// ============================================================
+
+function LogoutSection({ onLogout }: { onLogout: () => Promise<void> }) {
+  const mutation = useMutation<void, ApiError, void>({
+    mutationFn: () => api<void>("/auth/logout", { method: "DELETE" }),
+    onSuccess: onLogout,
+  })
+
+  return (
+    <section className="p-5 border border-ink/30 rounded-sm">
+      <h3 className="font-serif text-base text-ink mb-3">ログアウト</h3>
+      <Button variant="ghost" onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+        {mutation.isPending ? "処理中..." : "ログアウト"}
+      </Button>
+    </section>
+  )
+}
+
+export default SettingsPage

--- a/app/frontend/types/ranking.ts
+++ b/app/frontend/types/ranking.ts
@@ -1,0 +1,28 @@
+export type RankingUser = {
+  id: number
+  nickname: string
+  avatar_url: string | null
+}
+
+export type MonthlyRankingEntry = {
+  rank: number
+  user: RankingUser
+  achievement_count: number
+}
+
+export type StreakRankingEntry = {
+  rank: number
+  user: RankingUser
+  streak_count: number
+}
+
+export type MonthlyRankingResponse = {
+  month: string
+  rankings: MonthlyRankingEntry[]
+  my_rank: { rank: number | null; achievement_count: number }
+}
+
+export type StreakRankingResponse = {
+  rankings: StreakRankingEntry[]
+  my_rank: { rank: number | null; streak_count: number }
+}

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,9 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  # 30 日経過しても本登録に昇格していないゲストユーザーをクリーンアップ。
+  # 関連する Pact / CheckIn / Crest / Session / AiGeneration も dependent: :destroy で連鎖削除。
+  cleanup_expired_guests:
+    class: CleanupExpiredGuestsJob
+    queue: default
+    schedule: every day at 3am


### PR DESCRIPTION
## 概要

v1.1 体験ループの最終ピース。これで **「契約 → チェックイン → 達成 → 紋章 → ランキング → 設定（promote）」** の全周回が UI で動く状態に。

## 主な実装

### 1. ランキング画面（\`/rankings\`）

タブで切替：
- **連続日数**（\`GET /api/v1/rankings/streak\`）
- **今月の達成数**（\`GET /api/v1/rankings/monthly\`）

UI 工夫:
- 1〜3 位は 🥇 🥈 🥉、4 位以下は数字バッジ
- 自分の行は \`bg-seal/10\` でハイライト
- \`my_rank\` を別カード表示（圏外なら「圏外」）
- \`is_public=false\` ユーザーには「非表示中」の案内 → 設定画面で公開に切替可能と誘導

### 2. 設定画面（\`/settings\`）

5 セクション構成：

| セクション         | 表示条件          | 動作                                    |
| ------------------ | ----------------- | --------------------------------------- |
| **正式登録**      | ゲスト時のみ      | PATCH /auth/promote で本登録に昇格      |
| プロフィール       | 全員              | nickname / avatar_url / is_public 更新 |
| メールアドレス変更 | 登録済みのみ      | 現在のパスワード確認 + 新メアド         |
| パスワード変更     | 登録済みのみ      | 現在のパスワード確認 + 新パスワード     |
| ログアウト         | 全員              | DELETE /auth/logout                    |

#### Guest 体験ループの完成 🎯

PR #55 で BE 実装した Guest user モードの **FE 完成版**：

```
[HomePage] 「登録せずに試してみる」
   ↓
[ゲストとして契約作成・チェックイン・達成]
   ↓
[/settings] 「正式登録する」フォーム
   ↓
[これまでの誓約・チェックイン・紋章をそのまま引き継いで本登録ユーザーに昇格]
```

### 3. Layout ヘッダーナビ更新

「書庫」「殿堂」に「番付」「設定」を追加。

### 4. Solid Queue Cron 設定

\`config/recurring.yml\` に \`CleanupExpiredGuestsJob\` を **毎日 3am** で登録。
本番環境のみ有効（dev / test では走らない）。

## 設計のキモ

### \`react-hooks/purity\` 対応

「保存しました」を 3 秒表示する実装で、当初 \`Date.now()\` を render 内で呼んで lint エラー：

\`\`\`tsx
// ❌ NG
{savedAt && Date.now() - savedAt < 3000 && ...}

// ✅ OK
const [savedRecently, setSavedRecently] = useState(false)
onSuccess: () => {
  setSavedRecently(true)
  setTimeout(() => setSavedRecently(false), 3000)
}
{savedRecently && <span>...</span>}
\`\`\`

State 駆動 + setTimeout で同等の挙動を実現しつつ純粋性ルールに準拠。

### Guest / 登録済みでセクション出し分け

\`\`\`tsx
{user.is_guest && <PromoteSection />}
<ProfileSection user={user} />
{!user.is_guest && (
  <>
    <EmailSection />
    <PasswordSection />
  </>
)}
\`\`\`

ゲストはまだメアドもパスワードも持っていないので、これらのセクションは promote 完了後にだけ表示。

## 動作確認

ブラウザで通しシナリオを確認：

- [x] /rankings で streak / monthly タブ切替、自分の順位ハイライト
- [x] /settings でプロフィール編集 → 「✦ 保存しました」が 3 秒表示
- [x] ゲスト時の /settings：promote セクションのみ表示
- [x] 登録済みの /settings：promote 非表示、メール / パスワード変更可能
- [x] Layout のナビに「番付 / 設定」追加
- [x] is_public OFF のユーザーは /rankings で案内表示

### 自動チェック

- [x] \`./bin/rspec\` パス（247/247）
- [x] \`bundle exec rubocop\` クリーン
- [x] \`npm run lint\` / \`typecheck\` クリーン

## v1.1 完了状況 🎉

| 項目                                      | ステータス |
| ----------------------------------------- | ---------- |
| BE：CheckIn / Streak / 達成判定           | ✅         |
| BE：Crest / 紋章生成                      | ✅         |
| BE：AI ロギング / レート制限              | ✅         |
| BE：Guest user                            | ✅         |
| FE：契約作成 / 締結ページ                 | ✅         |
| FE：契約一覧 / 詳細 / 紋章ギャラリー       | ✅         |
| FE：**ランキング / 設定 / promote UI**    | ✅（今回） |
| Solid Queue Cron 設定                     | ✅（今回） |

**v1.1 の機能実装はこれで完了**。残るは v1.2 の #34 パスワードリセット / #32 i18n。