### PR TITLE
hotfix: 動的 OG 画像生成を一時無効化 + MemoryStore を 64MB に縮小

### DIFF
--- a/app/frontend/pages/PublicPactPage.tsx
+++ b/app/frontend/pages/PublicPactPage.tsx
@@ -33,21 +33,22 @@ function PublicPactPage() {
     enabled: !!id,
   })
 
-  // OG image を先取りフェッチして Rails.cache を温める。
-  // 初回ユーザー閲覧時に生成しておけば、X クローラーが投稿後にアクセスしたとき cache hit する。
-  useEffect(() => {
-    if (!id) return
-    const ctrl = new AbortController()
-    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-    return () => ctrl.abort()
-  }, [id])
+  // 動的 OG image 生成は OOM / レンダリング不安定のため一時無効化中。
+  // 再開する際は以下の useEffect（先取りフェッチ）も復活させる。
+  // useEffect(() => {
+  //   if (!id) return
+  //   const ctrl = new AbortController()
+  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+  //   return () => ctrl.abort()
+  // }, [id])
 
-  // OGP / Twitter Card 用のメタタグを動的に注入
+  // OGP / Twitter Card 用のメタタグを動的に注入。
+  // 動的 OG image は無効化中のため og:image / twitter:image は出さず、
+  // twitter:card は summary（画像なし）にする。
   useEffect(() => {
     if (!pact) return
     const origin = window.location.origin
     const url = `${origin}/p/${pact.id}`
-    const ogImage = `${origin}/api/v1/public/pacts/${pact.id}/og.png`
     const title = `${pact.author.nickname} の誓約：${pact.goal}`
     const description = `制約：${pact.constraint_text} / 期日：${pact.deadline}`
 
@@ -55,12 +56,10 @@ function PublicPactPage() {
     setMetaProperty("og:title", title)
     setMetaProperty("og:description", description)
     setMetaProperty("og:url", url)
-    setMetaProperty("og:image", ogImage)
     setMetaProperty("og:type", "website")
-    setMetaProperty("twitter:card", "summary_large_image")
+    setMetaProperty("twitter:card", "summary")
     setMetaProperty("twitter:title", title)
     setMetaProperty("twitter:description", description)
-    setMetaProperty("twitter:image", ogImage)
     document.title = title
   }, [pact])
 

--- a/app/frontend/pages/SignedPage.tsx
+++ b/app/frontend/pages/SignedPage.tsx
@@ -67,16 +67,14 @@ function SignedPage() {
     titleMutation.mutate()
   }, [pact, titleMutation])
 
