### PR TITLE
feat: 主要画面に契約書カード + Caveat 署名 + 章ラベル [PR 3/6]

### DIFF
--- a/app/frontend/components/ContractCard.tsx
+++ b/app/frontend/components/ContractCard.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react"
+import CornerOrnament from "./CornerOrnament"
+
+type Props = {
+  children: ReactNode
+  /** カードの追加 className（margin 等の外側調整用）。 */
+  className?: string
+  /** 4 隅の鉤型装飾を出すか。デフォルト true。 */
+  withCorners?: boolean
+  /** 内側の二重線オフセット（px）。デフォルト 10。 */
+  outlineOffset?: number
+}
+
+/**
+ * 契約書らしい装飾を持ったカードラッパー。
+ *
+ * - 羊皮紙背景 + 金の枠
+ * - 4 隅の CornerOrnament
+ * - 内側に薄い金の二重線（outline 1px gold + outlineOffset で実現）
+ * - わずかな影で浮き出させる
+ *
+ * Design signed.jsx ContractCard:177-310 のスタイルを抽象化。
+ * PactDetailPage / SignedPage / 公開ページで共通利用する。
+ */
+function ContractCard({
+  children,
+  className = "",
+  withCorners = true,
+  outlineOffset = 10,
+}: Props) {
+  return (
+    <article
+      className={`relative ${className}`}
+      style={{
+        background: "var(--color-parchment)",
+        border: "0.5px solid var(--color-border-soft)",
+        boxShadow:
+          "0 1px 0 rgba(255,255,255,0.4) inset, 0 12px 28px -16px rgba(44,24,16,0.35), 0 2px 4px rgba(44,24,16,0.06)",
+        padding: "36px 26px 28px",
+        outline: "1px solid var(--color-gold)",
+        outlineOffset: `-${outlineOffset}px`,
+      }}
+    >
+      {withCorners && (
+        <>
+          <CornerOrnament position="tl" />
+          <CornerOrnament position="tr" />
+          <CornerOrnament position="bl" />
+          <CornerOrnament position="br" />
+        </>
+      )}
+      {children}
+    </article>
+  )
+}
+
+export default ContractCard

--- a/app/frontend/pages/HomePage.tsx
+++ b/app/frontend/pages/HomePage.tsx
@@ -50,10 +50,21 @@ function HomePage() {
         </div>
 
         <div className="relative max-w-3xl mx-auto text-center">
+          <p
+            className="font-display font-semibold mb-2"
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.55em",
+              color: "var(--color-gold-deep)",
+              paddingLeft: "0.55em",
+            }}
+            aria-hidden="true"
+          >
+            ── VOW PACT &middot; MMXXVI ──
+          </p>
           <h2 className="font-serif text-3xl sm:text-5xl font-bold text-seal mb-2 tracking-wide">
             誓約 <span className="text-gold mx-1 sm:mx-2">⚔</span> 契約
           </h2>
-          <p className="font-serif text-xs sm:text-sm text-ink/60 mb-3 tracking-[0.3em]">VOW PACT</p>
           <p className="text-ink/80 text-sm sm:text-base leading-relaxed mb-6 max-w-md mx-auto">
             目標と制約を「誓い」として刻み、達成すれば紋章を得る。
             <br className="hidden sm:block" />
@@ -112,12 +123,28 @@ function HomePage() {
 
       {/* 使い方 3 ステップ（ファーストビューに収まる位置に） */}
       <section className="max-w-5xl mx-auto mb-12">
-        <div className="flex items-end justify-between mb-4">
-          <h3 className="font-serif text-xl sm:text-2xl text-seal">使い方</h3>
+        <div className="flex items-end justify-between mb-1">
+          <div>
+            <p
+              className="font-display font-semibold"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.5em",
+                color: "var(--color-gold-muted)",
+                paddingLeft: "0.5em",
+              }}
+              aria-hidden="true"
+            >
+              ── HOW IT WORKS ──
+            </p>
+            <h3 className="font-serif text-xl sm:text-2xl text-seal mt-1">使い方</h3>
+          </div>
           <Link to="/how-it-works" className="text-xs text-seal hover:underline">
             くわしく →
           </Link>
         </div>
