### PR TITLE
fix: /p/:id の OGP meta タグをサーバーサイドで埋め込む（X カード表示対応）

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,4 +7,12 @@ class HomeController < ActionController::Base
 
   def index
   end
+
+  # 公開契約ページ（/p/:id）。
+  # X クローラーは JS を実行しないため、OGP meta タグを HTML に直接埋め込んで配信する。
+  # 公開設定 OFF / 存在しない id でも 200 で SPA を返し、React 側で「見つかりません」を表示。
+  def public_pact
+    @pact = Pact.where(is_public: true).includes(:user).find_by(id: params[:id])
+    render :index
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,28 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%# 公開契約ページ（/p/:id）の OGP / Twitter Card meta タグ。
+        SPA の useEffect で注入する meta は X クローラーから見えないため、
+        サーバーサイドで HTML に直接埋め込む。 %>
+    <% if defined?(@pact) && @pact.present? %>
+      <% page_url    = "#{request.protocol}#{request.host_with_port}/p/#{@pact.id}" %>
+      <% image_url   = "#{request.protocol}#{request.host_with_port}/api/v1/public/pacts/#{@pact.id}/og.png" %>
+      <% nickname    = @pact.user&.nickname.presence || "誓約者" %>
+      <% page_title  = "#{nickname} の誓約：#{@pact.goal}" %>
+      <% description = "目標：#{@pact.goal} ／ 制約：#{@pact.constraint_text} ／ 期日：#{@pact.deadline}" %>
+      <meta name="description"          content="<%= description %>">
+      <meta property="og:title"         content="<%= page_title %>">
+      <meta property="og:description"   content="<%= description %>">
+      <meta property="og:url"           content="<%= page_url %>">
+      <meta property="og:image"         content="<%= image_url %>">
+      <meta property="og:type"          content="article">
+      <meta property="og:site_name"     content="Vow Pact">
+      <meta name="twitter:card"         content="summary_large_image">
+      <meta name="twitter:title"        content="<%= page_title %>">
+      <meta name="twitter:description"  content="<%= description %>">
+      <meta name="twitter:image"        content="<%= image_url %>">
+    <% end %>
+
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # 公開契約ページ。X クローラーは JS を実行しないため、og:image / twitter:card 等の OGP meta を
+  # サーバーサイドで HTML に埋め込む必要がある。SPA fallback より前に定義する。
+  get "/p/:id", to: "home#public_pact", constraints: { id: /\d+/ }, as: :public_pact_share
+
   root "home#index"
   get "*path", to: "home#index", constraints: ->(req) {
     !req.path.start_with?("/api", "/up", "/rails", "/letter_opener")

--- a/spec/requests/public_pact_share_spec.rb
+++ b/spec/requests/public_pact_share_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+# /p/:id は X クローラー（Twitterbot 等）が JS を実行しなくても OGP を取得できるよう、
+# サーバーサイドで og:* / twitter:* meta タグを HTML に埋め込んで配信するルート。
+RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
+  let!(:user) do
+    create(:user, nickname: "テスト誓約者", email: "share@example.com",
+                  password: "password123", password_confirmation: "password123")
+  end
+
+  describe "GET /p/:id" do
+    context "is_public=true の契約の場合" do
+      let!(:pact) do
+        # validate スキップで is_public=true な契約を作る
+        p = build(:pact, user: user, goal: "毎日 30 分読書する",
+                          constraint_text: "夜 22 時以降スマホを触らない",
+                          deadline: Date.parse("2026-06-30"))
+        p.is_public = true
+        p.save!(validate: false)
+        p
+      end
+
+      it "200 OK で HTML を返す" do
+        get "/p/#{pact.id}"
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/html")
+      end
+
+      it "og:image / twitter:card 等の OGP meta タグを HTML に直接埋め込む" do
+        get "/p/#{pact.id}"
+        body = response.body
+
+        # 主要 meta が存在すること
+        expect(body).to include('property="og:title"')
+        expect(body).to include('property="og:description"')
+        expect(body).to include('property="og:image"')
+        expect(body).to include('property="og:url"')
+        expect(body).to include('name="twitter:card"')
+        expect(body).to include('content="summary_large_image"')
+
+        # OG image URL は API エンドポイントを指す
+        expect(body).to include("/api/v1/public/pacts/#{pact.id}/og.png")
+
+        # 契約の中身が description / title に入っている
+        expect(body).to include("毎日 30 分読書する")
+        expect(body).to include("夜 22 時以降スマホを触らない")
+        expect(body).to include("テスト誓約者")
+      end
+    end
+
+    context "is_public=false の契約の場合" do
+      let!(:private_pact) do
+        p = build(:pact, user: user, goal: "ひみつの目標",
+                          deadline: Date.parse("2026-06-30"))
+        p.is_public = false
+        p.save!(validate: false)
+        p
+      end
+
+      it "200 OK だが OGP meta は付かない（React 側で「見つかりません」表示）" do
+        get "/p/#{private_pact.id}"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('property="og:image"')
+        expect(response.body).not_to include("ひみつの目標")
+      end
+    end
+
+    context "存在しない id の場合" do
+      it "200 OK だが OGP meta は付かない" do
+        get "/p/999999"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('property="og:image"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 問題

X の Card Validator で公開契約 URL を検証すると：

\`\`\`
INFO:  Page fetched successfully
INFO:  8 metatags were found
ERROR: No card found (Card error)
\`\`\`

HTML には meta が 8 個見つかったが、その中に \`twitter:card\` 系が無く、カードを生成できない状態だった。

## 原因

- 公開契約ページ \`/p/:id\` は React の SPA でレンダリングされる
- \`PublicPactPage.tsx\` は \`useEffect\` 内で og:image / twitter:card 等の meta タグを動的注入
- **Twitterbot は JavaScript を実行しない**ため、初期 HTML には Twitter Card 系の meta が無い → カード生成不可

## 対応

サーバーサイドで HTML を返す時点で OGP meta を埋め込む構成に変更。

### routes.rb
\`/p/:id\` を SPA fallback より前に分岐：
\`\`\`ruby
get "/p/:id", to: "home#public_pact", constraints: { id: /\\d+/ }
\`\`\`

### HomeController#public_pact
- \`is_public=true\` の Pact を読み込んで \`@pact\` に格納
- 公開設定 OFF / 存在しない id でも 200 で SPA を返し、React 側で「見つかりません」を表示

### application.html.erb
\`@pact\` が存在するときのみ \`og:title / og:description / og:image / og:url / og:type / og:site_name / twitter:card / twitter:title / twitter:description / twitter:image\` を直接埋め込み。

### React 側の useEffect 注入は残す
SPA 内遷移時（例: 別ページから \`/p/:id\` にナビゲート）に meta を更新する用途。\`setMetaTag\` は既存の meta 要素を上書きするので、SSR で埋めた meta と衝突しない。

## 動作確認

- [x] \`bundle exec rspec\`: **288 / 0**
- [x] \`bundle exec rubocop\`: クリーン
- [x] \`npm run test\`: **17 / 17**
- [x] \`npm run lint\`: クリーン
- [x] \`npx tsc --noEmit\`: クリーン
- [x] 新規 spec \`public_pact_share_spec.rb\` で SSR meta が HTML に含まれること、非公開/存在しない id では含まれないことを検証

## マージ後の確認手順

1. Render で再デプロイされたら、本番で公開契約 URL を作成
2. X の Card Validator (\`https://cards-dev.x.com/validator\`) に URL を入力
3. 「Card found」になり、契約書 PNG（1200×630）がプレビューに表示されることを確認