### PR TITLE
feat(og): OG 画像を Design ベースで再有効化 [PR 6/6]

### DIFF
--- a/app/frontend/pages/PublicPactPage.tsx
+++ b/app/frontend/pages/PublicPactPage.tsx
@@ -33,22 +33,22 @@ function PublicPactPage() {
     enabled: !!id,
   })
 
-  // 動的 OG image 生成は OOM / レンダリング不安定のため一時無効化中。
-  // 再開する際は以下の useEffect（先取りフェッチ）も復活させる。
-  // useEffect(() => {
-  //   if (!id) return
-  //   const ctrl = new AbortController()
-  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-  //   return () => ctrl.abort()
-  // }, [id])
+  // OG image の先取りフェッチ（cache 温め）。SignedPage と同じ意図。
+  useEffect(() => {
+    if (!id) return
+    const ctrl = new AbortController()
+    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+    return () => ctrl.abort()
+  }, [id])
 
   // OGP / Twitter Card 用のメタタグを動的に注入。
-  // 動的 OG image は無効化中のため og:image / twitter:image は出さず、
-  // twitter:card は summary（画像なし）にする。
+  // SSR で /p/:id 直接アクセス時は application.html.erb 側で og:image も含めて埋め込む。
+  // ここで設定するのは SPA 内遷移時の document.title などのフォールバック用。
   useEffect(() => {
     if (!pact) return
     const origin = window.location.origin
     const url = `${origin}/p/${pact.id}`
+    const ogImage = `${origin}/api/v1/public/pacts/${pact.id}/og.png`
     const title = `${pact.author.nickname} の誓約：${pact.goal}`
     const description = `制約：${pact.constraint_text} / 期日：${pact.deadline}`
 
@@ -56,10 +56,12 @@ function PublicPactPage() {
     setMetaProperty("og:title", title)
     setMetaProperty("og:description", description)
     setMetaProperty("og:url", url)
-    setMetaProperty("og:type", "website")
-    setMetaProperty("twitter:card", "summary")
+    setMetaProperty("og:type", "article")
+    setMetaProperty("og:image", ogImage)
+    setMetaProperty("twitter:card", "summary_large_image")
     setMetaProperty("twitter:title", title)
     setMetaProperty("twitter:description", description)
+    setMetaProperty("twitter:image", ogImage)
     document.title = title
   }, [pact])
 

--- a/app/frontend/pages/SignedPage.tsx
+++ b/app/frontend/pages/SignedPage.tsx
@@ -115,14 +115,16 @@ function SignedPage() {
     titleMutation.mutate()
   }, [pact, titleMutation])
 