+        <div className="mb-4" />
+
 
         <div className="grid grid-cols-3 gap-2 sm:gap-4">
           {HOW_IT_WORKS.map((item) => (
@@ -141,11 +168,23 @@ function HomePage() {
       </section>
 
       {/* 特徴 */}
-      <section className="max-w-4xl mx-auto mb-12">
-        <h3 className="font-serif text-xl sm:text-2xl text-center text-seal mb-2">
+      <section className="max-w-4xl mx-auto mb-12 text-center">
+        <p
+          className="font-display font-semibold mb-1"
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.5em",
+            color: "var(--color-gold-muted)",
+            paddingLeft: "0.5em",
+          }}
+          aria-hidden="true"
+        >
+          ── DIFFERENCES ──
+        </p>
+        <h3 className="font-serif text-xl sm:text-2xl text-seal mb-2">
           他の習慣アプリとの違い
         </h3>
-        <p className="text-center text-xs text-ink/60 mb-6">
+        <p className="text-xs text-ink/60 mb-6">
           「TODO リスト」では味わえない、自分との契約感
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/app/frontend/pages/PactDetailPage.tsx
+++ b/app/frontend/pages/PactDetailPage.tsx
@@ -7,7 +7,9 @@ import Modal from "../components/Modal"
 import HeraldicCrest from "../components/HeraldicCrest"
 import ProgressGrass from "../components/ProgressGrass"
 import StarDivider from "../components/StarDivider"
+import ContractCard from "../components/ContractCard"
 import { api, ApiError } from "../lib/api"
+import { useAuth } from "../hooks/useAuth"
 import type { Pact } from "../types/pact"
 import type { CheckIn, CheckInStatus } from "../types/check_in"
 
@@ -27,10 +29,53 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10)
 }
 
+/** 契約書のセクション（【目標】 / 【制約】 / 等のラベル付き）。 */
+function DetailSection({
+  label,
+  en,
+  children,
+}: {
+  label: string
+  en: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="mb-4">
+      <div className="flex items-baseline justify-between mb-1.5">
+        <h3
+          className="font-serif font-semibold m-0"
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.45em",
+            color: "var(--color-gold-muted)",
+            paddingLeft: "0.45em",
+          }}
+        >
+          【{label}】
+        </h3>
+        <span
+          className="font-display"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.3em",
+            color: "var(--color-gold-muted)",
+            opacity: 0.7,
+          }}
+          aria-hidden="true"
+        >
+          {en}
+        </span>
+      </div>
+      {children}
+    </section>
+  )
+}
+
 function PactDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { user } = useAuth()
   const [note, setNote] = useState("")
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [editOpen, setEditOpen] = useState(false)
@@ -114,10 +159,37 @@ function PactDetailPage() {
           </div>
         )}
 
-        {/* 契約サマリ */}
-        <div className="mb-6 p-6 bg-parchment border-2 border-gold/60 rounded-sm">
-          <div className="flex items-start justify-between gap-3 mb-4">
-            <p className="font-serif text-xl text-seal flex-1">{pact.goal}</p>
+        {/* 契約書（4 隅装飾 + 二重金枠） */}
+        <ContractCard className="mb-6">
+          {/* 表題 */}
+          <header className="text-center mb-4">
+            <h2
+              className="font-serif font-semibold m-0"
+              style={{
+                fontSize: "clamp(20px, 6vw, 24px)",
+                letterSpacing: "0.45em",
+                color: "var(--color-ink)",
+                paddingLeft: "0.45em",
+              }}
+            >
+              誓約契約書
+            </h2>
+            <p
+              className="font-display mt-1.5"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.3em",
+                color: "var(--color-gold-muted)",
+              }}
+            >
+              VOW PACT &middot; No. {String(pact.id).padStart(3, "0")}
+            </p>
+          </header>
+
+          <StarDivider />
+
+          {/* ステータスバッジ */}
+          <div className="flex items-center justify-end mt-4">
             <span
               className={`text-xs px-2 py-0.5 rounded-sm whitespace-nowrap ${
                 pact.status === "active"
@@ -127,17 +199,33 @@ function PactDetailPage() {
                     : "bg-ink/5 text-ink/40 border border-ink/20"
               }`}
             >
