### PR TITLE
fix(avatar): rails_blob_url の host 分解 + 全てタブ削除 + デザイントークン拡張 [PR 1/6]

### DIFF
--- a/app/frontend/components/BottomTabs.tsx
+++ b/app/frontend/components/BottomTabs.tsx
@@ -49,7 +49,7 @@ function BottomTabs() {
       <div className="h-16" aria-hidden="true" />
 
       <nav
-        className="fixed bottom-0 inset-x-0 z-40 bg-parchment/95 backdrop-blur-md border-t border-gold/40 shadow-[0_-4px_20px_rgba(139,26,26,0.08)]"
+        className="fixed bottom-0 inset-x-0 z-40 bg-parchment-bg/95 backdrop-blur-md border-t border-gold/40 shadow-[0_-4px_20px_rgba(139,26,26,0.08)]"
         aria-label="メインナビゲーション"
       >
         <div className="container mx-auto max-w-2xl">

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -32,9 +32,9 @@ function Layout({ children, title, showHeader = true, showFooter = true }: Layou
   }
 
   return (
-    <div className="min-h-screen bg-parchment text-ink font-sans flex flex-col">
+    <div className="min-h-screen bg-parchment-bg text-ink font-sans flex flex-col">
       {showHeader && (
-        <header className="border-b border-gold/30 bg-parchment/80 backdrop-blur-sm sticky top-0 z-30">
+        <header className="border-b border-gold/30 bg-parchment-bg/80 backdrop-blur-sm sticky top-0 z-30">
           <div className="container mx-auto px-4 py-3 flex items-center justify-between">
             <Link
               to="/"

--- a/app/frontend/pages/PactsListPage.tsx
+++ b/app/frontend/pages/PactsListPage.tsx
@@ -6,8 +6,9 @@ import Button from "../components/Button"
 import { api, ApiError } from "../lib/api"
 import type { Pact, PactStatus } from "../types/pact"
 
-const STATUS_TABS: { value: PactStatus | "all"; label: string }[] = [
-  { value: "all", label: "全て" },
+// 「全て」タブは削除済み。Hall ページ（紋章コレクション）が
+// 達成 / 進行中 / 破棄 をまとめて表示する役割を担う。
+const STATUS_TABS: { value: PactStatus; label: string }[] = [
   { value: "active", label: "進行中" },
   { value: "completed", label: "達成" },
   { value: "abandoned", label: "破棄" },
@@ -22,21 +23,22 @@ const STATUS_BADGE: Record<PactStatus, { text: string; className: string }> = {
 }
 
 function PactsListPage() {
-  const [filter, setFilter] = useState<PactStatus | "all">("all")
+  // デフォルトは「進行中」。ユーザーがまず確認したいのは active な誓い。
+  const [filter, setFilter] = useState<PactStatus>("active")
 
   const { data: pacts, isLoading, isError } = useQuery<Pact[], ApiError>({
     queryKey: ["pacts"],
     queryFn: () => api<Pact[]>("/pacts"),
   })
 
-  const filtered = pacts?.filter((p) => filter === "all" || p.status === filter) ?? []
+  const filtered = pacts?.filter((p) => p.status === filter) ?? []
 
   return (
     <Layout title="契約一覧">
       <div className="max-w-3xl mx-auto">
         <div className="mb-6 text-center">
           <p className="font-serif text-2xl text-seal mb-2">契約一覧</p>
-          <p className="text-sm text-ink/60">これまでに結んだすべての契約</p>
+          <p className="text-sm text-ink/60">結んだ誓いの記録</p>
         </div>
 
         {/* タブ */}

--- a/app/frontend/styles/application.css
+++ b/app/frontend/styles/application.css
@@ -1,12 +1,37 @@
 @import "tailwindcss";
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;500;600;700&family=Cormorant+Garamond:wght@500;600;700&family=Caveat:wght@500;600&display=swap");
 
 @theme {
-  --color-parchment: #f4e8d0;
+  /* 既存（互換維持）*/
+  --color-parchment: #f4e8d0;        /* 中間: 契約書カード */
   --color-ink: #2c1810;
   --color-seal: #8b1a1a;
   --color-gold: #c9a961;
 
+  /* 背景の 3 層構造（モックアップ準拠）
+     bg(濃) → 中(parchment) → card(薄) で奥行きを出す */
+  --color-parchment-bg: #ece2cf;       /* 外側ページ背景 */
+  --color-parchment-bg-end: #d8c9a8;   /* グラデ終端 */
+  --color-parchment-card: #fbf6ec;     /* 内側カード背景（最も明るい）*/
+  --color-parchment-soft: #f1e7d2;     /* radial gradient 中間色 */
+
+  /* 補助色（モックアップ）*/
+  --color-gold-deep: #a77b1f;          /* 装飾英字 */
+  --color-gold-muted: #8b6f47;         /* 控えめゴールド（ラベル）*/
+  --color-border-soft: #d4c8b0;        /* 罫線 */
+
+  /* レアリティ色（HeraldicCrest 用、PR 2 で参照）*/
+  --color-rarity-common-primary: #7a7060;
+  --color-rarity-common-secondary: #a89c84;
+  --color-rarity-rare-primary: #3a5a8c;
+  --color-rarity-rare-secondary: #7a9bc2;
+  --color-rarity-epic-primary: #6b3a8c;
+  --color-rarity-epic-secondary: #a877c7;
+  --color-rarity-legendary-primary: #a77b1f;
+  --color-rarity-legendary-secondary: #e8c873;
+
   --font-sans: "Noto Sans JP", sans-serif;
   --font-serif: "Noto Serif JP", serif;
+  --font-display: "Cormorant Garamond", "Noto Serif JP", serif;  /* 英字装飾 */
+  --font-signature: "Caveat", "Dancing Script", cursive;          /* 手書き署名 */
 }

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -14,14 +14,26 @@ class UserSerializer
 
   # Active Storage で添付されたアバターのパブリック URL。
   # 添付なしなら nil。FE は avatar_image_url > avatar_url の優先順位で表示する。
+  #
+  # rails_blob_url は host:（ホスト名のみ）と protocol: を分けて受け取る。
+  # FRONTEND_URL は "https://example.com" 形式なので URI で分解する必要がある。
+  # 旧実装は host: にスキーム込みの URL を渡しており、生成 URL が壊れていたため
+  # アバターが本番で表示できなかった。
   attribute :avatar_image_url do |user|
-    if user.avatar.attached?
-      Rails.application.routes.url_helpers.rails_blob_url(
-        user.avatar,
-        host: ENV.fetch("FRONTEND_URL", "http://localhost:3000")
-      )
-    end
-  rescue StandardError
+    next nil unless user.avatar.attached?
+
+    frontend_url = ENV.fetch("FRONTEND_URL", "http://localhost:3000")
+    uri = URI.parse(frontend_url)
+    Rails.application.routes.url_helpers.rails_blob_url(
+      user.avatar,
+      host: uri.host,
+      protocol: uri.scheme || "https",
+      port: (uri.port if uri.port && uri.port != uri.default_port)
+    )
+  rescue StandardError => e
+    Rails.logger.error(
+      "[UserSerializer] avatar_image_url generation failed for user##{user.id}: #{e.class}: #{e.message}"
+    )
     nil
   end
 end

--- a/spec/requests/api/v1/auth/users_spec.rb
+++ b/spec/requests/api/v1/auth/users_spec.rb
@@ -72,6 +72,34 @@ RSpec.describe "Api::V1::Auth::Users", type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    # Active Storage の avatar が添付されているとき、avatar_image_url が
+    # 正しい絶対 URL（host + protocol が分離されたもの）を返すことを保証する。
+    # 旧実装は host: にスキーム込み URL を渡しており URL が壊れていた。
+    context "アバター画像が添付されている場合" do
+      before do
+        post "/api/v1/auth/login", params: login_params, as: :json
+        user.avatar.attach(
+          io: StringIO.new("dummy-png"),
+          filename: "avatar.png",
+          content_type: "image/png"
+        )
+      end
+
+      it "avatar_image_url が rails_blob_url の形式で返る" do
+        get "/api/v1/auth/me", as: :json
+
+        expect(response).to have_http_status(:ok)
+        url = response.parsed_body["avatar_image_url"]
+        expect(url).to be_a(String)
+        # 絶対 URL（http(s):// で始まる）
+        expect(url).to match(%r{\Ahttps?://})
+        # 重複したスキーム（http://https://...）が混入していない
+        expect(url).not_to match(%r{//https?://})
+        # Active Storage のパス
+        expect(url).to include("/rails/active_storage/")
+      end
+    end
   end
 
   describe "PATCH /api/v1/auth/email" do


### PR DESCRIPTION
## 概要

大規模リファイン（13 件改修 + Design 反映）の **PR 1/6**。小粒な修正を先に本番に届ける。

## 変更内容

### 🐛 アバター画像の表示不具合を修正
- `app/serializers/user_serializer.rb`: `rails_blob_url` の `host:` パラメータにスキーム込み URL（`\"https://example.com\"`）を渡していたため URL が壊れ、本番でアバターが表示されなかった。`URI.parse` で host / protocol / port に分解して渡すよう修正。
- `rescue StandardError → nil` を `Rails.logger.error` 付きに変更（原因不明のサイレント失敗を解除）。
- 添付時の URL 形式を保証する request spec を追加（重複スキーム検知 + 絶対 URL）。

### ✂️ 「全て」タブ削除
- `app/frontend/pages/PactsListPage.tsx`: STATUS_TABS から「全て」削除。デフォルトを「進行中」に。
- 達成 / 進行中 / 破棄 の統合表示は今後の Hall ページ（PR 2）の役割。

### 🎨 Design 準拠のデザイントークン拡張
- `app/frontend/styles/application.css`:
  - 背景 3 層（`parchment-bg` #ece2cf / `parchment` #f4e8d0 / `parchment-card` #fbf6ec）
  - 補助色（`gold-deep`, `gold-muted`, `border-soft`）
  - レアリティ色 8 種（HeraldicCrest 用、PR 2 で参照）
  - 装飾フォント（Cormorant Garamond / Caveat）追加
- `app/frontend/components/Layout.tsx` / `BottomTabs.tsx`: 外側背景を `bg-parchment-bg` に切替。カード（`bg-parchment`）と外側で奥行きを出した。

## 全体像（PR 6 までの計画）

| PR | 内容 |
|----|------|
| **PR 1（本 PR）** | アバター修正 + 全てタブ削除 + 色トークン |
| PR 2 | HeraldicCrest + 朱印 + Hall + 進捗草式 |
| PR 3 | 主要 4 画面ポリッシュ + Caveat 署名 |
| PR 4 | AI バリエーション拡充 |
| PR 5 | 公開フィード（ExplorePage） |
| PR 6 | OG 画像有効化（Design ベース） |

## 検証

- ✅ `bundle exec rspec` 317/317 examples
- ✅ `bundle exec rubocop` no offenses
- ✅ `npm run lint` clean
- ✅ `npx tsc --noEmit` clean

## ローカル目視確認

- [ ] `/settings` でアバター画像をアップロード → 保存後に正しく表示される
- [ ] `/pacts` でタブが 4 つ（進行中 / 達成 / 破棄 / 失敗）になり、初期表示が「進行中」
- [ ] 全画面で外側ヘッダー / フッターが少し濃いめの羊皮紙、コンテンツが浮き出る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ナビゲーションバーとレイアウトの背景色スタイルを統一しました。
  * デザインシステムに新しいフォント（Cormorant Garamond、Caveatなど）と色パレット変数を追加しました。

* **バグ修正**
  * ログアウト時のキャッシュ処理をより確実に実施するよう改善しました。
  * アバター画像URLの生成ロジックを最適化しました。
  * 契約一覧のフィルタ機能を簡潔化し、単一ステータスでの絞り込みに対応しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/vow_pact/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->