-  // OG image PNG を先取りフェッチして Rails.cache（Solid Cache）を温める。
-  // Render Free tier では初回生成に 10 秒以上かかるため、ユーザーが SignedPage を見ている間に
-  // 裏で生成完了させておく。シェアボタン押下後に X クローラーが来たときには cache hit するので
-  // 即座に PNG を返せる。失敗しても X 投稿フローには影響させない。
-  useEffect(() => {
-    if (!id) return
-    const ctrl = new AbortController()
-    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-    return () => ctrl.abort()
-  }, [id])
+  // 動的 OG image 生成は OOM / レンダリング不安定のため一時無効化中。
+  // 再開する際は以下の useEffect を復活させる（cache 温め用の先取りフェッチ）。
+  // useEffect(() => {
+  //   if (!id) return
+  //   const ctrl = new AbortController()
+  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+  //   return () => ctrl.abort()
+  // }, [id])
 
   if (isLoading) {
     return (

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,14 @@
 
     <%# 公開契約ページ（/p/:id）の OGP / Twitter Card meta タグ。
         SPA の useEffect で注入する meta は X クローラーから見えないため、
-        サーバーサイドで HTML に直接埋め込む。 %>
+        サーバーサイドで HTML に直接埋め込む。
+        ※ 動的 OG 画像生成は OOM / レンダリング不安定のため一時無効化中。
+           og:image / twitter:image を出さず、twitter:card は summary（画像なし）にする。
+           動的画像生成を再開する際は、og:image / twitter:image の出力と
+           twitter:card を summary_large_image に戻し、SignedPage / PublicPactPage の
+           先取りフェッチも復活させる。 %>
     <% if defined?(@pact) && @pact.present? %>
       <% page_url    = "#{request.protocol}#{request.host_with_port}/p/#{@pact.id}" %>
-      <% image_url   = "#{request.protocol}#{request.host_with_port}/api/v1/public/pacts/#{@pact.id}/og.png" %>
       <% nickname    = @pact.user&.nickname.presence || "誓約者" %>
       <% page_title  = "#{nickname} の誓約：#{@pact.goal}" %>
       <% description = "目標：#{@pact.goal} ／ 制約：#{@pact.constraint_text} ／ 期日：#{@pact.deadline}" %>
@@ -22,13 +26,11 @@
       <meta property="og:title"         content="<%= page_title %>">
       <meta property="og:description"   content="<%= description %>">
       <meta property="og:url"           content="<%= page_url %>">
-      <meta property="og:image"         content="<%= image_url %>">
       <meta property="og:type"          content="article">
       <meta property="og:site_name"     content="Vow Pact">
-      <meta name="twitter:card"         content="summary_large_image">
+      <meta name="twitter:card"         content="summary">
       <meta name="twitter:title"        content="<%= page_title %>">
       <meta name="twitter:description"  content="<%= description %>">
-      <meta name="twitter:image"        content="<%= image_url %>">
     <% end %>
 
     <%= yield :head %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,13 +53,18 @@ Rails.application.configure do
   # 本格的な永続キャッシュが必要になった段階で `bin/rails solid_cache:install` で
   # migration を作成して Solid Cache に戻す。
   #
+  # メモリ上限（OOM 対策）:
+  #   Render Free tier の RAM は 512MB。Rails 起動で 200〜250MB、rsvg-convert + Noto CJK で
+  #   一時的に +50MB スパイクするため、cache 上限は 64MB に抑える（256MB だと OOM-kill が起きた）。
+  #   PNG 1 枚 ~250KB（2x 出力）+ gzip 圧縮で実質 ~150KB なので、64MB あれば数百件キャッシュできる。
+  #
   # トレードオフ:
   #   - スピンダウン後の最初のアクセスはキャッシュが空のため OG image 生成に 10 秒以上かかり、
   #     X クローラーのタイムアウトに引っかかる可能性がある（SignedPage の useEffect で
   #     ユーザー操作中に先取りフェッチして温める対応で緩和）。
   #   - PNG（数百 KB）をそのまま保持するとメモリを食うので、compress: true で gzip 圧縮する。
   config.cache_store = :memory_store, {
-    size: 256.megabytes,
+    size: 64.megabytes,
     compress: true,
     compress_threshold: 1.kilobyte
   }

--- a/spec/requests/public_pact_share_spec.rb
+++ b/spec/requests/public_pact_share_spec.rb
@@ -26,20 +26,22 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
         expect(response.media_type).to eq("text/html")
       end
 
-      it "og:image / twitter:card 等の OGP meta タグを HTML に直接埋め込む" do
+      it "OGP meta タグを HTML に直接埋め込む（動的 OG image は一時無効化中のため画像系 meta は出さない）" do
         get "/p/#{pact.id}"
         body = response.body
 
         # 主要 meta が存在すること
         expect(body).to include('property="og:title"')
         expect(body).to include('property="og:description"')
-        expect(body).to include('property="og:image"')
         expect(body).to include('property="og:url"')
         expect(body).to include('name="twitter:card"')
-        expect(body).to include('content="summary_large_image"')
 
-        # OG image URL は API エンドポイントを指す
-        expect(body).to include("/api/v1/public/pacts/#{pact.id}/og.png")
+        # 動的 OG 画像生成は無効化中。og:image / twitter:image は出さず、
+        # twitter:card は summary（画像なし）にする。
+        expect(body).not_to include('property="og:image"')
+        expect(body).not_to include('name="twitter:image"')
+        expect(body).to include('content="summary"')
+        expect(body).not_to include('content="summary_large_image"')
 
         # 契約の中身が description / title に入っている
         expect(body).to include("毎日 30 分読書する")
@@ -60,7 +62,7 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
       it "200 OK だが OGP meta は付かない（React 側で「見つかりません」表示）" do
         get "/p/#{private_pact.id}"
         expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include('property="og:image"')
+        expect(response.body).not_to include('property="og:title"')
         expect(response.body).not_to include("ひみつの目標")
       end
     end
@@ -69,7 +71,7 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
       it "200 OK だが OGP meta は付かない" do
         get "/p/999999"
         expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include('property="og:image"')
+        expect(response.body).not_to include('property="og:title"')
       end
     end
   end


### PR DESCRIPTION
## 背景

1. Render から「Web Service vow_pact exceeded its memory limit」のアラート（Free tier 512MB を超えた → OOM-kill で再起動）
2. OG 画像が「変」に表示される問題（OOM 中の rsvg-convert 失敗が原因の可能性高い）

両方とも本番安定性を脅かすため、まず **動的 OG 画像生成を一時無効化** + **メモリ縮小** で本番を落ち着かせる。

## 変更点

### 1. MemoryStore のサイズを 256MB → 64MB に縮小

\`\`\`ruby
# config/environments/production.rb
config.cache_store = :memory_store, {
  size: 64.megabytes,   # 256 → 64
  compress: true,
  compress_threshold: 1.kilobyte
}
\`\`\`

Render Free tier の 512MB に対し、Rails ベース 200〜250MB + rsvg-convert スパイク +50MB で残り cache 領域が 256MB だと逼迫していた。64MB なら PNG 数百件キャッシュ可能で実用上問題なし。

### 2. 動的 OG 画像生成を一時無効化

- \`application.html.erb\`: og:image / twitter:image meta タグの出力を停止、twitter:card を \`summary\`（画像なし）に切替
- \`SignedPage.tsx\` / \`PublicPactPage.tsx\`: cache 温め用の先取りフェッチ useEffect をコメントアウト
- \`PublicPactPage.tsx\`: クライアント側 meta 動的注入からも og:image / twitter:image を除外
- \`public_pact_share_spec.rb\`: 仕様変更に合わせて検証ロジックを更新（4 件全 pass）

OG image エンドポイント (\`/api/v1/public/pacts/:id/og.png\`) のコード自体は **残す**（直アクセスや将来の復活用）。HTML から参照されないため呼ばれない。

## 復活する際の手順

1. \`application.html.erb\` の og:image / twitter:image 行のコメントアウトを解除
2. \`twitter:card\` を \`summary_large_image\` に戻す
3. SignedPage / PublicPactPage の cache 温め useEffect のコメントアウトを解除
4. PublicPactPage の動的 meta 注入で og:image / twitter:image を再度設定
5. spec の期待値も元に戻す

## 動作確認

- [x] \`bundle exec rspec spec/requests/public_pact_share_spec.rb\`: **4/4**
- [x] \`npm run lint\`: クリーン
- [x] \`npx tsc --noEmit\`: クリーン

## マージ後

Render 再デプロイ後、X 上のカードは「summary」形式（画像なし、テキストのみ）になります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * メモリ使用量を削減し、安定性を向上。キャッシュサイズを最適化。
  * 公開ページでソーシャルメディアカードのメタタグを更新。画像タグは削除され、表示形式をシンプルに変更。

* **テスト**
  * メタタグの新しい動作に対応するテストを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->