### PR TITLE
hotfix(avatar): RENDER_EXTERNAL_URL を二次 fallback に追加

### DIFF
--- a/app/serializers/public_pact_serializer.rb
+++ b/app/serializers/public_pact_serializer.rb
@@ -26,12 +26,20 @@ class PublicPactSerializer
 
   # rails_blob_url の host: は host 名のみ（"https://example.com" 全体ではない）を
   # 受け取るため、FRONTEND_URL を URI で分解して host / protocol / port を分けて渡す。
-  # 旧実装は host: にスキーム込み URL を渡しており本番でアバター URL が壊れていた
-  # （PR 1 で UserSerializer に同じ修正を適用済み）。
+  #
+  # ベース URL の優先順位:
+  #   1. FRONTEND_URL（明示設定。dev / prod 共通の正規ルート）
+  #   2. RENDER_EXTERNAL_URL（Render が自動で付与。FRONTEND_URL 設定漏れの保険）
+  #   3. http://localhost:3000（dev デフォルト）
+  # UserSerializer と同じロジック。本番で FRONTEND_URL 未設定だと localhost の
+  # URL が返り Mixed Content でブロックされる事故が発生したため、
+  # プラットフォーム側で必ず入る RENDER_EXTERNAL_URL を二次 fallback に置く。
   def self.avatar_blob_url(user)
     return nil unless user&.avatar&.attached?
 