-  // 動的 OG image 生成は OOM / レンダリング不安定のため一時無効化中。
-  // 再開する際は以下の useEffect を復活させる（cache 温め用の先取りフェッチ）。
-  // useEffect(() => {
-  //   if (!id) return
-  //   const ctrl = new AbortController()
-  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-  //   return () => ctrl.abort()
-  // }, [id])
+  // OG image の先取りフェッチ（cache 温め）。
+  // Render Free tier では rsvg-convert 初回 +Noto CJK 読み込みで 10 秒以上かかるため、
+  // ユーザーが SignedPage を見ている間に裏で発火しておくと、X 投稿後にクローラーが
+  // 来たときにはほぼ即時で 200 を返せる。失敗しても致命的ではないので catch は no-op。
+  useEffect(() => {
+    if (!id) return
+    const ctrl = new AbortController()
+    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+    return () => ctrl.abort()
+  }, [id])
 
   if (isLoading) {
     return (

--- a/app/services/pact_og_image_generator.rb
+++ b/app/services/pact_og_image_generator.rb
@@ -2,112 +2,116 @@ require "open3"
 
 # 公開された契約から、X (Twitter) カードや OGP に表示する PNG 画像を生成する。
 # Twitter カードの推奨サイズは 1200x630（summary_large_image）。
-# 中世ファンタジー風の羊皮紙デザインで、契約の「目標」「制約」「期日」「難易度」を表示。
+#
+# Design 移植版（PR 6）:
+# - 羊皮紙 radial gradient + 二重金枠 + 4 隅装飾（screens/ogp.jsx 準拠）
+# - 左に HeraldicCrest（rarity 別の SVG 紋章。Common なら⚔ ニュアンス、達成済みは
+#   実際の crest.rarity の色）
+# - 右に契約書本文（目標 / 制約 / 期日 / 難易度 / 称号）
+# - 下部に "SIGN · ENDURE · BE CROWNED" + vowpact.app
 class PactOgImageGenerator
   # SVG の論理座標系（コード内の x, y はすべてこの値ベース）。
   # 1200x630 は Twitter Card "summary_large_image" の推奨サイズ。
   WIDTH = 1200
   HEIGHT = 630
   # 出力 PNG のピクセル数。Retina ディスプレイや X 側のダウンスケールで綺麗に見せるため 2x で書き出す。
-  # SVG 内の座標計算は WIDTH/HEIGHT ベースのまま（レンダラー側で拡大）。
   RENDER_WIDTH = WIDTH * 2
   RENDER_HEIGHT = HEIGHT * 2
 
-  COLOR_PARCHMENT = "#f4e8d0"
-  COLOR_INK       = "#2c1810"
-  COLOR_SEAL      = "#8b1a1a"
-  COLOR_GOLD      = "#c9a961"
+  # カラートークン（PR 1 で application.css に追加した値と同じ）
+  COLOR_PARCHMENT       = "#f4e8d0"
+  COLOR_PARCHMENT_LIGHT = "#fbf6ec"
+  COLOR_PARCHMENT_SOFT  = "#f1e7d2"
+  COLOR_INK             = "#2c1810"
+  COLOR_SEAL            = "#8b1a1a"
+  COLOR_GOLD            = "#c9a961"
+  COLOR_GOLD_DEEP       = "#a77b1f"
+  COLOR_GOLD_MUTED      = "#8b6f47"
+  COLOR_BORDER_SOFT     = "#d4c8b0"
+
+  # HeraldicCrest 用 rarity パレット（HeraldicCrest.tsx と完全一致）
+  RARITY_PALETTES = {
+    "common"    => { primary: "#7a7060", secondary: "#a89c84", glow: "rgba(168,156,132,0.25)", decorations: 0 },
+    "rare"      => { primary: "#3a5a8c", secondary: "#7a9bc2", glow: "rgba(80,130,200,0.35)",  decorations: 1 },
+    "epic"      => { primary: "#6b3a8c", secondary: "#a877c7", glow: "rgba(140,80,180,0.4)",   decorations: 2 },
+    "legendary" => { primary: "#a77b1f", secondary: "#e8c873", glow: "rgba(232,200,115,0.55)", decorations: 3 }
+  }.freeze
 
   def initialize(pact)
     @pact = pact
   end
 
   # SVG 文字列を返す。
-  # PNG に変換する場合は #to_png を呼ぶ（rsvg-convert または ImageMagick）。
-  # SignedPage（締結後画面）と同じ「誓いは刻まれた」「成就せり」のヘッドライン構成にしている。
   def to_svg
     completed = @pact.completed?
     headline  = completed ? "成就せり" : "誓いは刻まれた"
     subtitle  = completed ? "あなたの誓いは見事に達成された。紋章が授けられる。"
                           : "本書に記された誓いは、あなた自身との不動の契約となる。"
-    seal_symbol = completed ? "🏆" : "⚔"
+    # 達成済みは実際の crest.rarity の色、進行中は仮想 common（落ち着いた灰銀）
+    rarity = completed && @pact.crest ? @pact.crest.rarity : "common"
 
     <<~SVG
       <?xml version="1.0" encoding="UTF-8"?>
       <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}">
-        <defs>
-          <radialGradient id="parchment" cx="50%" cy="40%" r="80%">
-            <stop offset="0%" stop-color="#fbf6ec"/>
-            <stop offset="60%" stop-color="#f1e7d2"/>
-            <stop offset="100%" stop-color="#ead9b8"/>
-          </radialGradient>
-        </defs>
+        #{defs_svg}
+        #{background_svg}
+        #{frame_svg}
+        #{corner_ornaments_svg}
+        #{top_brand_svg}
 
-        <!-- 背景：羊皮紙風グラデーション -->
-        <rect width="100%" height="100%" fill="url(#parchment)"/>
+        <!-- 左側：HeraldicCrest（盾形紋章） -->
+        #{heraldic_crest_svg(cx: 270, cy: 340, size: 280, rarity: rarity)}
 
-        <!-- 二重罫線（外枠） -->
-        <rect x="36" y="36" width="#{WIDTH - 72}" height="#{HEIGHT - 72}" fill="none" stroke="#{COLOR_GOLD}" stroke-width="2"/>
-        <rect x="48" y="48" width="#{WIDTH - 96}" height="#{HEIGHT - 96}" fill="none" stroke="#{COLOR_GOLD}" stroke-width="1" stroke-opacity="0.5"/>
+        <!-- 右側：契約書本文 -->
+        <g>
+          <!-- ヘッドライン -->
+          <text x="580" y="160" font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
+                font-size="48" font-weight="700"
+                fill="#{COLOR_SEAL}" style="fill:#{COLOR_SEAL};">#{escape(headline)}</text>
 
-        <!-- 中央上のシール（円 + シンボル） -->
-        <circle cx="#{WIDTH / 2}" cy="100" r="48" fill="#{COLOR_SEAL}" fill-opacity="0.1"
-                stroke="#{COLOR_GOLD}" stroke-width="3"/>
-        <text x="#{WIDTH / 2}" y="120" text-anchor="middle" font-size="52">#{seal_symbol}</text>
+          <!-- サブタイトル -->
+          <text x="580" y="200" font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
+                font-size="18"
+                fill="#{COLOR_INK}" fill-opacity="0.7"
+                style="fill:#{COLOR_INK};fill-opacity:0.7;">#{escape(subtitle)}</text>
 
-        <!-- ヘッドライン: fill は style でも明示する（rsvg-convert の一部環境で
-             attribute fill より style fill の方が確実に効くケースがあるため） -->
-        <text x="#{WIDTH / 2}" y="195" text-anchor="middle"
-              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
-              font-size="42" font-weight="bold"
-              fill="#{COLOR_SEAL}" style="fill:#{COLOR_SEAL};">#{headline}</text>
+          <!-- 区切り（金線 + 星） -->
+          #{divider_svg(x1: 580, x2: 1110, y: 230)}
 
-        <!-- サブタイトル -->
-        <text x="#{WIDTH / 2}" y="240" text-anchor="middle"
-              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
-              font-size="20"
-              fill="#{COLOR_INK}" fill-opacity="0.7" style="fill:#{COLOR_INK};fill-opacity:0.7;">#{subtitle}</text>
+          <!-- 目標 -->
+          <text x="580" y="278" font-family="'Cormorant Garamond', 'Noto Serif JP', serif"
+                font-size="14" font-weight="600" letter-spacing="6"
+                fill="#{COLOR_GOLD_MUTED}" style="fill:#{COLOR_GOLD_MUTED};">GOAL</text>
+          #{wrap_text(@pact.goal, x: 580, y: 312, width: 540, font_size: 28, color: COLOR_INK, max_lines: 2)}
 
-        <!-- 称号バナー（pact.title が存在するときのみ） -->
+          <!-- 制約 -->
+          <text x="580" y="386" font-family="'Cormorant Garamond', 'Noto Serif JP', serif"
+                font-size="14" font-weight="600" letter-spacing="6"
+                fill="#{COLOR_GOLD_MUTED}" style="fill:#{COLOR_GOLD_MUTED};">TRIAL</text>
+          #{wrap_text(@pact.constraint_text, x: 580, y: 418, width: 540, font_size: 22, color: COLOR_INK, max_lines: 2)}
+
+          <!-- 期日・難易度 -->
+          <text x="580" y="488" font-family="'Cormorant Garamond', 'Noto Serif JP', serif"
+                font-size="13" font-weight="600" letter-spacing="6"
+                fill="#{COLOR_GOLD_MUTED}" style="fill:#{COLOR_GOLD_MUTED};">DEADLINE</text>
+          <text x="580" y="518" font-family="'Noto Serif JP', serif" font-size="22"
+                fill="#{COLOR_INK}" style="fill:#{COLOR_INK};">#{@pact.deadline}</text>
+
+          <text x="850" y="488" font-family="'Cormorant Garamond', 'Noto Serif JP', serif"
+                font-size="13" font-weight="600" letter-spacing="6"
+                fill="#{COLOR_GOLD_MUTED}" style="fill:#{COLOR_GOLD_MUTED};">DIFFICULTY</text>
+          <text x="850" y="518" font-family="'Noto Serif JP', serif" font-size="22">
+            #{difficulty_marks_svg}
+          </text>
+        </g>
+
         #{title_banner_svg}
-
-        <!-- 契約書ボックス -->
-        <rect x="80" y="370" width="#{WIDTH - 160}" height="210" rx="12"
-              fill="#{COLOR_PARCHMENT}" stroke="#{COLOR_GOLD}" stroke-width="2"/>
-
-        <!-- 目標 -->
-        <text x="100" y="395" font-family="'Noto Serif JP', serif" font-size="18"
-              fill="#{COLOR_INK}" fill-opacity="0.6">目標</text>
-        #{wrap_text(@pact.goal, x: 100, y: 428, width: 1000, font_size: 28, color: COLOR_INK, max_lines: 1)}
-
-        <!-- 制約 -->
-        <text x="100" y="465" font-family="'Noto Serif JP', serif" font-size="18"
-              fill="#{COLOR_INK}" fill-opacity="0.6">制約</text>
-        #{wrap_text(@pact.constraint_text, x: 100, y: 498, width: 1000, font_size: 24, color: COLOR_INK, max_lines: 1)}
-
-        <!-- 期日 -->
-        <text x="100" y="535" font-family="'Noto Serif JP', serif" font-size="18"
-              fill="#{COLOR_INK}" fill-opacity="0.6">期日</text>
-        <text x="100" y="565" font-family="'Noto Serif JP', serif" font-size="26"
-              fill="#{COLOR_INK}">#{@pact.deadline}</text>
-
-        <!-- 難易度 -->
-        <text x="600" y="535" font-family="'Noto Serif JP', serif" font-size="18"
-              fill="#{COLOR_INK}" fill-opacity="0.6">難易度</text>
-        <text x="600" y="565" font-family="'Noto Serif JP', serif" font-size="26">
-          #{difficulty_marks_svg}
-        </text>
-
-        <!-- 右下のブランディング -->
-        <text x="#{WIDTH - 60}" y="615" text-anchor="end"
-              font-family="'Cormorant Garamond', serif" font-size="14"
-              fill="#{COLOR_GOLD}" letter-spacing="3">VOW PACT</text>
+        #{footer_svg}
       </svg>
     SVG
   end
 
   # SVG を PNG に変換する。
-  # 優先順位: rsvg-convert（日本語フォントに強い）→ ImageMagick convert → フォールバック PNG。
   def to_png
     if rsvg_available?
       png_via_rsvg
@@ -120,6 +124,217 @@ class PactOgImageGenerator
   end
 
   private
+
+  # =====================================================================
+  # SVG 部品
+  # =====================================================================
+
+  def defs_svg
+    <<~SVG
+      <defs>
+        <radialGradient id="og-bg" cx="35%" cy="40%" r="85%">
+          <stop offset="0%" stop-color="#{COLOR_PARCHMENT_LIGHT}"/>
+          <stop offset="55%" stop-color="#{COLOR_PARCHMENT_SOFT}"/>
+          <stop offset="100%" stop-color="#e2d2ad"/>
+        </radialGradient>
+        <linearGradient id="og-edge" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#000000" stop-opacity="0.06"/>
+          <stop offset="50%" stop-color="#000000" stop-opacity="0"/>
+          <stop offset="100%" stop-color="#000000" stop-opacity="0.08"/>
+        </linearGradient>
+      </defs>
+    SVG
+  end
+
+  def background_svg
+    <<~SVG
+      <rect width="100%" height="100%" fill="url(#og-bg)"/>
+      <rect width="100%" height="100%" fill="url(#og-edge)"/>
+    SVG
+  end
+
+  # 二重の金枠（外: 太、内: 細）。
+  def frame_svg
+    <<~SVG
+      <rect x="28" y="28" width="#{WIDTH - 56}" height="#{HEIGHT - 56}"
+            fill="none" stroke="#{COLOR_GOLD}" stroke-width="2.5"/>
+      <rect x="42" y="42" width="#{WIDTH - 84}" height="#{HEIGHT - 84}"
+            fill="none" stroke="#{COLOR_GOLD}" stroke-width="1" stroke-opacity="0.55"/>
+    SVG
+  end
+
+  # 4 隅の鉤型装飾（CornerOrnament を OGP 用にスケールアップ）。
+  def corner_ornaments_svg
+    [
+      [ 70, 70, 0 ],
+      [ WIDTH - 70, 70, 90 ],
+      [ 70, HEIGHT - 70, -90 ],
+      [ WIDTH - 70, HEIGHT - 70, 180 ]
+    ].map do |x, y, rot|
+      <<~SVG
+        <g transform="translate(#{x},#{y}) rotate(#{rot})" opacity="0.85">
+          <path d="M0 0 L60 0 M0 0 L0 60" stroke="#{COLOR_GOLD}" stroke-width="2"/>
+          <circle cx="0" cy="0" r="4" fill="#{COLOR_GOLD}"/>
+          <path d="M14 0 L18 -3 L18 3 Z" fill="#{COLOR_GOLD}"/>
+          <path d="M0 14 L-3 18 L3 18 Z" fill="#{COLOR_GOLD}"/>
+        </g>
+      SVG
+    end.join
+  end
+
+  # 上部のブランド帯
+  def top_brand_svg
+    <<~SVG
+      <text x="#{WIDTH / 2}" y="105" text-anchor="middle"
+            font-family="'Cormorant Garamond', serif"
+            font-size="20" font-weight="700" letter-spacing="13"
+            fill="#{COLOR_GOLD_DEEP}" style="fill:#{COLOR_GOLD_DEEP};">── VOW PACT · MMXXVI ──</text>
+    SVG
+  end
+
+  # 区切り線（金線 + 中央の星）
+  def divider_svg(x1:, x2:, y:)
+    star_x = (x1 + x2) / 2
+    s = 8
+    <<~SVG
+      <path d="M #{x1} #{y} L #{star_x - s - 4} #{y}" stroke="#{COLOR_GOLD}" stroke-width="1.5" opacity="0.6"/>
+      <path d="M #{star_x} #{y - s} L #{star_x + s * 0.3} #{y - s * 0.3} L #{star_x + s} #{y} L #{star_x + s * 0.3} #{y + s * 0.3} L #{star_x} #{y + s} L #{star_x - s * 0.3} #{y + s * 0.3} L #{star_x - s} #{y} L #{star_x - s * 0.3} #{y - s * 0.3} Z" fill="#{COLOR_GOLD}"/>
+      <path d="M #{star_x + s + 4} #{y} L #{x2} #{y}" stroke="#{COLOR_GOLD}" stroke-width="1.5" opacity="0.6"/>
+    SVG
+  end
+
+  # フッター: 左 SIGN · ENDURE · BE CROWNED / 右 vowpact.app
+  def footer_svg
+    <<~SVG
+      <g opacity="0.78">
+        <text x="70" y="#{HEIGHT - 50}"
+              font-family="'Cormorant Garamond', serif"
+              font-size="14" font-weight="600" letter-spacing="6"
+              fill="#{COLOR_GOLD_DEEP}" style="fill:#{COLOR_GOLD_DEEP};">SIGN · ENDURE · BE CROWNED</text>
+        <text x="#{WIDTH - 70}" y="#{HEIGHT - 50}" text-anchor="end"
+              font-family="'Cormorant Garamond', serif"
+              font-size="14" font-weight="600" letter-spacing="6"
+              fill="#{COLOR_GOLD_DEEP}" style="fill:#{COLOR_GOLD_DEEP};">vowpact.app</text>
+      </g>
+    SVG
+  end
+
+  # 称号バナー（pact.title が存在するときのみ）
+  def title_banner_svg
+    return "" if @pact.title.blank?
+
+    <<~SVG
+      <g transform="translate(0, 562)">
+        <rect x="580" y="0" width="540" height="50" rx="2"
+              fill="rgba(201,169,97,0.10)" stroke="#{COLOR_GOLD}" stroke-width="1"/>
+        <text x="850" y="20" text-anchor="middle"
+              font-family="'Cormorant Garamond', serif" font-size="11"
+              fill="#{COLOR_GOLD_DEEP}" letter-spacing="6"
+              style="fill:#{COLOR_GOLD_DEEP};">── TITLE GRANTED ──</text>
+        <text x="850" y="42" text-anchor="middle"
+              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
+              font-size="18" font-weight="700"
+              fill="#{COLOR_INK}" style="fill:#{COLOR_INK};">#{escape(@pact.title.to_s)}</text>
+      </g>
+    SVG
+  end
+
+  # =====================================================================
+  # HeraldicCrest（盾形紋章）— React 版 HeraldicCrest.tsx の Ruby 移植
+  # =====================================================================
+
+  # 中央に "誓" 字、上部冠、下部星（rarity の decorations + 1 個）、月桂樹、外周 8 ドット環。
+  # cx/cy は紋章の中心座標、size はピクセル幅。
+  def heraldic_crest_svg(cx:, cy:, size:, rarity:)
+    palette = RARITY_PALETTES[rarity.to_s] || RARITY_PALETTES["common"]
+    primary = palette[:primary]
+    secondary = palette[:secondary]
+    glow = palette[:glow]
+    decorations = palette[:decorations]
+
+    # SVG 内部は viewBox 0 0 140 140 で描いて scale で size に合わせる
+    scale = size.to_f / 140.0
+    half = size / 2.0
+    # transform 内では `(cx - half), (cy - half)` で平行移動 → scale → 内部 viewBox
+    # viewBox 内の中心 (70, 70) を size の中央に置く
+    star_paths = (0...(decorations + 1)).map do |i|
+      offset = (i - decorations / 2.0) * 8
+      "<path d=\"M#{offset} -3 L#{offset + 1.4} -0.6 L#{offset + 4} -0.2 L#{offset + 2} 1.6 L#{offset + 2.6} 4.4 L#{offset} 3 L#{offset - 2.6} 4.4 L#{offset - 2} 1.6 L#{offset - 4} -0.2 L#{offset - 1.4} -0.6 Z\" fill=\"#{primary}\"/>"
+    end.join
+
+    # 外周 8 ドット
+    dots = (0...8).map do |i|
+      angle = (i.to_f / 8) * Math::PI * 2 - Math::PI / 2
+      cx_d = 70 + Math.cos(angle) * 60
+      cy_d = 70 + Math.sin(angle) * 60
+      r = i.even? ? 1.2 : 0.6
+      "<circle cx=\"#{cx_d.round(2)}\" cy=\"#{cy_d.round(2)}\" r=\"#{r}\" fill=\"#{primary}\"/>"
+    end.join
+
+    <<~SVG
+      <g transform="translate(#{cx - half}, #{cy - half}) scale(#{scale})">
+        <!-- ラジアルグロー（背景） -->
+        <circle cx="70" cy="70" r="80" fill="#{glow}" opacity="0.9"/>
+        <defs>
+          <linearGradient id="og-shield-#{rarity}" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#{secondary}"/>
+            <stop offset="100%" stop-color="#{primary}"/>
+          </linearGradient>
+          <linearGradient id="og-band-#{rarity}" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#{COLOR_PARCHMENT_LIGHT}"/>
+            <stop offset="100%" stop-color="#e8dec6"/>
+          </linearGradient>
+        </defs>
+
+        <!-- 月桂樹 左 -->
+        <g transform="translate(8, 60) rotate(-8)" opacity="0.8">
+          <path d="M0 35 Q-2 25 0 18 Q-3 10 -2 0 Q3 8 5 18 Q3 28 0 35z" fill="#{secondary}" opacity="0.6"/>
+          <path d="M-4 30 Q-8 25 -10 20" stroke="#{primary}" stroke-width="1" fill="none"/>
+          <path d="M-4 18 Q-8 14 -10 10" stroke="#{primary}" stroke-width="1" fill="none"/>
+        </g>
+        <!-- 月桂樹 右（鏡像） -->
+        <g transform="translate(132, 60) rotate(8) scale(-1, 1)" opacity="0.8">
+          <path d="M0 35 Q-2 25 0 18 Q-3 10 -2 0 Q3 8 5 18 Q3 28 0 35z" fill="#{secondary}" opacity="0.6"/>
+          <path d="M-4 30 Q-8 25 -10 20" stroke="#{primary}" stroke-width="1" fill="none"/>
+          <path d="M-4 18 Q-8 14 -10 10" stroke="#{primary}" stroke-width="1" fill="none"/>
+        </g>
+
+        <!-- 盾本体 -->
+        <path d="M70 14 L108 22 L108 70 Q108 100 70 122 Q32 100 32 70 L32 22 Z"
+              fill="url(#og-shield-#{rarity})" stroke="#{primary}" stroke-width="1.5"/>
+
+        <!-- 内側ハイライト -->
+        <path d="M70 18 L104 25 L104 70 Q104 96 70 116 Q36 96 36 70 L36 25 Z"
+              fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="0.8"/>
+
+        <!-- 中央バンド -->
+        <path d="M37 56 L103 56 L103 76 Q103 80 100 82 L70 90 L40 82 Q37 80 37 76 Z"
+              fill="url(#og-band-#{rarity})" stroke="#{primary}" stroke-width="1"/>
+
+        <!-- 中央の "誓" 字 -->
+        <text x="70" y="78" text-anchor="middle"
+              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
+              font-size="22" font-weight="700"
+              fill="#{primary}" style="fill:#{primary};">誓</text>
+
+        <!-- 上部の冠 -->
+        <g transform="translate(70, 28)">
+          <path d="M-12 6 L-8 -2 L-4 4 L0 -6 L4 4 L8 -2 L12 6 Z" fill="#{secondary}" stroke="#{primary}" stroke-width="0.8"/>
+          <circle cx="0" cy="-6" r="1.6" fill="#{primary}"/>
+        </g>
+
+        <!-- 下部の星（rarity の装飾レベル） -->
+        <g transform="translate(70, 102)">#{star_paths}</g>
+
+        <!-- 外周 8 ドット環 -->
+        <g opacity="0.6">#{dots}</g>
+      </g>
+    SVG
+  end
+
+  # =====================================================================
+  # PNG 変換
+  # =====================================================================
 
   def rsvg_available?
     @rsvg_available ||= system("which rsvg-convert > /dev/null 2>&1")
@@ -161,8 +376,11 @@ class PactOgImageGenerator
     )
   end
 
