### PR TITLE
feat(i18n): バックエンド側 i18n 基盤と日本語化（locales/ja.yml）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "tailwindcss-rails"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
+# 日本語ロケール（バリデーション標準メッセージ等を ja に翻訳）
+gem "rails-i18n"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -453,6 +456,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 8.1.3)
+  rails-i18n
   rspec-rails
   rubocop-rails-omakase
   ruby-openai

--- a/app/controllers/api/v1/ai/base_controller.rb
+++ b/app/controllers/api/v1/ai/base_controller.rb
@@ -18,14 +18,14 @@ module Api
         def render_ai_parse_error(exception)
           Rails.logger.error("[AI parse error] #{exception.class}: #{exception.message}")
           render json: {
-            errors: [ { code: "ai_parse_error", message: "AI レスポンスを解釈できませんでした。再度お試しください。" } ]
+            errors: [ { code: "ai_parse_error", message: I18n.t("errors.api.ai_parse_error") } ]
           }, status: :bad_gateway
         end
 
         def render_ai_upstream_error(exception)
           Rails.logger.error("[AI upstream error] #{exception.class}: #{exception.message}")
           render json: {
-            errors: [ { code: "ai_upstream_error", message: "AI サービスに接続できませんでした。しばらくしてから再度お試しください。" } ]
+            errors: [ { code: "ai_upstream_error", message: I18n.t("errors.api.ai_upstream_error") } ]
           }, status: :bad_gateway
         end
       end

--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -5,7 +5,7 @@ module Api
         def update
           unless Current.user.authenticate(params[:current_password])
             render json: {
-              errors: [ { code: "invalid_password", message: "現在のパスワードが正しくありません" } ]
+              errors: [ { code: "invalid_password", message: I18n.t("errors.api.invalid_password") } ]
             }, status: :unauthorized
             return
           end

--- a/app/controllers/api/v1/auth/promotions_controller.rb
+++ b/app/controllers/api/v1/auth/promotions_controller.rb
@@ -8,7 +8,7 @@ module Api
         def update
           unless Current.user&.is_guest?
             render json: {
-              errors: [ { code: "not_a_guest", message: "登録済みユーザーは promote できません" } ]
+              errors: [ { code: "not_a_guest", message: I18n.t("errors.api.not_a_guest") } ]
             }, status: :unprocessable_entity
             return
           end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -13,7 +13,7 @@ module Api
             render json: UserSerializer.new(user).serializable_hash, status: :ok
           else
             render json: {
-              errors: [ { code: "invalid_credentials", message: "メールアドレスまたはパスワードが正しくありません" } ]
+              errors: [ { code: "invalid_credentials", message: I18n.t("errors.api.invalid_credentials") } ]
             }, status: :unauthorized
           end
         end

--- a/app/controllers/api/v1/auth/users_controller.rb
+++ b/app/controllers/api/v1/auth/users_controller.rb
@@ -14,7 +14,7 @@ module Api
         def update_email
           unless Current.user.authenticate(params[:current_password])
             render json: {
-              errors: [ { code: "invalid_password", message: "現在のパスワードが正しくありません" } ]
+              errors: [ { code: "invalid_password", message: I18n.t("errors.api.invalid_password") } ]
             }, status: :unauthorized
             return
           end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -29,7 +29,7 @@ module Authentication
     end
 
     def request_authentication
-      render json: { errors: [ { code: "unauthorized", message: "ログインが必要です" } ] }, status: :unauthorized
+      render json: { errors: [ { code: "unauthorized", message: I18n.t("errors.api.unauthorized") } ] }, status: :unauthorized
     end
 
     def start_new_session_for(user)

