### PR TITLE
feat(og-image): SignedPage 風デザインに刷新 + 2x 画質 + 絵文字対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /rails
 # librsvg2-bin: 公開契約ページの OG image PNG を SVG から動的生成するために rsvg-convert を使う
 # fonts-noto-cjk: rsvg-convert が日本語（契約書本文）をレンダリングするためのフォント
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client librsvg2-bin fonts-noto-cjk && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client librsvg2-bin fonts-noto-cjk fonts-noto-color-emoji && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,7 @@ FROM ruby:3.4.9-slim
 # OS パッケージのインストール
 # librsvg2-bin: SVG → PNG 変換用（OG image 生成、日本語フォントに強い）
 # fonts-noto-cjk: SVG 内の日本語をきれいに描画
+# fonts-noto-color-emoji: SVG 内の絵文字（🏆 等）をカラーで描画。無いとコードポイントが「丸+数字」で出る
 # imagemagick: フォールバック用
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     build-essential \
@@ -15,6 +16,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     gnupg \
     librsvg2-bin \
     fonts-noto-cjk \
+    fonts-noto-color-emoji \
     imagemagick \
     && rm -rf /var/lib/apt/lists/*
 

--- a/app/services/pact_og_image_generator.rb
+++ b/app/services/pact_og_image_generator.rb
@@ -126,8 +126,13 @@ class PactOgImageGenerator
     @imagemagick_available ||= system("which convert > /dev/null 2>&1")
   end
 
+  # Open3.capture3 は配列形式で渡すためシェル展開はされない。
+  # 引数の補完値（RENDER_WIDTH/HEIGHT）は Integer 定数で攻撃面はないが、
+  # Brakeman の Execute チェックは式展開を一律警告するため、Integer() で型を明示する。
   def png_via_rsvg
-    cmd = [ "rsvg-convert", "--width=#{RENDER_WIDTH}", "--height=#{RENDER_HEIGHT}", "--format=png" ]
+    width  = Integer(RENDER_WIDTH)
+    height = Integer(RENDER_HEIGHT)
+    cmd = [ "rsvg-convert", "--width=#{width}", "--height=#{height}", "--format=png" ]
     out, err, status = Open3.capture3(*cmd, stdin_data: to_svg, binmode: true)
     return out if status.success?
     Rails.logger.error("[PactOgImage] rsvg-convert failed: #{err}")
@@ -135,8 +140,10 @@ class PactOgImageGenerator
   end
 
   def png_via_imagemagick
+    width  = Integer(RENDER_WIDTH)
+    height = Integer(RENDER_HEIGHT)
     cmd = [ "convert", "-background", "transparent", "-density", "200",
-            "svg:-", "-resize", "#{RENDER_WIDTH}x#{RENDER_HEIGHT}", "png:-" ]
+            "svg:-", "-resize", "#{width}x#{height}", "png:-" ]
     out, err, status = Open3.capture3(*cmd, stdin_data: to_svg, binmode: true)
     return out if status.success?
     Rails.logger.error("[PactOgImage] convert failed: #{err}")

--- a/app/services/pact_og_image_generator.rb
+++ b/app/services/pact_og_image_generator.rb
@@ -4,8 +4,14 @@ require "open3"
 # Twitter カードの推奨サイズは 1200x630（summary_large_image）。
 # 中世ファンタジー風の羊皮紙デザインで、契約の「目標」「制約」「期日」「難易度」を表示。
 class PactOgImageGenerator
+  # SVG の論理座標系（コード内の x, y はすべてこの値ベース）。
+  # 1200x630 は Twitter Card "summary_large_image" の推奨サイズ。
   WIDTH = 1200
   HEIGHT = 630
+  # 出力 PNG のピクセル数。Retina ディスプレイや X 側のダウンスケールで綺麗に見せるため 2x で書き出す。
+  # SVG 内の座標計算は WIDTH/HEIGHT ベースのまま（レンダラー側で拡大）。
+  RENDER_WIDTH = WIDTH * 2
+  RENDER_HEIGHT = HEIGHT * 2
 
   COLOR_PARCHMENT = "#f4e8d0"
   COLOR_INK       = "#2c1810"
@@ -17,8 +23,15 @@ class PactOgImageGenerator
   end
 
   # SVG 文字列を返す。
-  # PNG に変換する場合は #to_png を呼ぶ（ImageMagick 必須）。
+  # PNG に変換する場合は #to_png を呼ぶ（rsvg-convert または ImageMagick）。
+  # SignedPage（締結後画面）と同じ「誓いは刻まれた」「成就せり」のヘッドライン構成にしている。
   def to_svg
+    completed = @pact.completed?
+    headline  = completed ? "成就せり" : "誓いは刻まれた"
+    subtitle  = completed ? "あなたの誓いは見事に達成された。紋章が授けられる。"
+                          : "本書に記された誓いは、あなた自身との不動の契約となる。"
+    seal_symbol = completed ? "🏆" : "⚔"
+
     <<~SVG
       <?xml version="1.0" encoding="UTF-8"?>
       <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
@@ -33,49 +46,59 @@ class PactOgImageGenerator
         <!-- 背景：羊皮紙風グラデーション -->
         <rect width="100%" height="100%" fill="url(#parchment)"/>
 
-        <!-- 二重罫線 -->
+        <!-- 二重罫線（外枠） -->
         <rect x="36" y="36" width="#{WIDTH - 72}" height="#{HEIGHT - 72}" fill="none" stroke="#{COLOR_GOLD}" stroke-width="2"/>
         <rect x="48" y="48" width="#{WIDTH - 96}" height="#{HEIGHT - 96}" fill="none" stroke="#{COLOR_GOLD}" stroke-width="1" stroke-opacity="0.5"/>
 
-        <!-- 上部ロゴ：誓約 ⚔ 契約 -->
-        <text x="#{WIDTH / 2}" y="120" text-anchor="middle"
+        <!-- 中央上のシール（円 + シンボル） -->
+        <circle cx="#{WIDTH / 2}" cy="110" r="55" fill="#{COLOR_SEAL}" fill-opacity="0.1"
+                stroke="#{COLOR_GOLD}" stroke-width="3"/>
+        <text x="#{WIDTH / 2}" y="135" text-anchor="middle" font-size="60">#{seal_symbol}</text>
+
+        <!-- ヘッドライン: fill は style でも明示する（rsvg-convert の一部環境で
+             attribute fill より style fill の方が確実に効くケースがあるため） -->
+        <text x="#{WIDTH / 2}" y="220" text-anchor="middle"
               font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
-              font-size="42" font-weight="bold" fill="#{COLOR_SEAL}">
-          誓約 <tspan fill="#{COLOR_GOLD}">⚔</tspan> 契約
-        </text>
-        <text x="#{WIDTH / 2}" y="160" text-anchor="middle"
-              font-family="'Cormorant Garamond', serif" font-size="20"
-              fill="#{COLOR_GOLD}" letter-spacing="6">VOW PACT</text>
+              font-size="48" font-weight="bold"
+              fill="#{COLOR_SEAL}" style="fill:#{COLOR_SEAL};">#{headline}</text>
 
-        <!-- セパレータ -->
-        <line x1="#{WIDTH / 2 - 200}" y1="200" x2="#{WIDTH / 2 + 200}" y2="200"
-              stroke="#{COLOR_GOLD}" stroke-width="1.5"/>
+        <!-- サブタイトル -->
+        <text x="#{WIDTH / 2}" y="280" text-anchor="middle"
+              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
+              font-size="22"
+              fill="#{COLOR_INK}" fill-opacity="0.7" style="fill:#{COLOR_INK};fill-opacity:0.7;">#{subtitle}</text>
 
-        <!-- 「誓い」のラベル -->
-        <text x="100" y="260" font-family="'Noto Serif JP', serif" font-size="22"
+        <!-- 契約書ボックス -->
+        <rect x="80" y="340" width="#{WIDTH - 160}" height="240" rx="12"
+              fill="#{COLOR_PARCHMENT}" stroke="#{COLOR_GOLD}" stroke-width="2"/>
+
+        <!-- 目標 -->
+        <text x="100" y="370" font-family="'Noto Serif JP', serif" font-size="20"
               fill="#{COLOR_INK}" fill-opacity="0.6">目標</text>
-
-        <!-- 目標本文 -->
-        #{wrap_text(@pact.goal, x: 100, y: 305, width: 980, font_size: 36, color: COLOR_INK, max_lines: 2)}
+        #{wrap_text(@pact.goal, x: 100, y: 405, width: 1000, font_size: 32, color: COLOR_INK, max_lines: 1)}
 
         <!-- 制約 -->
-        <text x="100" y="400" font-family="'Noto Serif JP', serif" font-size="22"
+        <text x="100" y="450" font-family="'Noto Serif JP', serif" font-size="20"
               fill="#{COLOR_INK}" fill-opacity="0.6">制約</text>
-        #{wrap_text(@pact.constraint_text, x: 100, y: 440, width: 980, font_size: 28, color: COLOR_INK, max_lines: 2)}
+        #{wrap_text(@pact.constraint_text, x: 100, y: 485, width: 1000, font_size: 26, color: COLOR_INK, max_lines: 1)}
 
-        <!-- 下段：期日 / 難易度 -->
-        <text x="100" y="540" font-family="'Noto Serif JP', serif" font-size="22"
+        <!-- 期日 -->
+        <text x="100" y="525" font-family="'Noto Serif JP', serif" font-size="20"
               fill="#{COLOR_INK}" fill-opacity="0.6">期日</text>
-        <text x="100" y="580" font-family="'Noto Serif JP', serif" font-size="32"
+        <text x="100" y="560" font-family="'Noto Serif JP', serif" font-size="28"
               fill="#{COLOR_INK}">#{@pact.deadline}</text>
 
-        <text x="700" y="540" font-family="'Noto Serif JP', serif" font-size="22"
+        <!-- 難易度 -->
+        <text x="600" y="525" font-family="'Noto Serif JP', serif" font-size="20"
               fill="#{COLOR_INK}" fill-opacity="0.6">難易度</text>
-        <text x="700" y="582" font-family="'Noto Serif JP', serif" font-size="36"
-              fill="#{COLOR_SEAL}">#{difficulty_marks}</text>
+        <text x="600" y="560" font-family="'Noto Serif JP', serif" font-size="28">
+          #{difficulty_marks_svg}
+        </text>
 
-        <!-- 達成済みなら左上に紋章バッジ -->
-        #{@pact.completed? ? completed_badge : ""}
+        <!-- 右下のブランディング -->
+        <text x="#{WIDTH - 60}" y="615" text-anchor="end"
+              font-family="'Cormorant Garamond', serif" font-size="14"
+              fill="#{COLOR_GOLD}" letter-spacing="3">VOW PACT</text>
       </svg>
     SVG
   end
@@ -104,7 +127,7 @@ class PactOgImageGenerator
   end
 
   def png_via_rsvg
-    cmd = [ "rsvg-convert", "--width=#{WIDTH}", "--height=#{HEIGHT}", "--format=png" ]
+    cmd = [ "rsvg-convert", "--width=#{RENDER_WIDTH}", "--height=#{RENDER_HEIGHT}", "--format=png" ]
     out, err, status = Open3.capture3(*cmd, stdin_data: to_svg, binmode: true)
     return out if status.success?
     Rails.logger.error("[PactOgImage] rsvg-convert failed: #{err}")
@@ -112,7 +135,8 @@ class PactOgImageGenerator
   end
 
   def png_via_imagemagick
-    cmd = [ "convert", "-background", "transparent", "-density", "144", "svg:-", "png:-" ]
+    cmd = [ "convert", "-background", "transparent", "-density", "200",
+            "svg:-", "-resize", "#{RENDER_WIDTH}x#{RENDER_HEIGHT}", "png:-" ]
     out, err, status = Open3.capture3(*cmd, stdin_data: to_svg, binmode: true)
     return out if status.success?
     Rails.logger.error("[PactOgImage] convert failed: #{err}")
@@ -165,6 +189,17 @@ class PactOgImageGenerator
   def difficulty_marks
     n = [ [ @pact.difficulty.to_i, 0 ].max, 5 ].min
     ("⚔" * n) + ("⚔" * (5 - n))
+  end
+
+  # SignedPage と同じく「⚔ × n（seal）+ ⚔ × (5-n)（薄墨） {n}/5」を tspan で色分け表示。
+  # dx は rsvg-convert / X 上のレンダラーで意図しない位置にずれる場合があるため空白で代用。
+  def difficulty_marks_svg
+    n = [ [ @pact.difficulty.to_i, 0 ].max, 5 ].min
+    parts = []
+    parts << "<tspan fill=\"#{COLOR_SEAL}\">#{'⚔' * n}</tspan>" if n.positive?
+    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.3\">#{'⚔' * (5 - n)}</tspan>" if n < 5
+    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.6\" font-size=\"20\">  #{n} / 5</tspan>"
+    parts.join
   end
 
   def completed_badge

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,52 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "2690fddcc003157286a8eb555440f915a327b3499d2e8ac78305e2d36f0834fc",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/pact_og_image_generator.rb",
+      "line": 136,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(*[\"rsvg-convert\", \"--width=#{Integer(RENDER_WIDTH)}\", \"--height=#{Integer(RENDER_HEIGHT)}\", \"--format=png\"], :stdin_data => to_svg, :binmode => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PactOgImageGenerator",
+        "method": "png_via_rsvg"
+      },
+      "user_input": "Integer(RENDER_WIDTH)",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "RENDER_WIDTH / RENDER_HEIGHT はクラス内で定義された Integer 定数（WIDTH * 2 / HEIGHT * 2）であり、ユーザー入力ではない。Open3.capture3 は配列形式のためシェル展開もされず、command injection は不可能。Brakeman の Execute チェックは式展開を一律警告するための false positive として無視する。"
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "fcb96f33be7b22a6542ae0739f3be9ebc2bda2808daf4e29d79ce49287b42c09",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/pact_og_image_generator.rb",
+      "line": 147,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(*[\"convert\", \"-background\", \"transparent\", \"-density\", \"200\", \"svg:-\", \"-resize\", \"#{Integer(RENDER_WIDTH)}x#{Integer(RENDER_HEIGHT)}\", \"png:-\"], :stdin_data => to_svg, :binmode => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PactOgImageGenerator",
+        "method": "png_via_imagemagick"
+      },
+      "user_input": "Integer(RENDER_WIDTH)",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "RENDER_WIDTH / RENDER_HEIGHT はクラス内で定義された Integer 定数（WIDTH * 2 / HEIGHT * 2）であり、ユーザー入力ではない。Open3.capture3 は配列形式のためシェル展開もされず、command injection は不可能。Brakeman の Execute チェックは式展開を一律警告するための false positive として無視する。"
+    }
+  ],
+  "updated": "2026-05-06 13:30:00 +0000",
+  "brakeman_version": "8.0.4"
+}

--- a/spec/services/pact_og_image_generator_spec.rb
+++ b/spec/services/pact_og_image_generator_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe PactOgImageGenerator, type: :service do
+  let(:user) { create(:user, nickname: "テスト誓約者") }
+  let(:base_attrs) do
+    { goal: "毎朝鏡の自分に「今日もえらい」を1回言う",
+      constraint_text: "寝る30分前からスマホ見ない",
+      deadline: Date.parse("2026-05-31"),
+      difficulty: 2 }
+  end
+
+  def build_pact(**overrides)
+    p = build(:pact, **base_attrs, user: user, **overrides)
+    p.save!(validate: false)
+    p
+  end
+
+  describe "#to_svg" do
+    context "active な契約（未達成）" do
+      let(:pact) { build_pact(status: :active) }
+      subject(:svg) { described_class.new(pact).to_svg }
+
+      it "ヘッドラインが「誓いは刻まれた」になる" do
+        expect(svg).to include("誓いは刻まれた")
+        expect(svg).not_to include("成就せり")
+      end
+
+      it "サブタイトルが SignedPage と同じ文言になる" do
+        expect(svg).to include("本書に記された誓いは、あなた自身との不動の契約となる。")
+      end
+
+      it "契約書本文（目標 / 制約 / 期日）を描画する" do
+        expect(svg).to include("毎朝鏡の自分に")
+        expect(svg).to include("寝る30分前からスマホ見ない")
+        expect(svg).to include("2026-05-31")
+      end
+
+      it "難易度を ⚔ + n/5 で表示する" do
+        expect(svg).to include("⚔")
+        expect(svg).to include("2 / 5")
+      end
+
+      it "完了バッジは描画されない" do
+        expect(svg).not_to include("成就")
+      end
+    end
+
+    context "completed な契約（達成済み）" do
+      let(:pact) { build_pact(status: :completed, completed_at: Time.current) }
+      subject(:svg) { described_class.new(pact).to_svg }
+
+      it "ヘッドラインが「成就せり」になる" do
+        expect(svg).to include("成就せり")
+        expect(svg).not_to include("誓いは刻まれた")
+      end
+
+      it "サブタイトルが達成版になる" do
+        expect(svg).to include("あなたの誓いは見事に達成された。紋章が授けられる。")
+      end
+
+      it "完了バッジ（成就）が含まれる" do
+        expect(svg).to include("成就")
+      end
+    end
+  end
+
+  describe "#to_png" do
+    let(:pact) { build_pact(status: :active) }
+
+    it "rsvg-convert / convert が使える環境では PNG バイナリを返す（テスト環境はフォールバック PNG）" do
+      png = described_class.new(pact).to_png
+      expect(png).to be_a(String)
+      expect(png.bytesize).to be > 0
+      # PNG マジックバイト
+      expect(png.byteslice(0, 8).bytes).to eq([ 137, 80, 78, 71, 13, 10, 26, 10 ])
+    end
+  end
+end


### PR DESCRIPTION
## 背景

PR #64 で本番の OG image エンドポイントが 200 を返すようになり X Card Validator は \`Card loaded successfully\` を返すようになったが、ユーザーが目にしたカード画像は「アプリのプロモカード」風で、想定していた **SignedPage（締結後画面）と同じ "誓いは刻まれた" + 契約書本文の画像** ではなかった。

## 主な変更

### デザインを SignedPage に揃える

| 要素 | Before                                          | After                                                       |
| ---- | ----------------------------------------------- | ----------------------------------------------------------- |
| 上部 | 「誓約 ⚔ 契約 / VOW PACT」(ロゴ風で大きい)      | 円形シール ⚔ / 🏆 + 「誓いは刻まれた」/「成就せり」          |
| 直下 | セパレータ線                                    | サブタイトル「本書に記された誓いは…」「あなたの誓いは見事に…」 |
| 中央 | 目標 / 制約 / 期日 / 難易度（既存）             | 同左を契約書ボックスにまとめて、サマリ感を強調              |
| 右上 | 達成時に \`🏆 成就\` バッジ                      | 削除（中央 🏆 シール + 「成就せり」と冗長）                  |
| 右下 | なし                                            | 「VOW PACT」を小さくブランディング                          |

### レンダリング品質改善

- **出力 PNG を 2x（2400×1260）に拡大**。SVG 内座標系は 1200×630 のまま維持し、Retina / X 側ダウンスケールでも輪郭がクッキリ見える
- ヘッドラインの \`fill\` を **\`fill\` 属性 + \`style\` 属性** で二重に明示（rsvg-convert の一部環境で attribute fill が反映されないケースの保険）
- **\`fonts-noto-color-emoji\` を Dockerfile / Dockerfile.dev に追加**。これが無いと 🏆 が「丸 + 数字（コードポイント）」で描画される
- \`difficulty_marks_svg\` を新設し \`⚔ × n（seal）+ ⚔（薄墨）+ n/5\` を tspan で色分け表示（\`dx\` を空白に変更してレンダラ依存の位置ズレを回避）

### spec 新規追加

\`spec/services/pact_og_image_generator_spec.rb\`：
- active 契約: ヘッドライン「誓いは刻まれた」、サブタイトル一致、契約書本文、難易度 \`n / 5\`、完了文言が含まれない
- completed 契約: ヘッドライン「成就せり」、達成版サブタイトル
- to_png: PNG マジックバイト検証

## 動作確認

- [x] \`bundle exec rspec\`: **304 / 0**
- [x] \`bundle exec rubocop\`: クリーン
- [x] \`npm run lint\`: クリーン
- [x] \`npx tsc --noEmit\`: クリーン
- [x] ローカルで PNG を出力し目視確認:
  - active: \`/tmp/og_active.png\`（2400×1260, 246 KB）
  - completed: \`/tmp/og_completed.png\`（2400×1260, 235 KB）

## マージ後

1. Render 再デプロイ完了を待つ
2. 本番で **新しい契約**を作成（既存の id は X 側にカードがキャッシュされている可能性）
3. SignedPage を表示 → useEffect の先取り fetch で cache 温める（数十秒待つ）
4. 「𝕏で天下に宣する」を押下
5. X 上で **「誓いは刻まれた」+ 契約書本文** が描画されたカードが表示されるか確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カラー絵文字のレンダリングサポートを追加しました。
  * OGイメージ生成を高解像度で改善し、レイアウトを最適化しました。契約の完了状況に応じて動的にコンテンツを表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->