-  # 文字列を最大 max_lines 行に折り返す簡易ラッパー。
-  # 漢字・かな前提で、半角は 2 文字 = 1 文字幅相当として概算する。
+  # =====================================================================
+  # ヘルパー
+  # =====================================================================
+
+  # 文字列を最大 max_lines 行に折り返す。漢字・かな前提で半角=2 文字相当の概算。
   def wrap_text(text, x:, y:, width:, font_size:, color:, max_lines: 2)
     return "" if text.blank?
 
@@ -180,7 +398,6 @@ class PactOgImageGenerator
     end
     lines << buffer.join if buffer.any? && lines.size < max_lines
 
-    # 最後の行が max_lines に達して余りがあれば省略記号を付ける
     if lines.size == max_lines && (chars_per_line * max_lines) < chars.size
       last = lines.last
       lines[-1] = "#{last[0...-1]}…"
@@ -188,61 +405,26 @@ class PactOgImageGenerator
 
     lines.each_with_index.map do |line, i|
       line_y = y + (i * (font_size + 8))
-      escaped = line.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;")
       <<~LINE.chomp
         <text x="#{x}" y="#{line_y}" font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
-              font-size="#{font_size}" fill="#{color}" font-weight="bold">#{escaped}</text>
+              font-size="#{font_size}" fill="#{color}" font-weight="700"
+              style="fill:#{color};">#{escape(line)}</text>
       LINE
     end.join("\n")
   end
 