--- a/app/controllers/concerns/rate_limited.rb
+++ b/app/controllers/concerns/rate_limited.rb
@@ -19,7 +19,7 @@ module RateLimited
       errors: [
         {
           code: "rate_limit_exceeded",
-          message: "1 分間の AI 利用上限（#{AI_RATE_LIMIT} 回）を超えました。少し時間をおいて再度お試しください。"
+          message: I18n.t("errors.api.rate_limit_exceeded", limit: AI_RATE_LIMIT)
         }
       ]
     }, status: :too_many_requests

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -8,7 +8,7 @@ class PasswordsMailer < ApplicationMailer
     @reset_url = build_reset_url(token.token)
     @expires_in_minutes = (PasswordResetToken::EXPIRATION / 60).to_i
 
-    mail(to: @user.email, subject: "【Vow Pact】パスワード再設定のご案内")
+    mail(to: @user.email, subject: I18n.t("passwords_mailer.reset.subject"))
   end
 
   private

--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -30,18 +30,24 @@ class CheckIn < ApplicationRecord
 
   def checked_on_not_in_future
     return if checked_on.blank?
-    errors.add(:checked_on, "は未来の日付にできません") if checked_on > Time.zone.today
+    if checked_on > Time.zone.today
+      errors.add(:checked_on, I18n.t("activerecord.errors.models.check_in.attributes.checked_on.future_not_allowed"))
+    end
   end
 
   def checked_on_after_pact_signed_at
     return if checked_on.blank? || pact.blank? || pact.signed_at.blank?
     # pact.signed_at は datetime なので date に揃えて比較
-    errors.add(:checked_on, "は契約締結日以降である必要があります") if checked_on < pact.signed_at.to_date
+    if checked_on < pact.signed_at.to_date
+      errors.add(:checked_on, I18n.t("activerecord.errors.models.check_in.attributes.checked_on.before_signed_at"))
+    end
   end
 
   def pact_must_be_active
     return if pact.blank?
-    errors.add(:pact, "は active でなければなりません") unless pact.active?
+    unless pact.active?
+      errors.add(:pact, I18n.t("activerecord.errors.models.check_in.attributes.pact.must_be_active"))
+    end
   end
 
   def recalc_user_streak

--- a/app/models/crest.rb
+++ b/app/models/crest.rb
@@ -23,11 +23,14 @@ class Crest < ApplicationRecord
     return if crest_data.blank?
     missing = REQUIRED_CREST_DATA_KEYS - crest_data.keys.map(&:to_s)
     return if missing.empty?
-    errors.add(:crest_data, "は必須キー #{missing.join(', ')} を含む必要があります")
+    errors.add(:crest_data, I18n.t("activerecord.errors.models.crest.attributes.crest_data.missing_keys",
+                                    keys: missing.join(", ")))
   end
 
   def pact_must_be_completed
     return if pact.blank?
-    errors.add(:pact, "は completed 状態である必要があります") unless pact.completed?
+    unless pact.completed?
+      errors.add(:pact, I18n.t("activerecord.errors.models.crest.attributes.pact.must_be_completed"))
+    end
   end
 end

--- a/app/models/pact.rb
+++ b/app/models/pact.rb
@@ -38,7 +38,7 @@ class Pact < ApplicationRecord
     return if deadline.blank?
     return if deadline > Date.current
 
-    errors.add(:deadline, "must be in the future")
+    errors.add(:deadline, I18n.t("activerecord.errors.models.pact.attributes.deadline.must_be_future"))
   end
 
   def active_pacts_limit
@@ -47,7 +47,7 @@ class Pact < ApplicationRecord
     active_count = user.pacts.where(status: :active).where.not(id: id).count
     return if active_count < MAX_ACTIVE_PACTS
 
-    errors.add(:base, "active な契約は#{MAX_ACTIVE_PACTS}つまでです")
+    errors.add(:base, I18n.t("activerecord.errors.models.pact.too_many_active", limit: MAX_ACTIVE_PACTS))
   end
 
   def strip_text_fields

--- a/app/models/password_reset_token.rb
+++ b/app/models/password_reset_token.rb
@@ -31,8 +31,8 @@ class PasswordResetToken < ApplicationRecord
   def consume!(password:, password_confirmation:)
     with_lock do
       # ロック取得後に最新の DB 値で再判定する（reload は with_lock が暗黙に行う）