-              {pact.status === "active" ? "進行中" : pact.status === "completed" ? "達成" : pact.status}
+              {pact.status === "active"
+                ? "進行中"
+                : pact.status === "completed"
+                  ? "達成"
+                  : pact.status === "abandoned"
+                    ? "破棄"
+                    : pact.status === "failed"
+                      ? "失敗"
+                      : pact.status}
             </span>
           </div>
 
-          {/* 称号（締結時に AI で自動付与される）*/}
+          {/* 称号 */}
           {pact.title && (
-            <section className="mb-4 px-4 py-3 border border-gold/60 bg-gold/5 text-center">
-              <p className="text-[10px] tracking-[0.4em] text-gold font-serif font-semibold mb-1">
-                TITLE GRANTED
+            <section className="mt-4 px-4 py-3 border border-gold/60 bg-gold/5 text-center">
+              <p
+                className="font-display font-semibold mb-1"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: "0.4em",
+                  color: "var(--color-gold-deep)",
+                  paddingLeft: "0.4em",
+                }}
+              >
+                ── TITLE GRANTED ──
               </p>
-              <p className="font-serif text-sm sm:text-base font-semibold text-ink tracking-wider">
+              <p className="font-serif text-base sm:text-lg font-semibold text-ink tracking-wider">
                 {pact.title.endsWith("者") ? (
                   <>
                     {pact.title.slice(0, -1)}
@@ -150,22 +238,67 @@ function PactDetailPage() {
             </section>
           )}
 
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">制約</p>
-            <p className="text-sm text-ink">{pact.constraint_text}</p>
-          </section>
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">期日</p>
-            <p className="text-sm text-ink">{pact.deadline}</p>
-          </section>
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">難易度</p>
-            <p className="text-sm text-ink">
-              {"⚔".repeat(difficulty)}
-              <span className="text-ink/30">{"⚔".repeat(5 - difficulty)}</span>
-              <span className="ml-2">{pact.difficulty} / 5</span>
+          {/* 本文 */}
+          <DetailSection label="目標" en="GOAL">
+            <p className="font-serif text-base text-ink leading-relaxed">{pact.goal}</p>
+          </DetailSection>
+
+          <DetailSection label="制約" en="TRIAL">
+            <p className="font-serif text-base text-ink leading-relaxed">
+              {pact.constraint_text}
             </p>
-          </section>
+          </DetailSection>
+
+          <div className="grid grid-cols-2 gap-4">
+            <DetailSection label="期日" en="DEADLINE">
+              <p className="font-serif text-base text-ink">{pact.deadline}</p>
+            </DetailSection>
+            <DetailSection label="難易度" en="DIFFICULTY">
+              <p className="font-serif text-base">
+                <span className="text-seal tracking-widest">{"⚔".repeat(difficulty)}</span>
+                <span className="text-ink/20 tracking-widest">
+                  {"⚔".repeat(5 - difficulty)}
+                </span>
+                <span className="ml-2 text-sm text-ink/70">{pact.difficulty} / 5</span>
+              </p>
+            </DetailSection>
+          </div>
+
+          <div className="my-5">
+            <StarDivider />
+          </div>
+
+          {/* 署名（誓約者）：Caveat フォントで手書き感 */}
+          <div className="flex items-end justify-between mt-3">
+            <div>
+              <p
+                className="font-display"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: "0.3em",
+                  color: "var(--color-gold-muted)",
+                  marginBottom: 2,
+                }}
+              >
+                SIGNED BY
+              </p>
+              <span
+                className="inline-block"
+                style={{
+                  fontFamily: "var(--font-signature)",
+                  fontSize: 30,
+                  color: "var(--color-ink)",
+                  lineHeight: 1,
+                  transform: "rotate(-2deg)",
+                }}
+              >
+                {user?.nickname ?? "誓約者"}
+              </span>
+            </div>
+            <p className="text-xs text-ink/50">
+              締結 {pact.signed_at.slice(0, 10)}
+            </p>
+          </div>
 
           {/* 公開設定 */}
           <PublicToggle pact={pact} />
@@ -185,7 +318,7 @@ function PactDetailPage() {
               </div>
             </section>
           )}