-  def difficulty_marks
-    n = [ [ @pact.difficulty.to_i, 0 ].max, 5 ].min
-    ("⚔" * n) + ("⚔" * (5 - n))
-  end
-
-  # 称号バナー（TITLE GRANTED + 称号）。pact.title が無い場合は何も描画しない。
-  # サブタイトルと契約書ボックスの間（y: 270-355）に配置する。
-  def title_banner_svg
-    return "" if @pact.title.blank?
-
-    title_text = @pact.title.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;")
-    <<~SVG
-      <g>
-        <rect x="350" y="280" width="500" height="60" rx="2"
-              fill="rgba(201,169,97,0.10)" stroke="#{COLOR_GOLD}" stroke-width="1.2"/>
-        <text x="#{WIDTH / 2}" y="300" text-anchor="middle"
-              font-family="'Cormorant Garamond', serif" font-size="11"
-              fill="#{COLOR_GOLD}" letter-spacing="6"
-              style="fill:#{COLOR_GOLD};">TITLE GRANTED</text>
-        <text x="#{WIDTH / 2}" y="328" text-anchor="middle"
-              font-family="'Noto Serif JP', 'Hiragino Mincho ProN', serif"
-              font-size="22" font-weight="bold"
-              fill="#{COLOR_INK}" style="fill:#{COLOR_INK};">#{title_text}</text>
-      </g>
-    SVG
-  end
-
-  # SignedPage と同じく「⚔ × n（seal）+ ⚔ × (5-n)（薄墨） {n}/5」を tspan で色分け表示。
-  # dx は rsvg-convert / X 上のレンダラーで意図しない位置にずれる場合があるため空白で代用。
+  # SignedPage と同じく "⚔ × n（seal）+ ⚔ × (5-n)（薄墨） {n}/5" を tspan で色分け表示。
   def difficulty_marks_svg
     n = [ [ @pact.difficulty.to_i, 0 ].max, 5 ].min
     parts = []
