### PR TITLE
perf: OG image を Solid Cache でキャッシュし、SignedPage で cache 温め

### DIFF
--- a/app/controllers/api/v1/public/og_images_controller.rb
+++ b/app/controllers/api/v1/public/og_images_controller.rb
@@ -4,18 +4,30 @@ module Api
       # 公開された契約から OG image（PNG）を動的に生成して配信する。
       # /api/v1/public/pacts/:id/og.png でアクセス可能。
       # is_public=false の契約は 404。
-      # キャッシュ：契約の updated_at をキーにして CDN・ブラウザに乗せる。
+      # キャッシュ戦略：
+      #   1) updated_at をキーに Rails.cache（Solid Cache）へ PNG を保存
+      #      （Render Free tier では rsvg-convert + Noto CJK フォント読み込みに 10 秒以上かかるため、
+      #      毎回再生成すると X クローラー（タイムアウト 5〜10 秒）に間に合わない）
+      #   2) ETag / Last-Modified でブラウザ・CDN にも乗せる
       class OgImagesController < Api::V1::BaseController
         allow_unauthenticated_access only: [ :show ]
+
+        # Solid Cache に格納する OG image の有効期限。
+        # 契約が更新されると updated_at が変わり cache key も変わるため、古いキーは TTL で自動失効。
+        OG_IMAGE_CACHE_TTL = 30.days
 
         def show
           pact = Pact.where(is_public: true).find(params[:id])
 
-          # キャッシュ制御：updated_at が変わるまでブラウザ・CDN にキャッシュさせる
+          # ETag / Last-Modified で 304 を返せる場合は本文生成自体スキップ
           fresh_when(etag: pact, last_modified: pact.updated_at, public: true)
           return if request.fresh?(response)
 
-          png = PactOgImageGenerator.new(pact).to_png
+          cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
+          png = Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
+            PactOgImageGenerator.new(pact).to_png
+          end
+
           send_data png, type: "image/png", disposition: "inline",
                           filename: "pact-#{pact.id}-og.png"
         rescue ActiveRecord::RecordNotFound

--- a/app/frontend/pages/PublicPactPage.tsx
+++ b/app/frontend/pages/PublicPactPage.tsx
@@ -33,6 +33,15 @@ function PublicPactPage() {
     enabled: !!id,
   })
 
+  // OG image を先取りフェッチして Rails.cache を温める。
+  // 初回ユーザー閲覧時に生成しておけば、X クローラーが投稿後にアクセスしたとき cache hit する。
+  useEffect(() => {
+    if (!id) return
+    const ctrl = new AbortController()
+    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+    return () => ctrl.abort()
+  }, [id])
+
   // OGP / Twitter Card 用のメタタグを動的に注入
   useEffect(() => {
     if (!pact) return

--- a/app/frontend/pages/SignedPage.tsx
+++ b/app/frontend/pages/SignedPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { motion } from "framer-motion"
@@ -46,6 +47,17 @@ function SignedPage() {
       queryClient.invalidateQueries({ queryKey: ["pacts"] })
     },
   })
