### PR TITLE
hotfix(robots): クローラーへの明示的 Allow を追加（OGP 表示問題の対策）

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,30 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# Vow Pact robots.txt
+#
+# 仕様メモ:
+# - 空（Disallow なし）でも RFC 上は「全許可」だが、一部のクローラー検証ツール
+#   （特に X Card Validator）が「ルール不明 = 拒否」と解釈する事例が観測された
+#   ため、主要クローラーに対して明示的に Allow: / を書き出している。
+# - サイトマップは現状運用していないので未指定。
+
+User-agent: *
+Allow: /
+
+# X (Twitter) の OGP クローラー。明示しないと Card Validator で
+# "Fetching the page failed because it's denied by robots.txt." と返る場合がある。
+User-agent: Twitterbot
+Allow: /
+
+# Facebook の OGP クローラー。シェアプレビュー用。
+User-agent: facebookexternalhit
+Allow: /
+
+# Slack のリンク展開ボット。Slack 上でリンクをきれいに展開させる。
+User-agent: Slackbot-LinkExpanding
+Allow: /
+
+User-agent: Slackbot
+Allow: /
+
+# Discord の埋め込みボット。
+User-agent: Discordbot
+Allow: /


### PR DESCRIPTION
## 概要

要望「Card Validator で \`robots.txt で拒否\` エラーが繰り返し出る」への対応。

## 経緯

PR #80 で OGP meta を有効化したが、X Card Validator で

> ERROR: Fetching the page failed because it's denied by robots.txt.

が出続けて画像が反映されない状態だった。

### サーバー側の検証結果（全て正常）

| 確認項目 | 結果 |
|---|---|
| \`/og.png\` の HTTP 応答 | ✅ 200 OK, 1200×630, 626KB |
| Twitterbot UA で \`/og.png\` 取得 | ✅ 200 |
| HTML 内の \`og:image\` meta | ✅ 絶対 URL で出力 |
| Twitterbot UA で \`/\` 取得 | ✅ 200, og meta 含む |
| 旧 \`robots.txt\` | 空（Disallow なし = RFC 上は全許可） |

→ サーバーは完璧に動いている。原因は **X Card Validator が空 robots.txt を「ルール不明＝拒否」と解釈**している可能性が高い。

## 変更内容

\`public/robots.txt\` に主要クローラーへの明示的 Allow を追加:

\`\`\`
User-agent: *
Allow: /

User-agent: Twitterbot
Allow: /

User-agent: facebookexternalhit
Allow: /

User-agent: Slackbot-LinkExpanding
Allow: /

User-agent: Slackbot
Allow: /

User-agent: Discordbot
Allow: /
\`\`\`

仕様コメントも添えて、なぜ明示的 Allow を書いているか後の読み手に伝わるように。

## デプロイ後の確認

- [ ] https://vow-pact.onrender.com/robots.txt に明示ルールが反映
- [ ] X Card Validator で \`https://vow-pact.onrender.com/\` を再投入してエラー消滅
- [ ] X カードに /og.png のブランド画像が表示される

## 補足：X の負キャッシュ問題

robots.txt と別に、X は OG メタを **約 7 日キャッシュ**します。過去に画像なし状態で投稿した URL は古いメタを保持し続けます。

→ **キャッシュバスター付き URL**（例: \`https://vow-pact.onrender.com/?v=1\`）で投稿すれば X が新規取得し、画像が即出ます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ウェブクローラーのアクセスポリシーを明示的に設定しました。ソーシャルメディアおよびチャットプラットフォーム（Twitter/X、Facebook、Slack、Discord）でのリンクプレビュー表示が正確に行われるようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/vow_pact/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->