### PR TITLE
fix: 本番 OG image の 500 エラー解消（MemoryStore 化 + cache 失敗時フォールバック）

### DIFF
--- a/app/controllers/api/v1/public/og_images_controller.rb
+++ b/app/controllers/api/v1/public/og_images_controller.rb
@@ -5,14 +5,14 @@ module Api
       # /api/v1/public/pacts/:id/og.png でアクセス可能。
       # is_public=false の契約は 404。
       # キャッシュ戦略：
-      #   1) updated_at をキーに Rails.cache（Solid Cache）へ PNG を保存
+      #   1) updated_at をキーに Rails.cache（現在は MemoryStore）へ PNG を保存
       #      （Render Free tier では rsvg-convert + Noto CJK フォント読み込みに 10 秒以上かかるため、
       #      毎回再生成すると X クローラー（タイムアウト 5〜10 秒）に間に合わない）
       #   2) ETag / Last-Modified でブラウザ・CDN にも乗せる
       class OgImagesController < Api::V1::BaseController
         allow_unauthenticated_access only: [ :show ]
 
-        # Solid Cache に格納する OG image の有効期限。
+        # キャッシュストアに格納する OG image の有効期限。
         # 契約が更新されると updated_at が変わり cache key も変わるため、古いキーは TTL で自動失効。
         OG_IMAGE_CACHE_TTL = 30.days
 
@@ -33,16 +33,20 @@ module Api
 
         private
 
-        # Solid Cache から取り出すが、cache レイヤで例外が出たら同期生成にフォールバックする。
-        # 本番でキャッシュ DB がエラーになっても 500 にせず PNG を返し続けることを優先する。
+        # Rails.cache（現在は MemoryStore）から取り出すが、cache 層で例外が出たら同期生成にフォールバックする。
+        # cache 層に障害があっても 500 にせず PNG を返し続けることを優先する。
+        # rescue は cache 層だけに限定する。ジェネレーター本体（to_png）の例外は外側の show まで伝播させ、
+        # ログを「cache failed」として誤分類しない。
         def fetch_or_generate_png(pact)
           cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
-          Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
+          begin
+            Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
+              PactOgImageGenerator.new(pact).to_png
+            end
+          rescue StandardError => e
+            Rails.logger.error("[OgImage] cache failed: #{e.class}: #{e.message}")
             PactOgImageGenerator.new(pact).to_png
           end
-        rescue StandardError => e
-          Rails.logger.error("[OgImage] cache failed: #{e.class}: #{e.message}")
-          PactOgImageGenerator.new(pact).to_png
         end
       end
     end

--- a/app/controllers/api/v1/public/og_images_controller.rb
+++ b/app/controllers/api/v1/public/og_images_controller.rb
@@ -23,15 +23,26 @@ module Api
           fresh_when(etag: pact, last_modified: pact.updated_at, public: true)
           return if request.fresh?(response)
 
-          cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
-          png = Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
-            PactOgImageGenerator.new(pact).to_png
-          end
+          png = fetch_or_generate_png(pact)
 
           send_data png, type: "image/png", disposition: "inline",
                           filename: "pact-#{pact.id}-og.png"
         rescue ActiveRecord::RecordNotFound
           head :not_found
+        end
+
+        private
+
+        # Solid Cache から取り出すが、cache レイヤで例外が出たら同期生成にフォールバックする。
+        # 本番でキャッシュ DB がエラーになっても 500 にせず PNG を返し続けることを優先する。
+        def fetch_or_generate_png(pact)
+          cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
+          Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
+            PactOgImageGenerator.new(pact).to_png
+          end
+        rescue StandardError => e
+          Rails.logger.error("[OgImage] cache failed: #{e.class}: #{e.message}")
+          PactOgImageGenerator.new(pact).to_png
         end
       end
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,17 @@ Rails.application.configure do
   # Render Free tier は単一プロセス + 短いライフサイクル（30 分でスピンダウン）なので、
   # 本格的な永続キャッシュが必要になった段階で `bin/rails solid_cache:install` で
   # migration を作成して Solid Cache に戻す。