-    parts << "<tspan fill=\"#{COLOR_SEAL}\">#{'⚔' * n}</tspan>" if n.positive?
-    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.3\">#{'⚔' * (5 - n)}</tspan>" if n < 5
-    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.6\" font-size=\"20\">  #{n} / 5</tspan>"
+    parts << "<tspan fill=\"#{COLOR_SEAL}\" style=\"fill:#{COLOR_SEAL};\">#{'⚔' * n}</tspan>" if n.positive?
+    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.3\" style=\"fill:#{COLOR_INK};fill-opacity:0.3;\">#{'⚔' * (5 - n)}</tspan>" if n < 5
+    parts << "<tspan fill=\"#{COLOR_INK}\" fill-opacity=\"0.6\" font-size=\"18\">  #{n} / 5</tspan>"
     parts.join
   end
 
-  def completed_badge
-    <<~SVG
-      <g transform="translate(#{WIDTH - 240}, 100)">
-        <circle cx="80" cy="80" r="76" fill="#{COLOR_GOLD}" fill-opacity="0.2"
-                stroke="#{COLOR_GOLD}" stroke-width="3"/>
-        <text x="80" y="100" text-anchor="middle" font-size="60">🏆</text>
-        <text x="80" y="172" text-anchor="middle" font-size="22"
-              font-family="'Noto Serif JP', serif" fill="#{COLOR_SEAL}" font-weight="bold">成就</text>
-      </g>
-    SVG
+  # SVG 中の文字を XML エスケープ。
+  def escape(text)
+    text.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,13 +12,12 @@
     <%# 公開契約ページ（/p/:id）の OGP / Twitter Card meta タグ。
         SPA の useEffect で注入する meta は X クローラーから見えないため、
         サーバーサイドで HTML に直接埋め込む。
