### PR TITLE
hotfix(og): 動的 OG 画像生成を再度無効化

### DIFF
--- a/app/frontend/pages/PublicPactPage.tsx
+++ b/app/frontend/pages/PublicPactPage.tsx
@@ -33,22 +33,23 @@ function PublicPactPage() {
     enabled: !!id,
   })
 
-  // OG image の先取りフェッチ（cache 温め）。SignedPage と同じ意図。
-  useEffect(() => {
-    if (!id) return
-    const ctrl = new AbortController()
-    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-    return () => ctrl.abort()
-  }, [id])
+  // 動的 OG image は再度無効化中（rsvg-convert + Render の Design 品質ギャップ）。
+  // og:image meta も layout で出していないので先取りフェッチ不要。
+  // 再開する際は以下を復活させる:
+  // useEffect(() => {
+  //   if (!id) return
+  //   const ctrl = new AbortController()
+  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+  //   return () => ctrl.abort()
+  // }, [id])
 
   // OGP / Twitter Card 用のメタタグを動的に注入。
-  // SSR で /p/:id 直接アクセス時は application.html.erb 側で og:image も含めて埋め込む。
-  // ここで設定するのは SPA 内遷移時の document.title などのフォールバック用。
+  // 動的 OG image は無効化中のため og:image / twitter:image は出さず、
+  // twitter:card は summary（画像なし）にする。
   useEffect(() => {
     if (!pact) return
     const origin = window.location.origin
     const url = `${origin}/p/${pact.id}`
-    const ogImage = `${origin}/api/v1/public/pacts/${pact.id}/og.png`
     const title = `${pact.author.nickname} の誓約：${pact.goal}`
     const description = `制約：${pact.constraint_text} / 期日：${pact.deadline}`
 
@@ -57,11 +58,9 @@ function PublicPactPage() {
     setMetaProperty("og:description", description)
     setMetaProperty("og:url", url)
     setMetaProperty("og:type", "article")
-    setMetaProperty("og:image", ogImage)
-    setMetaProperty("twitter:card", "summary_large_image")
+    setMetaProperty("twitter:card", "summary")
     setMetaProperty("twitter:title", title)
     setMetaProperty("twitter:description", description)
-    setMetaProperty("twitter:image", ogImage)
     document.title = title
   }, [pact])
 

--- a/app/frontend/pages/SignedPage.tsx
+++ b/app/frontend/pages/SignedPage.tsx
@@ -115,16 +115,15 @@ function SignedPage() {
     titleMutation.mutate()
   }, [pact, titleMutation])
 