-    frontend_url = ENV.fetch("FRONTEND_URL", "http://localhost:3000")
+    frontend_url = ENV["FRONTEND_URL"].presence ||
+                   ENV["RENDER_EXTERNAL_URL"].presence ||
+                   "http://localhost:3000"
     uri = URI.parse(frontend_url)
     Rails.application.routes.url_helpers.rails_blob_url(
       user.avatar,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -17,12 +17,20 @@ class UserSerializer
   #
   # rails_blob_url は host:（ホスト名のみ）と protocol: を分けて受け取る。
   # FRONTEND_URL は "https://example.com" 形式なので URI で分解する必要がある。
-  # 旧実装は host: にスキーム込みの URL を渡しており、生成 URL が壊れていたため
-  # アバターが本番で表示できなかった。
+  #
+  # ベース URL の優先順位:
+  #   1. FRONTEND_URL（明示設定。dev / prod 共通の正規ルート）
+  #   2. RENDER_EXTERNAL_URL（Render が自動で付与。FRONTEND_URL 設定漏れの保険）
+  #   3. http://localhost:3000（dev デフォルト）
+  # 過去に FRONTEND_URL の本番設定漏れで avatar URL が localhost のまま返り、
+  # HTTPS ページから Mixed Content でブロックされる事故があったため、
+  # プラットフォーム側で必ず入る RENDER_EXTERNAL_URL を二次 fallback に置く。
   attribute :avatar_image_url do |user|
     next nil unless user.avatar.attached?
 
-    frontend_url = ENV.fetch("FRONTEND_URL", "http://localhost:3000")
+    frontend_url = ENV["FRONTEND_URL"].presence ||
+                   ENV["RENDER_EXTERNAL_URL"].presence ||
+                   "http://localhost:3000"
     uri = URI.parse(frontend_url)
     Rails.application.routes.url_helpers.rails_blob_url(
       user.avatar,

--- a/spec/requests/api/v1/auth/users_spec.rb
+++ b/spec/requests/api/v1/auth/users_spec.rb
@@ -99,6 +99,35 @@ RSpec.describe "Api::V1::Auth::Users", type: :request do
         # Active Storage のパス
         expect(url).to include("/rails/active_storage/")
       end
+
+      # 本番（Render）で FRONTEND_URL の設定漏れにより avatar URL が
+      # http://localhost:3000/... となり Mixed Content でブロックされる事故が
+      # 発生したため、Render が自動付与する RENDER_EXTERNAL_URL を二次 fallback
+      # として参照する。これによりプラットフォームの環境変数だけで安全側に倒れる。
+      context "FRONTEND_URL が未設定で RENDER_EXTERNAL_URL が設定されている場合" do
+        around do |example|
+          original_frontend = ENV["FRONTEND_URL"]
+          original_render = ENV["RENDER_EXTERNAL_URL"]
+          ENV.delete("FRONTEND_URL")
+          ENV["RENDER_EXTERNAL_URL"] = "https://vow-pact.onrender.com"
+          example.run
+        ensure
+          ENV["FRONTEND_URL"] = original_frontend
+          if original_render
+            ENV["RENDER_EXTERNAL_URL"] = original_render
+          else
+            ENV.delete("RENDER_EXTERNAL_URL")
+          end
+        end
+
+        it "RENDER_EXTERNAL_URL のホスト名・スキームで URL が生成される" do
+          get "/api/v1/auth/me", as: :json
+
+          url = response.parsed_body["avatar_image_url"]
+          expect(url).to start_with("https://vow-pact.onrender.com/")
+          expect(url).to include("/rails/active_storage/")
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/public/pacts_spec.rb
+++ b/spec/requests/api/v1/public/pacts_spec.rb
@@ -66,6 +66,42 @@ RSpec.describe "Api::V1::Public::Pacts", type: :request do
       expect(author).to have_key("avatar_url")
     end
 
+    # 本番（Render）で FRONTEND_URL の設定漏れにより avatar URL が
+    # http://localhost:3000/... となり Mixed Content でブロックされる事故が
+    # 発生したため、Render が自動付与する RENDER_EXTERNAL_URL を二次 fallback
+    # として参照する。
+    context "FRONTEND_URL が未設定で RENDER_EXTERNAL_URL が設定されている場合" do
+      around do |example|
+        original_frontend = ENV["FRONTEND_URL"]
+        original_render = ENV["RENDER_EXTERNAL_URL"]
+        ENV.delete("FRONTEND_URL")
+        ENV["RENDER_EXTERNAL_URL"] = "https://vow-pact.onrender.com"
+        example.run
+      ensure
+        ENV["FRONTEND_URL"] = original_frontend
+        if original_render
+          ENV["RENDER_EXTERNAL_URL"] = original_render
+        else
+          ENV.delete("RENDER_EXTERNAL_URL")
+        end
+      end
+
+      it "author.avatar_image_url が RENDER_EXTERNAL_URL のドメインで返る" do
+        pact = make_public_pact(user: author_a, goal: "誓約 X")
+        author_a.avatar.attach(
+          io: StringIO.new("dummy-png"),
+          filename: "avatar.png",
+          content_type: "image/png"
+        )
+
+        get "/api/v1/public/pacts", as: :json
+
+        author = response.parsed_body["pacts"].find { |p| p["id"] == pact.id }["author"]
+        expect(author["avatar_image_url"]).to start_with("https://vow-pact.onrender.com/")
+        expect(author["avatar_image_url"]).to include("/rails/active_storage/")
+      end
+    end
+
     context "ページネーション" do
       before do
         # 25 件作って per_page=20 を確認


### PR DESCRIPTION
## 背景

本番（Render）で **アバター画像が保存しても表示されない** 不具合が発生していた。

ブラウザのコンソールには以下のエラー:

> Mixed Content: The page at 'https://vow-pact.onrender.com/settings' was loaded over HTTPS, but requested an insecure element 'http://localhost:3000/rails/active_storage/blobs/...'

## 原因

`UserSerializer#avatar_image_url` および `PublicPactSerializer.avatar_blob_url` が `ENV.fetch(\"FRONTEND_URL\", \"http://localhost:3000\")` を参照していたが、本番の Render 環境に `FRONTEND_URL` が設定されていなかった。

結果、fallback の `http://localhost:3000` が使われて Active Storage の URL が `http://localhost:3000/rails/active_storage/...` で返り、HTTPS ページから Mixed Content でブロックされていた。

## 修正内容

ベース URL の優先順位を変更:

1. `FRONTEND_URL`（明示設定。dev / prod 共通の正規ルート）
2. **`RENDER_EXTERNAL_URL`**（Render が自動で付与）← 新規 fallback
3. `http://localhost:3000`（dev デフォルト）

Render は環境変数 `RENDER_EXTERNAL_URL` を **自動で** 各サービスに付与する（例: `https://vow-pact.onrender.com`）。これを二次 fallback に置くことで、`FRONTEND_URL` の設定漏れがあってもプラットフォーム側で安全側に倒れる。

## 変更ファイル

- `app/serializers/user_serializer.rb` — `avatar_image_url` の fallback 改善
- `app/serializers/public_pact_serializer.rb` — `avatar_blob_url` の fallback 改善
- `spec/requests/api/v1/auth/users_spec.rb` — `RENDER_EXTERNAL_URL` fallback 挙動の spec 追加
- `spec/requests/api/v1/public/pacts_spec.rb` — 同上

## Test plan

- [x] 既存テスト全 340 examples グリーン
- [x] 追加 spec で `RENDER_EXTERNAL_URL` のホスト名・スキームで URL が生成されることを確認
- [x] RuboCop offense なし
- [ ] マージ後、本番 (https://vow-pact.onrender.com/settings) でアバター画像をアップロード → 保存 → 即座に表示されることを確認
- [ ] 既存ユーザーのアバター画像が画面に正しく表示されることを確認

## 補足

- 別途、Render Dashboard に `FRONTEND_URL=https://vow-pact.onrender.com` を明示設定するのが正規ルート。本 PR は **設定漏れ時の保険** を入れるもの。
- 500 エラー（`PATCH /api/v1/auth/me` が 500 を返していた件）が併発していた場合は、別途 Render Logs を確認して調査が必要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * アバター画像URLの生成ロジックを改善し、環境設定に応じた適切なURLが生成されるようになりました。複数の環境変数に対応することで、本番環境やステージング環境での表示問題を解決しました。

* **Tests**
  * 異なる環境設定でのアバター画像URL生成を検証するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/vow_pact/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->