### PR TITLE
hotfix(prod): queue_adapter を :inline にして Solid Queue 依存を解消

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,9 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  # ActionCable は現状未使用。Solid Cable はテーブル未作成のため、
+  # 誤って ActionCable を使い始めた瞬間にエラーになる事故を防ぐため
+  # async（同一プロセス内のみ動く軽量アダプタ）に固定する。
+  # 本格的に WebSocket を使う段階で solid_cable に戻し、
+  # bin/rails solid_cable:install で db/cable_migrate を生成・migrate する。
+  adapter: async

--- a/config/database.yml
+++ b/config/database.yml
@@ -91,12 +91,7 @@ production:
   primary: &primary_production
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
-  cache:
-    <<: *primary_production
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    migrations_paths: db/cable_migrate
+  # Solid Queue / Cache / Cable は現状未使用のため接続定義から外す。
+  # 復活させる場合は本接続定義に加えて、
+  #   bin/rails solid_queue:install / solid_cache:install / solid_cable:install
+  # で db/queue_migrate などを生成 → migrate する必要がある。

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,9 +69,20 @@ Rails.application.configure do
     compress_threshold: 1.kilobyte
   }
 
-  # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  # Active Job 実行アダプタ。
+  #
+  # 当面は :inline（同期実行）を採用する。理由:
+  #   - Solid Queue を本格運用するには worker プロセス（または SOLID_QUEUE_IN_PUMA）と
+  #     専用テーブル（db/queue_migrate）の運用が必要だが、Render Free tier の
+  #     RAM 制約下では worker を別途動かす余裕がない。
+  #   - 現状のジョブ（Active Storage の PurgeJob など）は瞬時に完了するため、
+  #     同期実行で実害がない。
+  #   - 過去に Solid Queue のテーブル（solid_queue_jobs）が本番に作られておらず、
+  #     Active Storage の has_one_attached 上書き時に PurgeJob のエンキューで
+  #     500 が発生していたため、まずは確実に動く inline に倒す。
+  # 将来 AI 呼び出しの非同期化など本格的な job 運用が必要になった段階で、
+  # `bin/rails solid_queue:install` で migration を生成して有効化し直す。
+  config.active_job.queue_adapter = :inline
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -9,6 +9,9 @@
 #     priority: 2
 #     schedule: at 5am every day
 
+# 本番の Active Job は :inline 採用（Solid Queue 不使用）のため、
+# Solid Queue Scheduler は動いておらず、ここの recurring 定義は現状無効。
+# 将来 Solid Queue を有効化したら以下の定義が動き始める。
 production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"


### PR DESCRIPTION
## 背景

本番で **アバター画像が保存できない（500 エラー）** 不具合が発生していた。

Render Logs:

\`\`\`
[ActiveJob] Failed enqueuing ActiveStorage::PurgeJob to SolidQueue(default):
  SolidQueue::Job::EnqueueError
  (ActiveRecord::StatementInvalid: PG::UndefinedTable:
   ERROR:  relation \"solid_queue_jobs\" does not exist)
Completed 500 Internal Server Error in 909ms
app/controllers/api/v1/auth/users_controller.rb:10:in 'Api::V1::Auth::UsersController#update'
\`\`\`

## 原因

`User#avatar` は `has_one_attached :avatar` で、画像を**置き換える**ときに古い blob を消すため `ActiveStorage::PurgeJob` を Solid Queue にエンキューする。しかし:

- 本番 DB に `solid_queue_jobs` テーブルが存在しない（`db/queue_migrate/` ディレクトリが一度も作られていない）
- 結果、エンキュー時に `PG::UndefinedTable` で例外 → トランザクション全体が rollback → 500

加えて、同じパターンで **`solid_cache_entries` / `solid_cable_messages` も未作成**。Solid Cache は既に MemoryStore で回避済みだが、`database.yml` の宣言が残ったまま。Solid Cable は ActionCable を使った瞬間に同じ事故が起きる潜在バグ。

## 修正内容

Solid Queue を本格運用するには worker プロセス（または `SOLID_QUEUE_IN_PUMA`）と専用テーブルの運用が必要だが、**Render Free tier の RAM 制約下では worker を別途動かす余裕がない**。現状のジョブ（Active Storage の PurgeJob など）は同期実行で実害がないため、当面 `:inline` で運用する。

### 変更ファイル

- `config/environments/production.rb` — `queue_adapter = :inline` に変更、Solid Queue 接続宣言を削除
- `config/database.yml` — production の `queue` / `cache` / `cable` 接続を削除（マイグレーション未生成のため）
- `config/cable.yml` — production を `solid_cable` → `async` アダプタへ（潜在事故防止）
- `config/recurring.yml` — Solid Queue Scheduler が動いていないことをコメントで明記

### 将来 Solid Queue を本格運用する場合の手順

\`\`\`bash
bin/rails solid_queue:install   # db/queue_migrate を生成
bin/rails db:migrate            # solid_queue_jobs などのテーブルを作成
# config 復活:
#   - config/environments/production.rb: queue_adapter = :solid_queue + connects_to
#   - config/database.yml: queue 接続を復活
# 環境変数追加:
#   - SOLID_QUEUE_IN_PUMA=1 （Puma 内で worker を動かす場合）
\`\`\`

## Test plan

- [x] 既存テスト全 340 examples グリーン
- [x] RuboCop offense なし
- [ ] マージ後、本番デプロイで `vow-pact.onrender.com/settings` のアバター画像アップロード・差し替えが 200 を返し画面に反映されることを確認
- [ ] Render Logs で `SolidQueue::Job::EnqueueError` が出ないことを確認

## 補足

- 直前にマージされた #83 の Mixed Content 修正と合わせて、画像反映の不具合が完全に解消される想定。
- `CleanupExpiredGuestsJob` の recurring 実行は無効化されるが、worker プロセスがいない現状でもともと動いていなかったため実害なし。必要になったら別途 cron や手動実行で対応。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 本番環境のバックエンドサービス設定を簡素化しました
  * ジョブ処理の実行方式を同期実行に変更しました
  * 不要な接続設定を削除し、システムの複雑性を軽減しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/vow_pact/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->