-        ※ 動的 OG 画像生成は OOM / レンダリング不安定のため一時無効化中。
-           og:image / twitter:image を出さず、twitter:card は summary（画像なし）にする。
-           動的画像生成を再開する際は、og:image / twitter:image の出力と
-           twitter:card を summary_large_image に戻し、SignedPage / PublicPactPage の
-           先取りフェッチも復活させる。 %>
+        og:image は動的に生成した PNG（PactOgImageGenerator + Design 準拠の盾形紋章）。
+        Render Free tier の OOM 対策として MemoryStore を 64MB に絞り、画像は
+        Rails.cache に updated_at キーでキャッシュする（OgImagesController 参照）。 %>
     <% if defined?(@pact) && @pact.present? %>
       <% page_url    = "#{request.protocol}#{request.host_with_port}/p/#{@pact.id}" %>
+      <% og_image_url = "#{request.protocol}#{request.host_with_port}/api/v1/public/pacts/#{@pact.id}/og.png" %>
       <% nickname    = @pact.user&.nickname.presence || "誓約者" %>
       <% page_title  = "#{nickname} の誓約：#{@pact.goal}" %>
       <% description = "目標：#{@pact.goal} ／ 制約：#{@pact.constraint_text} ／ 期日：#{@pact.deadline}" %>
