### PR TITLE
hotfix(prod): solid_cache / solid_queue / solid_cable gem を削除（起動エラー修正）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,10 +20,14 @@ gem "rails-i18n"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
-# Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
-gem "solid_cache"
-gem "solid_queue"
-gem "solid_cable"
+# Solid Trifecta（Rails 8 標準の DB ベース cache/queue/cable）は現状未採用。
+#   ・cache:  MemoryStore（config/environments/production.rb で in-process 64MB）
+#   ・queue:  :inline（worker プロセスを動かす余裕がないため同期実行）
+#   ・cable:  :async（ActionCable は実質未使用）
+# gem を入れたままだと eager_load 時に SolidCache::Record などが connects_to を
+# 解決しようとしてエラーになるため、未使用の本 3 gem は Gemfile から外す。
+# 将来本格導入する場合は bundle add solid_cache solid_queue solid_cable して、
+# 各種 install ジェネレータで migration を生成すること。
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,8 +108,6 @@ GEM
     ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
-    et-orbi (1.4.0)
-      tzinfo
     event_stream_parser (1.0.0)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -133,9 +131,6 @@ GEM
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    fugit (1.12.1)
-      et-orbi (~> 1.4)
-      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -250,7 +245,6 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.1)
       nio4r (~> 2.0)
-    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-cors (3.0.0)
@@ -362,22 +356,6 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
-    solid_cable (3.0.12)
-      actioncable (>= 7.2)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-    solid_cache (1.0.10)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-    solid_queue (1.4.0)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11)
-      railties (>= 7.1)
-      thor (>= 1.3.1)
     sshkit (1.25.0)
       base64
       logger
@@ -460,9 +438,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails-omakase
   ruby-openai
-  solid_cable
-  solid_cache
-  solid_queue
   tailwindcss-rails
   thruster
   tzinfo-data

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,8 +34,9 @@ port ENV.fetch("PORT", 3000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+# Solid Queue は現状未採用（queue_adapter: :inline）のため plugin を読み込まない。
+# 将来 Solid Queue を有効化したら以下の行を復活させ、SOLID_QUEUE_IN_PUMA=1 を渡す。
+#   plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -9,16 +9,16 @@
 #     priority: 2
 #     schedule: at 5am every day
 
-# 本番の Active Job は :inline 採用（Solid Queue 不使用）のため、
-# Solid Queue Scheduler は動いておらず、ここの recurring 定義は現状無効。
-# 将来 Solid Queue を有効化したら以下の定義が動き始める。
-production:
-  clear_solid_queue_finished_jobs:
-    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
-    schedule: every hour at minute 12
-  # 30 日経過しても本登録に昇格していないゲストユーザーをクリーンアップ。
-  # 関連する Pact / CheckIn / Crest / Session / AiGeneration も dependent: :destroy で連鎖削除。
-  cleanup_expired_guests:
-    class: CleanupExpiredGuestsJob
-    queue: default
-    schedule: every day at 3am
+# Solid Queue Scheduler 用の recurring 定義。
+# 本番は queue_adapter :inline + solid_queue gem 不採用のため、現状すべて無効。
+# 将来 Solid Queue を本格運用したらコメントを外して有効化する。
+# production:
+#   clear_solid_queue_finished_jobs:
+#     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+#     schedule: every hour at minute 12
+#   # 30 日経過しても本登録に昇格していないゲストユーザーをクリーンアップ。
+#   # 関連する Pact / CheckIn / Crest / Session / AiGeneration も dependent: :destroy で連鎖削除。
+#   cleanup_expired_guests:
+#     class: CleanupExpiredGuestsJob
+#     queue: default
+#     schedule: every day at 3am


### PR DESCRIPTION
## 背景

直前の PR #84 マージ後、本番デプロイで Rails 起動が失敗した。

\`\`\`
from /opt/render/project/.gems/ruby/3.4.0/gems/solid_cache-1.0.10/app/models/solid_cache/record.rb:4:in '<module:SolidCache>'
...
==> Exited with status 1
\`\`\`

## 原因

PR #84 で `config/database.yml` の production から `cache` / `queue` / `cable` の接続定義を削除した。これにより Solid Cache の `SolidCache::Record < ApplicationRecord` がロード時に `connects_to database: { writing: :cache }` を解決できず、production の eager_load 中にエラー終了していた。

`config.eager_load = true`（本番標準）なので、起動時に必ず Solid Cache の Model がロードされ、その時点で gem が DB 接続を要求して落ちる構造。

## 修正内容

そもそも Vow Pact では:
- **Cache**: `MemoryStore` を採用（`config/environments/production.rb`）
- **Queue**: `:inline` を採用（PR #84）
- **Cable**: `:async` を採用（PR #84）

3 つとも **Solid Trifecta gem を実際には使っていない**。eager_load 時に gem の Model がロードされないよう、Gemfile から該当 3 gem を削除する。

### 変更ファイル

- `Gemfile` — `solid_cache` / `solid_queue` / `solid_cable` を削除
- `Gemfile.lock` — 依存も含めて自動更新
- `config/puma.rb` — `plugin :solid_queue` 行をコメントアウト
- `config/recurring.yml` — Solid Queue Scheduler の recurring 定義をコメントアウト

### 将来 Solid Queue を本格運用する場合

\`\`\`bash
bundle add solid_queue solid_cache solid_cable
bin/rails solid_queue:install   # db/queue_migrate を生成
bin/rails db:migrate
\`\`\`
合わせて `config/puma.rb` / `config/recurring.yml` / `config/database.yml` / `config/environments/production.rb` のコメントを戻す。

## Test plan

- [x] 既存テスト全 340 examples グリーン
- [x] RuboCop offense なし
- [x] **本命検証**: `RAILS_ENV=production bundle exec rails zeitwerk:check` が `All is good!` を返すことを確認（PR #84 マージ前はここで落ちていた）
- [ ] マージ後、Render デプロイが成功すること
- [ ] アバター画像のアップロード・差し替えが 200 を返し画面に反映されること
- [ ] Render Logs で `SolidCache::Record` などの参照エラーが消えていること

## 補足

これで一連のアバター反映問題（Mixed Content #83 → Solid Queue 依存 #84 → gem 残存による起動失敗 #本PR）が完全に解消される想定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 使用されていないSolidデータベースアダプタ（solid_cache、solid_queue、solid_cable）を依存関係から削除しました。
  * サーバー設定を更新し、Solid Queueプラグインの読み込みを無効化しました。
  * 不要になった本番環境のスケジュール済みジョブ定義を無効化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/vow_pact/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->