-      raise ArgumentError, "既に使用済みのトークンです" if used?
-      raise ArgumentError, "期限切れのトークンです" if expired?
+      raise ArgumentError, I18n.t("errors.api.already_used_token") if used?
+      raise ArgumentError, I18n.t("errors.api.expired_token") if expired?
 
       user.update!(password: password, password_confirmation: password_confirmation)
       update!(used_at: Time.current)

--- a/app/views/passwords_mailer/reset.html.erb
+++ b/app/views/passwords_mailer/reset.html.erb
@@ -1,26 +1,25 @@
 <div style="font-family: 'Noto Sans JP', system-ui, sans-serif; color: #2c1810; line-height: 1.7;">
-  <p><%= @user.nickname %> 様</p>
+  <p><%= t("passwords_mailer.reset.greeting", nickname: @user.nickname) %></p>
 
-  <p>Vow Pact のパスワード再設定リクエストを受け付けました。<br>
-  下のボタンから新しいパスワードを設定してください。</p>
+  <p><%= t("passwords_mailer.reset.body") %></p>
 
   <p style="margin: 24px 0;">
     <a href="<%= @reset_url %>"
        style="display: inline-block; padding: 12px 24px; background: #8b1a1a; color: #f4e8d0;
               text-decoration: none; border-radius: 2px; font-weight: bold;">
-      パスワードを再設定する
+      <%= t("passwords_mailer.reset.cta") %>
     </a>
   </p>
 
   <p style="font-size: 12px; color: #2c1810aa;">
-    ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてください。<br>
+    <%= t("passwords_mailer.reset.fallback") %><br>
     <a href="<%= @reset_url %>" style="color: #8b1a1a;"><%= @reset_url %></a>
   </p>
 
   <p style="font-size: 12px; color: #2c1810aa;">
-    このリンクは <%= @expires_in_minutes %> 分で失効します。<br>
-    リクエストに心当たりがない場合は、このメールを破棄してください。
+    <%= t("passwords_mailer.reset.expires_in", minutes: @expires_in_minutes) %><br>
+    <%= t("passwords_mailer.reset.not_requested") %>
   </p>
 
-  <p style="font-size: 11px; color: #2c181080; margin-top: 32px;">— Vow Pact</p>
+  <p style="font-size: 11px; color: #2c181080; margin-top: 32px;"><%= t("passwords_mailer.reset.signature") %></p>
 </div>

--- a/app/views/passwords_mailer/reset.text.erb
+++ b/app/views/passwords_mailer/reset.text.erb
@@ -1,11 +1,10 @@
-<%= @user.nickname %> 様
+<%= t("passwords_mailer.reset.greeting", nickname: @user.nickname) %>
 
-Vow Pact のパスワード再設定リクエストを受け付けました。
-以下の URL にアクセスして、新しいパスワードを設定してください。
+<%= t("passwords_mailer.reset.body") %>
 
 <%= @reset_url %>
 
-このリンクは <%= @expires_in_minutes %> 分で失効します。
-リクエストに心当たりがない場合は、このメールを破棄してください。
+<%= t("passwords_mailer.reset.expires_in", minutes: @expires_in_minutes) %>
+<%= t("passwords_mailer.reset.not_requested") %>
 
