### PR TITLE
feat: 契約の編集モーダル + 破棄（論理削除）ダイアログを追加

### DIFF
--- a/app/frontend/components/Button.tsx
+++ b/app/frontend/components/Button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react"
 
-type ButtonVariant = "primary" | "secondary" | "ghost"
+type ButtonVariant = "primary" | "secondary" | "ghost" | "destructive"
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode
@@ -12,6 +12,16 @@ const variantClasses: Record<ButtonVariant, string> = {
   primary: "bg-seal text-parchment shadow-md hover:shadow-lg hover:brightness-110 active:brightness-95",
   secondary: "bg-gold text-ink shadow-md hover:shadow-lg hover:brightness-105 active:brightness-95",
   ghost: "bg-transparent text-seal border border-seal hover:bg-seal/10 hover:shadow-sm active:bg-seal/20",
+  // 破棄など取り消せない操作向け。CTA そのものは red、控えめにしたい場合は ghost を使う。
+  destructive: "bg-red-700 text-parchment shadow-md hover:brightness-110 active:brightness-95",
+}
+
+// フォーカスリング色は variant に追従させる（特に destructive は赤系で揃える）
+const focusRingClasses: Record<ButtonVariant, string> = {
+  primary: "focus-visible:ring-seal/40",
+  secondary: "focus-visible:ring-seal/40",
+  ghost: "focus-visible:ring-seal/40",
+  destructive: "focus-visible:ring-red-700/40",
 }
 
 function Button({
@@ -26,13 +36,14 @@ function Button({
     "px-6 py-3 font-serif font-bold rounded-lg transition-all duration-200 ease-out " +
     "hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed " +
     "disabled:hover:translate-y-0 disabled:hover:shadow-none focus-visible:outline-none " +
-    "focus-visible:ring-2 focus-visible:ring-seal/40 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
+    "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
   const width = fullWidth ? "w-full" : ""
   const variantClass = variantClasses[variant]
+  const focusRingClass = focusRingClasses[variant]
 
   return (
     <button
-      className={`${base} ${variantClass} ${width} ${className}`.trim()}
+      className={`${base} ${focusRingClass} ${variantClass} ${width} ${className}`.trim()}
       disabled={disabled}
       {...rest}
     >

--- a/app/frontend/components/Modal.tsx
+++ b/app/frontend/components/Modal.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from "react"
+import type { ReactNode } from "react"
+
+type ModalProps = {
+  // モーダルを閉じるコールバック。backdrop クリック / ESC キーで呼ばれる。
+  onClose: () => void
+  // モーダル本体の見出し要素の id を渡す（aria-labelledby 用）。
+  labelledBy: string
+  // backdrop クリックや ESC を一時的に無効化したい場合に true を渡す
+  // （API の送信中などに UI を勝手に閉じさせたくないケース）。
+  disableClose?: boolean
+  children: ReactNode
+}
+
+// アクセシブルなモーダルの土台。
+// - ESC で閉じる
+// - 背景スクロールをロック（body.style.overflow を一時 hidden）
+// - 開いた瞬間に内側の最初のフォーカス可能要素へフォーカスを当てる（focus-trap の最低限）
+// - backdrop クリックで閉じる（disableClose が true の場合は無視）
+//
+// 完全な focus-trap（Tab/Shift+Tab で内側に閉じ込める）は本コンポーネントでは扱わない。
+// 必要が出てきたら focus-trap-react などの導入を検討する。
+function Modal({ onClose, labelledBy, disableClose = false, children }: ModalProps) {
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !disableClose) onClose()
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+
+    // 背景スクロールをロック。複数モーダルが重なるケースは想定外（その場合は別途参照カウントが必要）。
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+
+    // 開いた瞬間に内側の最初のフォーカス可能要素へフォーカス
+    contentRef.current
+      ?.querySelector<HTMLElement>(
+        'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])'
+      )
+      ?.focus()
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [onClose, disableClose])
+
+  const handleBackdropClick = () => {
+    if (disableClose) return
+    onClose()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={contentRef}
+        className="w-full max-w-md rounded-lg border-2 border-gold bg-parchment p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default Modal

--- a/app/frontend/pages/PactDetailPage.tsx
+++ b/app/frontend/pages/PactDetailPage.tsx
@@ -29,6 +29,8 @@ function PactDetailPage() {
   const queryClient = useQueryClient()
   const [note, setNote] = useState("")
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   const { data: pact, isLoading: isPactLoading, isError: isPactError } = useQuery<Pact, ApiError>({
     queryKey: ["pact", id],
@@ -137,7 +139,36 @@ function PactDetailPage() {
 
           {/* 公開設定 */}
           <PublicToggle pact={pact} />
+
+          {/* 操作（active な契約のみ） */}
+          {isActive && (
+            <section className="mt-4 pt-4 border-t border-gold/30">
+              <p className="text-sm text-ink font-bold mb-3">操作</p>
+              <div className="flex gap-2 flex-wrap">
+                <Button variant="ghost" type="button" onClick={() => setEditOpen(true)}>
+                  編集
+                </Button>
+                <button
+                  type="button"
+                  onClick={() => setDeleteOpen(true)}
+                  className="px-6 py-3 font-serif font-bold rounded-lg border border-red-700 text-red-700 transition hover:bg-red-700/10 active:bg-red-700/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
+                >
+                  破棄
+                </button>
+              </div>
+            </section>
+          )}
         </div>
+
+        {/* 編集モーダル */}
+        {editOpen && (
+          <EditPactModal pact={pact} onClose={() => setEditOpen(false)} />
+        )}
+
+        {/* 削除確認ダイアログ */}
+        {deleteOpen && (
+          <DeleteConfirmDialog pact={pact} onClose={() => setDeleteOpen(false)} />
+        )}
 
         {/* 今日のチェックイン */}
         {isActive && (
@@ -309,6 +340,182 @@ function PublicToggle({ pact }: { pact: Pact }) {
         </div>
       )}
     </section>
+  )
+}
+
+// =====================================================================
+// 契約編集モーダル
+// =====================================================================
+// 編集可能な属性は goal / constraint_text のみ。
+// 期日 / 難易度 / 締結日は契約時に確定する設計（CLAUDE.md 7. 重要な設計判断）。
+
+function EditPactModal({ pact, onClose }: { pact: Pact; onClose: () => void }) {
+  const queryClient = useQueryClient()
+  const [goal, setGoal] = useState(pact.goal)
+  const [constraintText, setConstraintText] = useState(pact.constraint_text)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation<Pact, ApiError, void>({
+    mutationFn: () =>
+      api<Pact>(`/pacts/${pact.id}`, {
+        method: "PATCH",
+        body: { goal: goal.trim(), constraint_text: constraintText.trim() },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
+      queryClient.invalidateQueries({ queryKey: ["pacts"] })
+      onClose()
+    },
+    onError: (err) => {
+      const errors = Array.isArray(err.errors) ? err.errors : []
+      const firstError = errors[0] as { message?: string } | undefined
+      setError(firstError?.message ?? "編集に失敗しました")
+    },
+  })
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (goal.trim() === "" || constraintText.trim() === "") {
+      setError("目標と制約は必須です")
+      return
+    }
+    setError(null)
+    mutation.mutate()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-pact-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border-2 border-gold bg-parchment p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="edit-pact-title" className="font-serif text-xl text-seal mb-4">
+          契約を編集する
+        </h2>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label htmlFor="edit-goal" className="block text-xs text-ink/70 mb-1">
+              目標
+            </label>
+            <textarea
+              id="edit-goal"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              maxLength={500}
+              rows={2}
+              className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="edit-constraint" className="block text-xs text-ink/70 mb-1">
+              制約
+            </label>
+            <textarea
+              id="edit-constraint"
+              value={constraintText}
+              onChange={(e) => setConstraintText(e.target.value)}
+              maxLength={500}
+              rows={2}
+              className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
+              required
+            />
+          </div>
+          <p className="text-xs text-ink/50">
+            ※ 期日 / 難易度 / 締結日は契約時に確定したため変更できません。
+          </p>
+          {error && (
+            <p className="text-xs text-seal" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+              キャンセル
+            </Button>
+            <Button variant="primary" type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中…" : "保存"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+// =====================================================================
+// 契約破棄（削除）確認ダイアログ
+// =====================================================================
+// 論理削除：DB からは消さず status を abandoned に変更する（CLAUDE.md 7.）。
+
+function DeleteConfirmDialog({ pact, onClose }: { pact: Pact; onClose: () => void }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation<void, ApiError, void>({
+    mutationFn: async () => {
+      await api(`/pacts/${pact.id}`, { method: "DELETE" })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
+      queryClient.invalidateQueries({ queryKey: ["pacts"] })
+      navigate("/pacts", { replace: true })
+    },
+    onError: (err) => {
+      const errors = Array.isArray(err.errors) ? err.errors : []
+      const firstError = errors[0] as { message?: string } | undefined
+      setError(firstError?.message ?? "破棄に失敗しました")
+    },
+  })
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-pact-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border-2 border-gold bg-parchment p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="delete-pact-title" className="font-serif text-xl text-seal mb-3">
+          この契約を破棄しますか？
+        </h2>
+        <p className="text-sm text-ink/70 mb-2">
+          目標：<span className="text-ink">{pact.goal}</span>
+        </p>
+        <p className="text-xs text-ink/60 mb-4">
+          破棄した契約は契約一覧から消え、紋章ももう得られません。一度破棄すると元に戻せません。
+        </p>
+        {error && (
+          <p className="text-xs text-seal mb-3" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+            キャンセル
+          </Button>
+          <button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+            className="px-6 py-3 font-serif font-bold rounded-lg bg-red-700 text-parchment shadow-md transition hover:brightness-110 active:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
+          >
+            {mutation.isPending ? "破棄中…" : "破棄する"}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/app/frontend/pages/PactDetailPage.tsx
+++ b/app/frontend/pages/PactDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from "react-router-dom"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import Layout from "../components/Layout"
 import Button from "../components/Button"
+import Modal from "../components/Modal"
 import { api, ApiError } from "../lib/api"
 import type { Pact } from "../types/pact"
 import type { CheckIn, CheckInStatus } from "../types/check_in"
@@ -148,13 +149,10 @@ function PactDetailPage() {
                 <Button variant="ghost" type="button" onClick={() => setEditOpen(true)}>
                   編集
                 </Button>
-                <button
-                  type="button"
-                  onClick={() => setDeleteOpen(true)}
-                  className="px-6 py-3 font-serif font-bold rounded-lg border border-red-700 text-red-700 transition hover:bg-red-700/10 active:bg-red-700/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
-                >
+                {/* 入り口ボタンは ghost で控えめに。実際の破棄コミットは確認ダイアログ内で destructive を使う。 */}
+                <Button variant="ghost" type="button" onClick={() => setDeleteOpen(true)}>
                   破棄
-                </button>
+                </Button>
               </div>
             </section>
           )}
@@ -361,9 +359,12 @@ function EditPactModal({ pact, onClose }: { pact: Pact; onClose: () => void }) {
         method: "PATCH",
         body: { goal: goal.trim(), constraint_text: constraintText.trim() },
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
-      queryClient.invalidateQueries({ queryKey: ["pacts"] })
+    onSuccess: async () => {
+      // 既存パターン（checkInMutation / PublicToggle）と挙動を揃えるため、
+      // invalidate を await してからモーダルを閉じる。閉じた直後に古いデータが
+      // チラ見えするのを避ける。
+      await queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
+      await queryClient.invalidateQueries({ queryKey: ["pacts"] })
       onClose()
     },
     onError: (err) => {
@@ -384,68 +385,57 @@ function EditPactModal({ pact, onClose }: { pact: Pact; onClose: () => void }) {
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="edit-pact-title"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-md rounded-lg border-2 border-gold bg-parchment p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 id="edit-pact-title" className="font-serif text-xl text-seal mb-4">
-          契約を編集する
-        </h2>
-        <form onSubmit={handleSave} className="space-y-4">
-          <div>
-            <label htmlFor="edit-goal" className="block text-xs text-ink/70 mb-1">
-              目標
-            </label>
-            <textarea
-              id="edit-goal"
-              value={goal}
-              onChange={(e) => setGoal(e.target.value)}
-              maxLength={500}
-              rows={2}
-              className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
-              required
-            />
-          </div>
-          <div>
-            <label htmlFor="edit-constraint" className="block text-xs text-ink/70 mb-1">
-              制約
-            </label>
-            <textarea
-              id="edit-constraint"
-              value={constraintText}
-              onChange={(e) => setConstraintText(e.target.value)}
-              maxLength={500}
-              rows={2}
-              className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
-              required
-            />
-          </div>
-          <p className="text-xs text-ink/50">
-            ※ 期日 / 難易度 / 締結日は契約時に確定したため変更できません。
+    <Modal onClose={onClose} labelledBy="edit-pact-title" disableClose={mutation.isPending}>
+      <h2 id="edit-pact-title" className="font-serif text-xl text-seal mb-4">
+        契約を編集する
+      </h2>
+      <form onSubmit={handleSave} className="space-y-4">
+        <div>
+          <label htmlFor="edit-goal" className="block text-xs text-ink/70 mb-1">
+            目標
+          </label>
+          <textarea
+            id="edit-goal"
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            maxLength={500}
+            rows={2}
+            className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="edit-constraint" className="block text-xs text-ink/70 mb-1">
+            制約
+          </label>
+          <textarea
+            id="edit-constraint"
+            value={constraintText}
+            onChange={(e) => setConstraintText(e.target.value)}
+            maxLength={500}
+            rows={2}
+            className="w-full px-3 py-2 bg-parchment border border-ink/30 rounded-sm text-sm focus:border-seal focus:outline-none"
+            required
+          />
+        </div>
+        <p className="text-xs text-ink/50">
+          ※ 期日 / 難易度 / 締結日は契約時に確定したため変更できません。
+        </p>
+        {error && (
+          <p className="text-xs text-seal" role="alert">
+            {error}
           </p>
-          {error && (
-            <p className="text-xs text-seal" role="alert">
-              {error}
-            </p>
-          )}
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
-              キャンセル
-            </Button>
-            <Button variant="primary" type="submit" disabled={mutation.isPending}>
-              {mutation.isPending ? "保存中…" : "保存"}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+            キャンセル
+          </Button>
+          <Button variant="primary" type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? "保存中…" : "保存"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
   )
 }
 
@@ -463,9 +453,10 @@ function DeleteConfirmDialog({ pact, onClose }: { pact: Pact; onClose: () => voi
     mutationFn: async () => {
       await api(`/pacts/${pact.id}`, { method: "DELETE" })
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
-      queryClient.invalidateQueries({ queryKey: ["pacts"] })
+    onSuccess: async () => {
+      // 既存パターンと挙動を揃えるため、invalidate を await してから navigate する。
+      await queryClient.invalidateQueries({ queryKey: ["pact", String(pact.id)] })
+      await queryClient.invalidateQueries({ queryKey: ["pacts"] })
       navigate("/pacts", { replace: true })
     },
     onError: (err) => {
@@ -476,46 +467,35 @@ function DeleteConfirmDialog({ pact, onClose }: { pact: Pact; onClose: () => voi
   })
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="delete-pact-title"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-md rounded-lg border-2 border-gold bg-parchment p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 id="delete-pact-title" className="font-serif text-xl text-seal mb-3">
-          この契約を破棄しますか？
-        </h2>
-        <p className="text-sm text-ink/70 mb-2">
-          目標：<span className="text-ink">{pact.goal}</span>
+    <Modal onClose={onClose} labelledBy="delete-pact-title" disableClose={mutation.isPending}>
+      <h2 id="delete-pact-title" className="font-serif text-xl text-seal mb-3">
+        この契約を破棄しますか？
+      </h2>
+      <p className="text-sm text-ink/70 mb-2">
+        目標：<span className="text-ink">{pact.goal}</span>
+      </p>
+      <p className="text-xs text-ink/60 mb-4">
+        破棄した契約は契約一覧から消え、紋章ももう得られません。一度破棄すると元に戻せません。
+      </p>
+      {error && (
+        <p className="text-xs text-seal mb-3" role="alert">
+          {error}
         </p>
-        <p className="text-xs text-ink/60 mb-4">
-          破棄した契約は契約一覧から消え、紋章ももう得られません。一度破棄すると元に戻せません。
-        </p>
-        {error && (
-          <p className="text-xs text-seal mb-3" role="alert">
-            {error}
-          </p>
-        )}
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
-            キャンセル
-          </Button>
-          <button
-            type="button"
-            onClick={() => mutation.mutate()}
-            disabled={mutation.isPending}
-            className="px-6 py-3 font-serif font-bold rounded-lg bg-red-700 text-parchment shadow-md transition hover:brightness-110 active:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-700/40 focus-visible:ring-offset-2 focus-visible:ring-offset-parchment"
-          >
-            {mutation.isPending ? "破棄中…" : "破棄する"}
-          </button>
-        </div>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+          キャンセル
+        </Button>
+        <Button
+          variant="destructive"
+          type="button"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "破棄中…" : "破棄する"}
+        </Button>
       </div>
-    </div>
+    </Modal>
   )
 }
 


### PR DESCRIPTION
## 概要

契約詳細画面（\`PactDetailPage\`）に、契約の **編集** と **破棄（論理削除）** UI を追加する。

API は既に揃っていた（\`PATCH /pacts/:id\` / \`DELETE /pacts/:id\`、対応 spec も完備）ため、今回は FE のみの変更。

## 変更内容

### \`app/frontend/pages/PactDetailPage.tsx\`

- active な契約のみ「編集」「破棄」ボタンを表示
- 編集モーダル \`EditPactModal\`:
  - \`goal\` / \`constraint_text\` のみ編集可能（CLAUDE.md 7. 重要な設計判断に従い、\`deadline\` / \`difficulty\` / \`signed_at\` は契約時に確定したため不変）
  - 注意書き「期日 / 難易度 / 締結日は契約時に確定したため変更できません」を表示
  - PATCH 成功で \`["pact", id]\` / \`["pacts"]\` キャッシュを invalidate
- 破棄ダイアログ \`DeleteConfirmDialog\`:
  - 削除すると \`status = abandoned\` に変わり契約一覧から消える / 紋章も得られない / 復元不可、を明示
  - 確認 → DELETE → \`/pacts\` へ \`replace: true\` で遷移
- backdrop クリックで閉じる、\`role=\"dialog\"\` / \`aria-modal\` / \`aria-labelledby\` でアクセシビリティ確保
- 破棄ボタンは destructive 表現として赤系の専用スタイル（Button の variant に合うものが無いため inline）

## ルール準拠

CLAUDE.md より:
- 編集可: \`goal\` / \`constraint_text\` のみ ✓
- 削除は論理削除（\`status: abandoned\`）✓（API 側で実装済み）
- 文言ルール: 「編集」「破棄」「キャンセル」は現代語、世界観演出は契約締結や達成画面に限定 ✓

## 動作確認

- [x] \`bundle exec rspec\`: **304 / 0**
- [x] \`bundle exec rubocop\`: クリーン
- [x] \`npm run lint\`: クリーン
- [x] \`npx tsc --noEmit\`: クリーン
- [x] \`npm run test\`: **17 / 17**

## 補足

API のテストは既存の \`spec/requests/api/v1/pacts_spec.rb\` に網羅済み（goal/constraint_text 編集、deadline/difficulty/signed_at は無視、他人の契約 404、論理削除での abandoned 化など）。FE 単体テストは現状 ShareButton / lib のみなので追加なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* Pact詳細ページに「操作」セクションが追加されました
* ユーザーはPactの目標と制約条件を編集できるようになりました
* Pact削除機能が実装され、削除前に確認ダイアログが表示されます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->