-  config.cache_store = :memory_store, { size: 256.megabytes }
+  #
+  # トレードオフ:
+  #   - スピンダウン後の最初のアクセスはキャッシュが空のため OG image 生成に 10 秒以上かかり、
+  #     X クローラーのタイムアウトに引っかかる可能性がある（SignedPage の useEffect で
+  #     ユーザー操作中に先取りフェッチして温める対応で緩和）。
+  #   - PNG（数百 KB）をそのまま保持するとメモリを食うので、compress: true で gzip 圧縮する。
+  config.cache_store = :memory_store, {
+    size: 256.megabytes,
+    compress: true,
+    compress_threshold: 1.kilobyte
+  }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,13 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # cache store: 当面は in-process MemoryStore を使う。
+  # Solid Cache の migration（db/cache_migrate/）が未生成で本番 DB にテーブルが無く、
+  # Rails.cache.fetch 時に「relation does not exist」で 500 になっていたため。
+  # Render Free tier は単一プロセス + 短いライフサイクル（30 分でスピンダウン）なので、
+  # 本格的な永続キャッシュが必要になった段階で `bin/rails solid_cache:install` で
+  # migration を作成して Solid Cache に戻す。
+  config.cache_store = :memory_store, { size: 256.megabytes }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue


### PR DESCRIPTION
## 問題

PR #63 で \`Rails.cache.fetch\` を導入後、本番で OG image エンドポイントが **500 エラー**を返すようになった：

\`\`\`
$ curl -s -o /dev/null -w "%{http_code}\n" https://vow-pact.onrender.com/api/v1/public/pacts/5/og.png
500
\`\`\`

## 原因

\`config/environments/production.rb\` で \`cache_store = :solid_cache_store\` を指定しているが、
**\`db/cache_migrate/\` ディレクトリが未生成**で本番 DB に \`solid_cache_entries\` テーブルが存在しない状態だった。

\`\`\`bash
$ ls db/cache_migrate/
ls: cannot access 'db/cache_migrate/': No such file or directory
$ grep -i 'solid_cache' db/schema.rb
（何も出ない）
\`\`\`

→ \`Rails.cache.fetch\` 実行時に「relation does not exist」で例外 → 500

## 対応

### 1. production の cache_store を MemoryStore に切り替え

Render Free tier は単一プロセス + 短ライフサイクル（30 分でスピンダウン）なので、
インプロセス MemoryStore で実用上問題ない。

\`\`\`ruby
config.cache_store = :memory_store, { size: 256.megabytes }
\`\`\`

本格的な永続キャッシュが必要になった段階で \`bin/rails solid_cache:install\` で
migration を作成して Solid Cache に戻す方針。

### 2. cache レイヤの例外を握り潰して同期生成にフォールバック

\`og_images_controller\` に \`fetch_or_generate_png\` を切り出し、
cache 書き込み/読み込みで何か起きても 500 ではなく PNG を返し続ける防御コード。

\`\`\`ruby
def fetch_or_generate_png(pact)
  cache_key = [ "pact_og_image", pact.id, pact.updated_at.to_i ]
  Rails.cache.fetch(cache_key, expires_in: OG_IMAGE_CACHE_TTL) do
    PactOgImageGenerator.new(pact).to_png
  end
rescue StandardError => e
  Rails.logger.error("[OgImage] cache failed: #{e.class}: #{e.message}")
  PactOgImageGenerator.new(pact).to_png
end
\`\`\`

## 動作確認

- [x] \`bundle exec rspec\`: **295 / 0**
- [x] \`bundle exec rubocop\`: クリーン

## マージ後の確認

\`\`\`bash
for i in 1 2 3; do
  curl -s -o /dev/null -w "${i}: %{time_total}s status=%{http_code}\n" \\
    https://vow-pact.onrender.com/api/v1/public/pacts/5/og.png
done
\`\`\`

期待値:
- 全て status=200
- 1 回目は ~13s（生成）
- 2 回目以降は ~0.5s（MemoryStore 経由 cache hit）

その後、新しい契約で X Card Validator に **\`/p/<id>\` の URL** を投入してカードを確認。
（注: \`/pacts/<id>\` は認証必須の SPA で SSR meta 無し）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * OG画像生成のキャッシング処理を改善し、キャッシュレイヤーが失敗した場合のフォールバック処理を追加しました。
  * 本番環境のキャッシュ設定をメモリベースの仕組みに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->