-— Vow Pact
+<%= t("passwords_mailer.reset.signature") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,11 @@ module VowPact
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # i18n（多言語対応）
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = %i[ja]
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{yml,rb}")]
+    # ネストしたディレクトリ（locales/models/*.yml 等）も読み込む
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,215 @@
+ja:
+  # ============================================================
+  # ActiveRecord 標準
+  # ============================================================
+  activerecord:
+    models:
+      user: "ユーザー"
+      pact: "誓約"
+      check_in: "チェックイン"
+      crest: "紋章"
+      ai_generation: "AI 生成履歴"
+      password_reset_token: "パスワード再設定トークン"
+
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+        nickname: "ニックネーム"
+        avatar_url: "アバター URL"
+        is_public: "公開設定"
+        is_guest: "ゲスト"
+        streak_count: "連続記録"
+        longest_streak: "最長記録"
+        current_password: "現在のパスワード"
+      pact:
+        goal: "目標"
+        constraint_text: "制約"
+        difficulty: "難易度"
+        difficulty_reason: "難易度の理由"
+        deadline: "期日"
+        signed_at: "締結日時"
+        completed_at: "達成日時"
+        status: "状態"
+        title: "称号"
+      check_in:
+        pact: "誓約"
+        checked_on: "チェックイン日"
+        status: "状態"
+        note: "メモ"
+      crest:
+        pact: "誓約"
+        rarity: "レアリティ"
+        crest_data: "紋章データ"
+        generated_at: "生成日時"
+      password_reset_token:
+        token: "トークン"
+        expires_at: "有効期限"
+        used_at: "使用日時"
+
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+
+      models:
+        pact:
+          attributes:
+            deadline:
+              must_be_future: "は未来の日付を指定してください"
+          too_many_active: "進行中の誓約は最大 %{limit} つまでです"
+        check_in:
+          attributes:
+            checked_on:
+              future_not_allowed: "は未来の日付にできません"
+              before_signed_at: "は契約締結日以降である必要があります"
+            pact:
+              must_be_active: "は active でなければなりません"
+        crest:
+          attributes:
+            crest_data:
+              missing_keys: "は必須キー %{keys} を含む必要があります"
+            pact:
+              must_be_completed: "は completed 状態である必要があります"
+
+  # ============================================================
+  # Vow Pact 固有
+  # ============================================================
+  pacts:
+    headings:
+      new: "新たな誓いを立てる"
+      list: "誓約の書庫"
+      detail: "誓約の詳細"
+      signed: "誓いは刻まれた"
+    statuses:
+      active: "進行中"
+      completed: "達成"
+      failed: "失敗"
+      abandoned: "破棄"
+    buttons:
+      sign: "ここに誓う"
+      next: "次へ"
+      back: "戻る"
+      abandon: "誓いを破棄する"
+    messages:
+      signed: "本書に記された誓いは、あなた自身との不動の契約となる。"
+      completed: "成就せり"
+
+  check_ins:
+    statuses:
+      kept: "守れた"
+      broken: "破れた"
+      skipped: "休戦"
+    buttons:
+      submit: "記録する"
+
+  crests:
+    headings:
+      gallery: "誓約の殿堂"
+    rarities:
+      common: "通常"
+      rare: "稀少"
+      epic: "英雄"
+      legendary: "伝説"
+    labels:
+      common: "Common"
+      rare: "Rare"
+      epic: "Epic"
+      legendary: "Legendary"
+
+  rankings:
+    headings:
+      title: "誓約者の番付"
+      streak: "連続日数"
+      monthly: "今月の達成数"
+    labels:
+      my_rank: "あなたの順位"
+      out_of_rank: "圏外"
+      you: "あなた"
+      private_notice: "あなたは「ランキング非表示」設定です。一覧には載りませんが、自分の順位は見えます。"
+
+  ai:
+    buttons:
+      suggest_goal: "AI に提案してもらう"
+      suggest_random: "おまかせで提案してもらう"
+      suggest_constraint: "AI に提案してもらう"
+      judge_difficulty: "難易度を判定"
+      generate_title: "称号を授かる"
+    placeholders:
+      theme: "例：健康、学習、創作"
+    messages:
+      suggesting: "提案中..."
+      failed: "提案を取得できませんでした。再度お試しください。"
+
+  share:
+    buttons:
+      signed: "𝕏で天下に宣する"
+      check_in: "𝕏で歩みを刻む"
+      fulfilled: "𝕏で栄光を示す"
+
+  auth:
+    headings:
+      login: "ログイン"
+      signup: "新規登録"
+      forgot_password: "パスワードをお忘れですか"
+      reset_password: "新しいパスワードを設定"
+    buttons:
+      login: "ここに誓う"
+      signup: "誓約を交わす"
+      logout: "ログアウト"
+      guest_start: "登録せずに試してみる"
+      forgot_password_link: "パスワードを忘れた方"
+      send_reset_link: "再設定リンクを送る"
+      update_password: "パスワードを更新"
+      back_to_login: "ログイン画面へ戻る"
+    messages:
+      reset_email_sent: "再設定リンクを記載したメールを送信しました（該当アカウントが存在する場合）"
+      password_updated: "パスワードを更新しました"
+      send_failed: "送信に失敗しました。ネットワーク接続を確認するか、しばらくしてから再度お試しください。"
+      invalid_token_title: "リンクが無効です"
+      invalid_token_message: "このリンクは期限切れか、既に使用されています。再度パスワード再設定リクエストをお送りください。"
+      network_error_title: "通信エラー"
+      network_error_message: "サーバーに接続できませんでした。ネットワーク接続を確認のうえ、ページを再読み込みしてください。"
+
+  settings:
+    headings:
+      title: "設定"
+      profile: "プロフィール"
+      email_change: "メールアドレス変更"
+      password_change: "パスワード変更"
+      logout: "ログアウト"
+      promote: "正式登録する"
+    messages:
+      saved: "保存しました"
+      promote_completed: "正式登録が完了しました。これからもよろしく。"
+      promote_description: "メールアドレスとパスワードを登録すると、これまでの誓約・チェックイン・紋章がそのまま引き継がれます。30 日経過すると自動で削除されます。"
+
+  # API エラーレスポンス内のメッセージ
+  errors:
+    api:
+      not_found: "リソースが見つかりません"
+      unauthorized: "認証が必要です"
+      rate_limit_exceeded: "1 分間の AI 利用上限（%{limit} 回）を超えました。少し時間をおいて再度お試しください。"
+      invalid_password: "現在のパスワードが正しくありません"
+      invalid_credentials: "メールアドレスまたはパスワードが正しくありません"
+      ai_parse_error: "AI レスポンスを解釈できませんでした。再度お試しください。"
+      ai_upstream_error: "AI サービスに接続できませんでした。しばらくしてから再度お試しください。"
+      not_a_guest: "登録済みユーザーは promote できません"
+      invalid_or_expired_token: "リンクが無効または期限切れです"
+      already_used_token: "既に使用済みのトークンです"
+      expired_token: "期限切れのトークンです"
+
+  # メール本文
+  passwords_mailer:
+    reset:
+      subject: "【Vow Pact】パスワード再設定のご案内"
+      greeting: "%{nickname} 様"
+      body: "Vow Pact のパスワード再設定リクエストを受け付けました。下のリンクから新しいパスワードを設定してください。"
+      cta: "パスワードを再設定する"
+      fallback: "ボタンが動作しない場合は、以下の URL をブラウザに貼り付けてください。"
+      expires_in: "このリンクは %{minutes} 分で失効します。"
+      not_requested: "リクエストに心当たりがない場合は、このメールを破棄してください。"
+      signature: "— Vow Pact"