-        </div>
+        </ContractCard>
 
         {/* 編集モーダル */}
         {editOpen && (

--- a/app/frontend/pages/SignedPage.tsx
+++ b/app/frontend/pages/SignedPage.tsx
@@ -7,6 +7,9 @@ import Button from "../components/Button"
 import ShareButton from "../components/ShareButton"
 import PactSeal from "../components/PactSeal"
 import HeraldicCrest from "../components/HeraldicCrest"
+import ContractCard from "../components/ContractCard"
+import StarDivider from "../components/StarDivider"
+import { useAuth } from "../hooks/useAuth"
 import { api, ApiError } from "../lib/api"
 import type { Pact } from "../types/pact"
 import {
@@ -20,10 +23,54 @@ const fadeUp = {
   animate: { opacity: 1, y: 0 },
 }
 
+/** 契約書のセクションラベル（【目標】 / GOAL）。PactDetailPage の DetailSection と
+ * 同じパターン。コンポーネント分離するほどでもないので各画面でローカル定義する。 */
+function SignedSection({
+  label,
+  en,
+  children,
+}: {
+  label: string
+  en: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="mb-3">
+      <div className="flex items-baseline justify-between mb-1">
+        <h4
+          className="font-serif font-semibold m-0"
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.45em",
+            color: "var(--color-gold-muted)",
+            paddingLeft: "0.45em",
+          }}
+        >
+          【{label}】
+        </h4>
+        <span
+          className="font-display"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.3em",
+            color: "var(--color-gold-muted)",
+            opacity: 0.7,
+          }}
+          aria-hidden="true"
+        >
+          {en}
+        </span>
+      </div>
+      {children}
+    </section>
+  )
+}
+
 function SignedPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { user } = useAuth()
 
   const {
     data: pact,
@@ -171,40 +218,107 @@ function SignedPage() {
           )}
         </motion.div>
 
-        {/* 契約サマリ */}
+        {/* 契約サマリ（ContractCard で 4 隅装飾 + 二重金枠） */}
         <motion.div