@@ -28,9 +27,13 @@
       <meta property="og:url"           content="<%= page_url %>">
       <meta property="og:type"          content="article">
       <meta property="og:site_name"     content="Vow Pact">
-      <meta name="twitter:card"         content="summary">
+      <meta property="og:image"         content="<%= og_image_url %>">
+      <meta property="og:image:width"   content="1200">
+      <meta property="og:image:height"  content="630">
+      <meta name="twitter:card"         content="summary_large_image">
       <meta name="twitter:title"        content="<%= page_title %>">
       <meta name="twitter:description"  content="<%= description %>">
+      <meta name="twitter:image"        content="<%= og_image_url %>">
     <% end %>
 
     <%= yield :head %>

--- a/spec/requests/public_pact_share_spec.rb
+++ b/spec/requests/public_pact_share_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
         expect(response.media_type).to eq("text/html")
       end
 
-      it "OGP meta タグを HTML に直接埋め込む（動的 OG image は一時無効化中のため画像系 meta は出さない）" do
+      it "OGP meta タグ（og:image / twitter:image 含む）を HTML に直接埋め込む" do
         get "/p/#{pact.id}"
         body = response.body
 
@@ -36,12 +36,18 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
         expect(body).to include('property="og:url"')
         expect(body).to include('name="twitter:card"')
 