--- a/spec/models/pact_spec.rb
+++ b/spec/models/pact_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Pact, type: :model do
       it "必須" do
         pact = build(:pact, goal: nil)
         expect(pact).not_to be_valid
-        expect(pact.errors[:goal]).to include("can't be blank")
+        expect(pact.errors[:goal]).to be_present
       end
 
       it "1〜500文字" do
@@ -63,7 +63,7 @@ RSpec.describe Pact, type: :model do
       it "必須" do
         pact = build(:pact, constraint_text: nil)
         expect(pact).not_to be_valid
-        expect(pact.errors[:constraint_text]).to include("can't be blank")
+        expect(pact.errors[:constraint_text]).to be_present
       end
 
       it "1〜500文字" do
@@ -76,7 +76,7 @@ RSpec.describe Pact, type: :model do
       it "必須" do
         pact = build(:pact, difficulty: nil)
         expect(pact).not_to be_valid
-        expect(pact.errors[:difficulty]).to include("can't be blank")
+        expect(pact.errors[:difficulty]).to be_present
       end
 
       it "1〜5の整数" do
@@ -91,7 +91,7 @@ RSpec.describe Pact, type: :model do
       it "必須" do
         pact = build(:pact, deadline: nil)
         expect(pact).not_to be_valid
-        expect(pact.errors[:deadline]).to include("can't be blank")
+        expect(pact.errors[:deadline]).to be_present
       end
 
       it "未来の日付（新規作成時のみ検証）" do