-          className="text-left p-6 bg-parchment border-2 border-gold/60 rounded-xl shadow-lg mb-8"
+          className="text-left mb-8"
           {...fadeUp}
           transition={{ duration: 0.6, delay: 1.0 }}
         >
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">目標</p>
-            <p className="text-base text-ink">{pact.goal}</p>
-          </section>
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">制約</p>
-            <p className="text-base text-ink">{pact.constraint_text}</p>
-          </section>
-          <section className="mb-3">
-            <p className="text-xs text-ink/60 font-serif">期日</p>
-            <p className="text-base text-ink">{pact.deadline}</p>
-          </section>
-          <section>
-            <p className="text-xs text-ink/60 font-serif">難易度</p>
-            <p className="text-base text-ink">
-              {(() => {
-                // 想定外の値（API 異常等）でも repeat() が RangeError を起こさないようクランプ
-                const d = Math.min(5, Math.max(0, pact.difficulty))
-                return (
-                  <>
-                    {"⚔".repeat(d)}
-                    <span className="text-ink/30">{"⚔".repeat(5 - d)}</span>
-                    <span className="ml-2 text-sm">{pact.difficulty} / 5</span>
-                  </>
-                )
-              })()}
-            </p>
-          </section>
+          <ContractCard>
+            <header className="text-center mb-3">
+              <h3
+                className="font-serif font-semibold m-0"
+                style={{
+                  fontSize: "clamp(18px, 5.5vw, 22px)",
+                  letterSpacing: "0.45em",
+                  color: "var(--color-ink)",
+                  paddingLeft: "0.45em",
+                }}
+              >
+                誓約契約書
+              </h3>
+              <p
+                className="font-display mt-1.5"
+                style={{
+                  fontSize: 9,
+                  letterSpacing: "0.3em",
+                  color: "var(--color-gold-muted)",
+                }}
+              >
+                VOW PACT &middot; No. {String(pact.id).padStart(3, "0")}
+              </p>
+            </header>
+
+            <StarDivider />
+
+            <div className="mt-5 mb-1">
+              <SignedSection label="目標" en="GOAL">
+                <p className="font-serif text-base text-ink">{pact.goal}</p>
+              </SignedSection>
+              <SignedSection label="制約" en="TRIAL">
+                <p className="font-serif text-base text-ink">{pact.constraint_text}</p>
+              </SignedSection>
+              <div className="grid grid-cols-2 gap-4">
+                <SignedSection label="期日" en="DEADLINE">
+                  <p className="font-serif text-base text-ink">{pact.deadline}</p>
+                </SignedSection>
+                <SignedSection label="難易度" en="DIFFICULTY">
+                  <p className="font-serif text-base">
+                    {(() => {
+                      const d = Math.min(5, Math.max(0, pact.difficulty))
+                      return (
+                        <>
+                          <span className="text-seal tracking-widest">{"⚔".repeat(d)}</span>
+                          <span className="text-ink/20 tracking-widest">
+                            {"⚔".repeat(5 - d)}
+                          </span>
+                          <span className="ml-2 text-sm text-ink/70">
+                            {pact.difficulty} / 5
+                          </span>
+                        </>
+                      )
+                    })()}
+                  </p>
+                </SignedSection>
+              </div>
+            </div>
+
+            <div className="my-4">
+              <StarDivider />
+            </div>
+
+            {/* 署名: Caveat フォントで手書き感 */}
+            <div className="flex items-end justify-between mt-2">
+              <div>
+                <p
+                  className="font-display"
+                  style={{
+                    fontSize: 9,
+                    letterSpacing: "0.3em",
+                    color: "var(--color-gold-muted)",
+                    marginBottom: 2,
+                  }}
+                >
+                  SIGNED BY
+                </p>
+                <span
+                  className="inline-block"
+                  style={{
+                    fontFamily: "var(--font-signature)",
+                    fontSize: 28,
+                    color: "var(--color-ink)",
+                    lineHeight: 1,
+                    transform: "rotate(-2deg)",
+                  }}
+                >
+                  {user?.nickname ?? "誓約者"}
+                </span>
+              </div>
+              <p className="text-xs text-ink/50">
+                締結 {pact.signed_at.slice(0, 10)}
+              </p>
+            </div>
+          </ContractCard>
         </motion.div>
 
         {/* X シェア。常に /p/:id を使い、押下時に契約を公開化する（A 案）。


### PR DESCRIPTION
## 概要

大規模リファインの **PR 3/6**。PR 2 で投入した装飾プリミティブ（CornerOrnament / StarDivider）を主要画面に行き渡らせて、「自分との契約」感を視覚的に強める。

## 新規

### 📜 ContractCard
契約書らしさを持った再利用可能カードラッパー。
- 羊皮紙背景 (`bg-parchment`)
- 4 隅の CornerOrnament（PR 2 で実装）
- 内側に薄い二重金枠（`outline 1px gold` + `outlineOffset -10px`）
- わずかな影で浮き出す
- PactDetailPage / SignedPage で共通利用

## PactDetailPage

契約サマリを ContractCard 化:
- **表題**「誓約契約書」 + Cormorant Garamond の `VOW PACT · No.XXX`
- ステータスバッジ整理（進行中 / 達成 / 破棄 / 失敗 全パターン対応）
- 称号バナーを `── TITLE GRANTED ──` フォーマットで装飾
- **DetailSection** で 【目標】【制約】【期日】【難易度】を統一
  - 各ラベルに英字（GOAL / TRIAL / DEADLINE / DIFFICULTY）併記
- StarDivider をセクション境界に配置
- **Caveat フォント**の手書き署名（誓約者ニックネーム）+ 締結日

## SignedPage

契約サマリを ContractCard 化:
- 同じく表題 + 章ラベル + StarDivider
- SignedSection で統一見出し
- Caveat 署名（締結時の「私はこの誓いを結んだ」という痕跡）

## HomePage

タイポグラフィ polish:
- ヒーローに `── VOW PACT · MMXXVI ──` 装飾英字
- 各セクションに `── HOW IT WORKS ──` / `── DIFFERENCES ──` の章ラベル

## 検証

- ✅ `bundle exec rspec` 317/317 examples
- ✅ `bundle exec rubocop` clean
- ✅ `npm run lint` clean
- ✅ `npx tsc --noEmit` clean

## ローカル目視確認

- [x] `/pacts/:id` 詳細ページで契約書らしい 4 隅装飾 + 二重金枠 + Caveat 署名
- [x] 締結後画面（SignedPage）で同様の契約書スタイル
- [x] HomePage に章ラベルとブランド英字が見える