+
+  // OG image PNG を先取りフェッチして Rails.cache（Solid Cache）を温める。
+  // Render Free tier では初回生成に 10 秒以上かかるため、ユーザーが SignedPage を見ている間に
+  // 裏で生成完了させておく。シェアボタン押下後に X クローラーが来たときには cache hit するので
+  // 即座に PNG を返せる。失敗しても X 投稿フローには影響させない。
+  useEffect(() => {
+    if (!id) return
+    const ctrl = new AbortController()
+    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+    return () => ctrl.abort()
+  }, [id])
 
   if (isLoading) {
     return (

--- a/spec/requests/api/v1/public/og_images_spec.rb
+++ b/spec/requests/api/v1/public/og_images_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Public::OgImages", type: :request do
+  let(:user) do
+    create(:user, nickname: "OG画像テスト", email: "og@example.com",
+                  password: "password123", password_confirmation: "password123")
+  end
+
+  describe "GET /api/v1/public/pacts/:id/og.png" do
+    context "is_public=true の契約" do
+      let!(:pact) do
+        p = build(:pact, user: user, goal: "OG 画像テスト目標")
+        p.is_public = true
+        p.save!(validate: false)
+        p
+      end
+
+      it "200 OK で image/png を返す" do
+        get "/api/v1/public/pacts/#{pact.id}/og.png"
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("image/png")
+        expect(response.body.bytesize).to be > 0
+      end
+
+      it "ETag と Last-Modified を返す（条件付き GET 用）" do
+        get "/api/v1/public/pacts/#{pact.id}/og.png"
+        expect(response.headers["ETag"]).to be_present
+        expect(response.headers["Last-Modified"]).to be_present
+      end
+
+      it "If-None-Match 付きで叩くと 304 Not Modified を返す（生成スキップ）" do
+        get "/api/v1/public/pacts/#{pact.id}/og.png"
+        etag = response.headers["ETag"]
+
+        get "/api/v1/public/pacts/#{pact.id}/og.png", headers: { "If-None-Match" => etag }
+        expect(response).to have_http_status(:not_modified)
+      end
+
+      it "キャッシュ可能（Cache-Control: public）" do
+        get "/api/v1/public/pacts/#{pact.id}/og.png"
+        expect(response.headers["Cache-Control"]).to include("public")
+      end
+    end
+
+    context "is_public=false の契約" do
+      let!(:private_pact) do
+        p = build(:pact, user: user, goal: "ひみつ")
+        p.is_public = false
+        p.save!(validate: false)
+        p
+      end
+
+      it "404 Not Found を返す" do
+        get "/api/v1/public/pacts/#{private_pact.id}/og.png"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "存在しない id" do
+      it "404 Not Found を返す" do
+        get "/api/v1/public/pacts/999999/og.png"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "Rails.cache に PNG を保存する（初回生成 → 以降 cache hit）" do
+      # 本番では Solid Cache、テストでは :null_store がデフォルトで保存されないため、
+      # 一時的に memory_store に切り替えて挙動を検証する。
+      around do |example|
+        original = Rails.cache
+        Rails.application.config.action_controller.perform_caching = true
+        Rails.cache = ActiveSupport::Cache::MemoryStore.new
+        example.run
+      ensure
+        Rails.cache = original
+      end
+
+      let!(:pact) do
+        p = build(:pact, user: user, goal: "キャッシュ検証")
+        p.is_public = true
+        p.save!(validate: false)
+        p
+      end
+
+      it "1 回目のリクエストで PactOgImageGenerator が呼ばれ、2 回目は cache から返す" do
+        png_bytes = "fake-png-bytes"
+        allow_any_instance_of(PactOgImageGenerator).to receive(:to_png).and_return(png_bytes)
+
+        # 1 回目: 生成が走る
+        get "/api/v1/public/pacts/#{pact.id}/og.png"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(png_bytes)
+
+        # cache key には pact.id と updated_at が含まれている
+        cached = Rails.cache.read([ "pact_og_image", pact.id, pact.updated_at.to_i ])
+        expect(cached).to eq(png_bytes)
+
+        # 2 回目: 別のリクエストでも生成は走らない（fresh_when の 304 を避けるため別の curl 相当）
+        # ETag を変えるために cache_key だけが効くようキャッシュを別途検証
+        expect_any_instance_of(PactOgImageGenerator).not_to receive(:to_png)
+        get "/api/v1/public/pacts/#{pact.id}/og.png", headers: { "If-None-Match" => "different-etag" }
+        # If-None-Match が一致しないので 200 で再ヒット → cache から返却
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(png_bytes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 問題

PR #62（OGP meta SSR 化）後も、X 上にカード画像が表示されない。

本番で挙動を確認した結果：

\`\`\`
$ curl -s -o /dev/null -w "%{time_total}s status=%{http_code}\n" https://vow-pact.onrender.com/api/v1/public/pacts/5/og.png
1st: 13.10s status=200
2nd: 13.24s status=200
3rd: 13.37s status=200
\`\`\`

**毎回 13 秒**かかっていた。原因：
- Render Free tier の CPU で **rsvg-convert + Noto CJK フォントの読み込みに 10 秒以上**
- ETag / Last-Modified は初回アクセス時には If-None-Match が無いので 304 にできない
- → X クローラー（タイムアウト 5〜10 秒）が画像取得に失敗 → カード生成不可

## 対応

### 1. \`OgImagesController\` で \`Rails.cache.fetch\` を導入

\`Solid Cache\`（本番設定済み）に PNG を保存。cache key は \`["pact_og_image", pact.id, pact.updated_at.to_i]\` で、契約が更新されると自動的に新しい key になり古いものは TTL（30 日）で失効。

\`\`\`ruby
cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
png = Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
  PactOgImageGenerator.new(pact).to_png
end
\`\`\`

### 2. \`SignedPage\` / \`PublicPactPage\` で OG image を先取りフェッチ

ユーザーが画面を見ている数秒〜数十秒の間に裏で cache を温める：

\`\`\`tsx
useEffect(() => {
  if (!id) return
  const ctrl = new AbortController()
  fetch(\`/api/v1/public/pacts/\${id}/og.png\`, { signal: ctrl.signal }).catch(() => {})
  return () => ctrl.abort()
}, [id])
\`\`\`

これにより、ユーザーが SignedPage で「𝕏で天下に宣する」を押すまでに **PNG 生成が完了している**ので、
X クローラーが投稿後にアクセスしたときには cache hit → 即座に PNG を返せる。

## 動作確認

- [x] \`bundle exec rspec\`: **295 / 0**
- [x] \`bundle exec rubocop\`: クリーン
- [x] \`npm run test\`: 全パス
- [x] \`npm run lint\`: クリーン
- [x] \`npx tsc --noEmit\`: クリーン
- [x] og_images 用の spec を新規追加（200/304/404 + cache hit 検証）

## マージ後の確認

1. Render の再デプロイ完了を待つ
2. 本番で **新しい契約**を作成（既存の id は X 側にキャッシュが残ってる可能性あるので必ず新規）
3. SignedPage を表示 → 数秒待つ（裏で cache 生成）
4. 「𝕏で天下に宣する」ボタンを押下 → ツイート
5. 投稿後に X 上のカードを確認、または Card Validator で URL を検証

cache 完成は curl で確認可能：
\`\`\`bash
curl -s -o /dev/null -w "%{time_total}s\n" https://vow-pact.onrender.com/api/v1/public/pacts/<id>/og.png
\`\`\`
2 回目以降が **1 秒未満**なら cache hit。