-        # 動的 OG 画像生成は無効化中。og:image / twitter:image は出さず、
-        # twitter:card は summary（画像なし）にする。
-        expect(body).not_to include('property="og:image"')
-        expect(body).not_to include('name="twitter:image"')
-        expect(body).to include('content="summary"')
-        expect(body).not_to include('content="summary_large_image"')
+        # 動的 OG 画像生成（PR 6 で再有効化）。og:image / twitter:image を出し、
+        # twitter:card は summary_large_image。
+        expect(body).to include('property="og:image"')
+        expect(body).to include('name="twitter:image"')
+        expect(body).to include('content="summary_large_image"')
+        # og:image の URL は /api/v1/public/pacts/:id/og.png を指す
+        expect(body).to match(%r{/api/v1/public/pacts/#{pact.id}/og\.png})
+        # 推奨サイズ
+        expect(body).to include('property="og:image:width"')
+        expect(body).to include('content="1200"')
+        expect(body).to include('property="og:image:height"')
+        expect(body).to include('content="630"')
 
         # 契約の中身が description / title に入っている
         expect(body).to include("毎日 30 分読書する")

--- a/spec/services/pact_og_image_generator_spec.rb
+++ b/spec/services/pact_og_image_generator_spec.rb
@@ -40,8 +40,27 @@ RSpec.describe PactOgImageGenerator, type: :service do
         expect(svg).to include("2 / 5")
       end
 
-      it "完了バッジは描画されない" do
-        expect(svg).not_to include("成就")
+      it "active 状態では「成就せり」（達成ヘッドライン）は描画されない" do
+        expect(svg).not_to include("成就せり")
+      end
+
+      it "HeraldicCrest（盾形紋章 + 中央の「誓」字）が描画される" do
+        # 盾の path は HeraldicCrest 共通の値
+        expect(svg).to include("M70 14 L108 22")
+        # 中央バンドの「誓」字（紋章中央）
+        expect(svg).to include(">誓<")
+      end
+
+      it "Design 準拠の二重金枠と 4 隅装飾が含まれる" do
+        expect(svg).to include('stroke-width="2.5"')
+        expect(svg).to include('stroke-opacity="0.55"')
+        expect(svg).to include("M0 0 L60 0 M0 0 L0 60")
+      end
+
+      it "ブランド帯と SIGN · ENDURE · BE CROWNED フッターが含まれる" do
+        expect(svg).to include("VOW PACT · MMXXVI")
+        expect(svg).to include("SIGN · ENDURE · BE CROWNED")
+        expect(svg).to include("vowpact.app")
       end
     end
 
@@ -58,8 +77,14 @@ RSpec.describe PactOgImageGenerator, type: :service do
         expect(svg).to include("あなたの誓いは見事に達成された。紋章が授けられる。")
       end
 
-      it "完了バッジ（成就）が含まれる" do
-        expect(svg).to include("成就")
+      it "達成済み crest があれば rarity 別の紋章色が出る" do
+        # crest を持たせて legendary 色（金）を確認
+        crest = build(:crest, pact: pact, rarity: :legendary)
+        crest.save!(validate: false)
+        pact.reload
+        legendary_svg = described_class.new(pact).to_svg
+        # legendary palette の primary 色（#a77b1f）が SVG に含まれる
+        expect(legendary_svg).to include("#a77b1f")
       end
     end
 


### PR DESCRIPTION
## 概要

大規模リファインの **PR 6/6（最終）**。PR #68 で一時無効化していた動的 OG 画像生成を、Design の OGP プロトタイプ（`screens/ogp.jsx`）ベースで再有効化する。

## 新デザイン（PactOgImageGenerator 完全書き直し）

- 羊皮紙 radial gradient + 二重金枠 + 4 隅装飾（CornerOrnament）
- 上部「── VOW PACT · MMXXVI ──」のブランド帯
- **左に HeraldicCrest**（盾形紋章）: rarity 別の色
  - 達成済み: `pact.crest.rarity` の色
  - 進行中: 落ち着いた common（灰銀）
  - 中央バンドに「誓」字、上部冠、下部星、月桂樹、外周 8 ドット
- **右に契約書本文**:
  - ヘッドライン「誓いは刻まれた / 成就せり」+ サブタイトル
  - GOAL / TRIAL / DEADLINE / DIFFICULTY ラベル付き目標 / 制約 / 期日 / 難易度
- 称号バナー（TITLE GRANTED + 称号）
- フッター「SIGN · ENDURE · BE CROWNED」+ vowpact.app

## 設定 / meta

- `application.html.erb`: `og:image` / `twitter:image` を復活、`twitter:card` を `summary_large_image` に戻す。`og:image:width` / `og:image:height` も明示
- `SignedPage` / `PublicPactPage`: **cache 温め用 useEffect を復活**（rsvg-convert 初回 +Noto CJK 読み込みで 10 秒以上かかる Render Free tier 対策）
- `PublicPactPage`: SPA 内遷移時の `og:image` / `twitter:image` meta 注入も追加
- `production.rb` の MemoryStore 64MB は維持（PR #68 の OOM 対策）

## テスト

- `spec/services/pact_og_image_generator_spec.rb`: 既存 active / completed / title ケースは継続パス。新規アサーション:
  - HeraldicCrest 描画（盾 path + 中央「誓」字）
  - 二重金枠 + 4 隅装飾
  - "VOW PACT · MMXXVI" ブランド帯 + "SIGN · ENDURE · BE CROWNED" フッター
  - legendary crest で金色 (#a77b1f) が出る
- `spec/requests/public_pact_share_spec.rb`: og:image を「出ない」検証から「出る + 1200×630」検証に切替

## 検証

- ✅ `bundle exec rspec` **338/338** examples passed
- ✅ `bundle exec rubocop` clean
- ✅ `bundle exec brakeman` 0 warnings（2 ignored）
- ✅ `npm run lint` clean
- ✅ `npx tsc --noEmit` clean

## 本番デプロイ後の確認

- [ ] X Card Validator (`https://cards-dev.x.com/validator`) で `/p/<id>` を投入し、Design 準拠カードが描画される
- [ ] Render の RAM 使用量を 30 分〜1 時間モニタリング（OOM 再発防止）
- [ ] 公開契約をシェア → SignedPage で先取りフェッチが走る → X 投稿時にカードが即時表示される

## 大規模リファイン完了

PR 1〜PR 6 で 13 件の改善 + Design 反映を完了:
1. ✅ アバター修正 + 全てタブ削除 + 色トークン
2. ✅ HeraldicCrest + 蝋印 + Hall + 進捗草式 + 紋章カタログ
3. ✅ 主要画面ポリッシュ + 契約書カード + Caveat 署名
4. ✅ AI バリエーション拡充（PR 5 に統合）
5. ✅ 公開フィード（広場 /explore）+ AI バリエーション拡充
6. ✅ OG 画像再有効化（本 PR）