@@ -99,7 +99,7 @@ RSpec.describe Pact, type: :model do
         # 過去日は弾く
         past_pact = build(:pact, deadline: 1.day.ago.to_date)
         expect(past_pact).not_to be_valid
-        expect(past_pact.errors[:deadline]).to include("must be in the future")
+        expect(past_pact.errors[:deadline]).to be_present
         # 既存 pact は更新時に過去日でも valid（期日切れは状態として許容）
         existing = create(:pact, deadline: 1.day.from_now.to_date)
         existing.update(goal: "新しい目標")
@@ -120,7 +120,7 @@ RSpec.describe Pact, type: :model do
         7.times { create(:pact, user: user, status: :active) }
         eighth = build(:pact, user: user, status: :active)
         expect(eighth).not_to be_valid
-        expect(eighth.errors[:base]).to include("active な契約は7つまでです")
+        expect(eighth.errors[:base]).to be_present
       end
 
       it "completed / abandoned はカウントしない（8つ目作成可能）" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,20 +13,20 @@ RSpec.describe User, type: :model do
       it "必須" do
         user = build(:user, email: nil)
         expect(user).not_to be_valid
-        expect(user.errors[:email]).to include("can't be blank")
+        expect(user.errors[:email]).to be_present
       end
 
       it "メール形式チェック" do
         user = build(:user, email: "not-an-email")
         expect(user).not_to be_valid
-        expect(user.errors[:email]).to include("is invalid")
+        expect(user.errors[:email]).to be_present
       end
 
       it "重複は不可（大文字小文字無視）" do
         create(:user, email: "test@example.com")
         duplicate = build(:user, email: "TEST@example.com")
         expect(duplicate).not_to be_valid
-        expect(duplicate.errors[:email]).to include("has already been taken")
+        expect(duplicate.errors[:email]).to be_present
       end
 
       it "DB レベルの UNIQUE 制約も大文字小文字無視（バリデーションをすり抜けても止まる）" do
@@ -43,7 +43,7 @@ RSpec.describe User, type: :model do
       it "必須" do
         user = build(:user, nickname: nil)
         expect(user).not_to be_valid
-        expect(user.errors[:nickname]).to include("can't be blank")
+        expect(user.errors[:nickname]).to be_present
       end
 
       it "1〜30文字" do
@@ -57,13 +57,13 @@ RSpec.describe User, type: :model do
       it "必須（新規作成時）" do
         user = User.new(email: "x@example.com", nickname: "X", password: nil)
         expect(user).not_to be_valid
-        expect(user.errors[:password]).to include("can't be blank")
+        expect(user.errors[:password]).to be_present
       end
 
       it "6文字以上" do
         user = build(:user, password: "12345")
         expect(user).not_to be_valid
-        expect(user.errors[:password]).to include("is too short (minimum is 6 characters)")
+        expect(user.errors[:password]).to be_present
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe User, type: :model do
       create(:user, email: "test@example.com")
       duplicate = build(:user, email: "  TEST@example.com  ")
       expect(duplicate).not_to be_valid
-      expect(duplicate.errors[:email]).to include("has already been taken")
+      expect(duplicate.errors[:email]).to be_present
     end
   end
 