-  // OG image の先取りフェッチ（cache 温め）。
-  // Render Free tier では rsvg-convert 初回 +Noto CJK 読み込みで 10 秒以上かかるため、
-  // ユーザーが SignedPage を見ている間に裏で発火しておくと、X 投稿後にクローラーが
-  // 来たときにはほぼ即時で 200 を返せる。失敗しても致命的ではないので catch は no-op。
-  useEffect(() => {
-    if (!id) return
-    const ctrl = new AbortController()
-    fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
-    return () => ctrl.abort()
-  }, [id])
+  // 動的 OG image はレンダリング品質の問題（背景黒・フォント崩れ・レイアウト崩れ）
+  // で再度無効化中。og:image meta も layout で出していないので先取りフェッチ不要。
+  // 再開する際は以下を復活させる:
+  // useEffect(() => {
+  //   if (!id) return
+  //   const ctrl = new AbortController()
+  //   fetch(`/api/v1/public/pacts/${id}/og.png`, { signal: ctrl.signal }).catch(() => {})
+  //   return () => ctrl.abort()
+  // }, [id])
 
   if (isLoading) {
     return (

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,14 @@
     <%# 公開契約ページ（/p/:id）の OGP / Twitter Card meta タグ。
         SPA の useEffect で注入する meta は X クローラーから見えないため、
         サーバーサイドで HTML に直接埋め込む。
-        og:image は動的に生成した PNG（PactOgImageGenerator + Design 準拠の盾形紋章）。
-        Render Free tier の OOM 対策として MemoryStore を 64MB に絞り、画像は
-        Rails.cache に updated_at キーでキャッシュする（OgImagesController 参照）。 %>
+        ※ 動的 OG 画像（PactOgImageGenerator）は rsvg-convert + Render の組み合わせで
+           Design 品質に届かない（背景が黒 / フォント崩れ / レイアウト崩れ）ため、
+           再度無効化。og:image / twitter:image を出さず、twitter:card は summary
+           （画像なしのテキストカード）にする。
+           将来 Satori や Cloudflare Browser Rendering 等で再挑戦予定。
+           generator 自体（PactOgImageGenerator / OgImagesController）は残す。 %>
     <% if defined?(@pact) && @pact.present? %>
       <% page_url    = "#{request.protocol}#{request.host_with_port}/p/#{@pact.id}" %>
-      <% og_image_url = "#{request.protocol}#{request.host_with_port}/api/v1/public/pacts/#{@pact.id}/og.png" %>
       <% nickname    = @pact.user&.nickname.presence || "誓約者" %>
       <% page_title  = "#{nickname} の誓約：#{@pact.goal}" %>
       <% description = "目標：#{@pact.goal} ／ 制約：#{@pact.constraint_text} ／ 期日：#{@pact.deadline}" %>
@@ -27,13 +29,9 @@
       <meta property="og:url"           content="<%= page_url %>">
       <meta property="og:type"          content="article">
       <meta property="og:site_name"     content="Vow Pact">
-      <meta property="og:image"         content="<%= og_image_url %>">
-      <meta property="og:image:width"   content="1200">
-      <meta property="og:image:height"  content="630">
-      <meta name="twitter:card"         content="summary_large_image">
+      <meta name="twitter:card"         content="summary">
       <meta name="twitter:title"        content="<%= page_title %>">
       <meta name="twitter:description"  content="<%= description %>">
-      <meta name="twitter:image"        content="<%= og_image_url %>">
     <% end %>
 
     <%= yield :head %>

--- a/spec/requests/public_pact_share_spec.rb
+++ b/spec/requests/public_pact_share_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
         expect(response.media_type).to eq("text/html")
       end
 
-      it "OGP meta タグ（og:image / twitter:image 含む）を HTML に直接埋め込む" do
+      it "OGP meta タグを HTML に直接埋め込む（動的 OG image は再度無効化中のため画像系 meta は出さない）" do
         get "/p/#{pact.id}"
         body = response.body
 
@@ -36,18 +36,12 @@ RSpec.describe "/p/:id 公開契約シェアページ", type: :request do
         expect(body).to include('property="og:url"')
         expect(body).to include('name="twitter:card"')
 
-        # 動的 OG 画像生成（PR 6 で再有効化）。og:image / twitter:image を出し、
-        # twitter:card は summary_large_image。
-        expect(body).to include('property="og:image"')
-        expect(body).to include('name="twitter:image"')
-        expect(body).to include('content="summary_large_image"')
-        # og:image の URL は /api/v1/public/pacts/:id/og.png を指す
-        expect(body).to match(%r{/api/v1/public/pacts/#{pact.id}/og\.png})
-        # 推奨サイズ
-        expect(body).to include('property="og:image:width"')
-        expect(body).to include('content="1200"')
-        expect(body).to include('property="og:image:height"')
-        expect(body).to include('content="630"')
+        # 動的 OG 画像生成は再度無効化中（rsvg-convert + Render の Design 品質ギャップ）。
+        # og:image / twitter:image は出さず、twitter:card は summary（画像なし）にする。
+        expect(body).not_to include('property="og:image"')
+        expect(body).not_to include('name="twitter:image"')
+        expect(body).to include('content="summary"')
+        expect(body).not_to include('content="summary_large_image"')
 
         # 契約の中身が description / title に入っている
         expect(body).to include("毎日 30 分読書する")


### PR DESCRIPTION
## 概要

PR #76 で有効化した動的 OG 画像が本番（Render）で品質要件を満たさないため、再度無効化する。

## 確認された問題（本番 `https://vow-pact.onrender.com/p/26`）

- **背景が黒**になる（rsvg-convert の `radialGradient` 解釈差異が疑わしい）
- **"VOW PACT MMXXVI" の文字が崩れる**（Cormorant Garamond 不在 + kerning）
- **カード内に目標 / 制約 / 期日が収まらず**、盾と並列で散らかる
- 盾紋章のディテール（`feTurbulence` の月桂樹質感）が小サイズで潰れる

## 変更内容

- `application.html.erb`: `og:image` / `twitter:image` / `og:image:width/height` を削除、`twitter:card` を `summary` に戻す
- `SignedPage` / `PublicPactPage`: cache 温め用 `useEffect` をコメントアウト、og:image / twitter:image meta も注入しない、twitter:card=summary
- `spec/requests/public_pact_share_spec.rb`: og:image を「出ない」検証に戻す

`PactOgImageGenerator` / `OgImagesController` / spec **本体は残す**（将来 Satori / Cloudflare Browser Rendering 等で再挑戦する際の足場として）。

## 将来の再挑戦候補

- **Satori（Vercel）+ resvg-js**: HTML/JSX → SVG → PNG。仕様準拠が高く Tailwind 風 className 可
- **Cloudflare Browser Rendering** / Browserless.io: 実 Chromium で完璧（有料）
- **静的 OG 画像 1 枚**（手作りデザイン） + Ruby でテキスト合成だけ

## 検証

- ✅ `bundle exec rspec` 338/338 examples
- ✅ `bundle exec rubocop` clean
- ✅ `npm run lint` clean
- ✅ `npx tsc --noEmit` clean