### PR DESCRIPTION
## 概要

Issue #32（i18n 対応）の **段階的実装の前半**。バックエンド側の i18n 基盤を整え、ja.yml に文言を集約。
**FE 側の文言抽出は後続 PR に分離**（規模が大きいため）。

## スコープ

| 観点                              | 今 PR | 後続 PR             |
| --------------------------------- | ----- | ------------------- |
| rails-i18n 導入                   | ✅    | -                   |
| default_locale = :ja              | ✅    | -                   |
| ActiveRecord 標準メッセージ ja 化 | ✅    | -                   |
| カスタムバリデーション ja.yml 化  | ✅    | -                   |
| Controller エラーレスポンス ja 化 | ✅    | -                   |
| Mailer 件名・本文 ja.yml 化       | ✅    | -                   |
| spec の英語メッセージ依存解消     | ✅    | -                   |
| FE：i18n ライブラリ導入           | -     | ⏳ 別 PR           |
| FE：全画面の文言を t() に置換    | -     | ⏳ 別 PR           |
| 英語版 (en.yml)                   | -     | v2 以降             |

### 段階的実装の理由

FE の文言抽出は **対象 15 ファイル / 文字列約 200 個** の機械的だが規模大の作業。
**1 PR にまとめるとレビュー困難**になるため、BE 完了で一旦区切る。

## 主な実装

### 1. rails-i18n 導入

- \`Gemfile\` に \`gem "rails-i18n"\` を追加
- \`config/application.rb\`：
  - \`default_locale = :ja\`
  - \`available_locales = %i[ja]\`
  - load_path をネスト対応（locales/models/*.yml 等）

### 2. config/locales/ja.yml の網羅整備

セクション構成：

\`\`\`
activerecord:
  models:        # User / Pact / CheckIn / Crest / AiGeneration / PasswordResetToken
  attributes:    # 各モデルのカラム表示名
  errors:
    models:      # カスタムバリデーションメッセージ

pacts: / check_ins: / crests: / rankings:   # FE 用見出し・ステータス・ボタン
ai:                                          # AI 操作ボタン
share:                                       # 𝕏 シェアボタン
auth:                                        # ログイン / 登録 / リセット系
settings:                                    # プロフィール編集等

errors:
  api:           # 不正パスワード / レート制限 / トークン関連 等

passwords_mailer:
  reset:         # メール本文
\`\`\`

### 3. モデル / コントローラ / Mailer のハードコード解消

| ファイル                            | 内容                                                  |
| ----------------------------------- | ----------------------------------------------------- |
| Pact / CheckIn / Crest              | カスタムバリデーションを I18n.t                      |
| PasswordResetToken#consume!         | ArgumentError メッセージを I18n.t                    |
| Authentication concern              | unauthorized レスポンス                               |
| RateLimited concern                 | rate_limit_exceeded（%{limit} 補間）                  |
| passwords / users / promotions /   |                                                       |
| sessions / ai/base_controller       | 全 controller のエラーレスポンス                      |
| PasswordsMailer + reset テンプレ    | 件名・本文を I18n.t                                  |

### 4. spec の英語メッセージ依存を解消

```ruby
# Before
expect(record.errors[:email]).to include("can't be blank")

# After
expect(record.errors[:email]).to be_present
```

→ default_locale を切り替えても spec が落ちない。**ロケール独立な spec** に。

## 動作確認

- [x] \`./bin/rspec\` パス（**281/281**、全テスト青）
- [x] \`bundle exec rubocop\` クリーン
- [x] バリデーションエラーが日本語で返る（手動確認）

## 残作業（後続 PR で対応）

- FE：i18n ライブラリ（react-i18next 等）導入
- FE：locales/ja.json 作成 + 全画面の文言を \`t()\` 置換
- FE：useTranslation hook での参照
- v2：英語版（en.yml / en.json）
- v2：ロケール切替 UI

closes #32 の **第 1 段（BE）**。FE は別 PR で完了予定。